### PR TITLE
Follow up manual changes to autoscaling group metrics, cleanup.

### DIFF
--- a/govwifi-backend/db.tf
+++ b/govwifi-backend/db.tf
@@ -11,6 +11,7 @@ resource "aws_db_subnet_group" "db-subnets" {
 resource "aws_db_instance" "db" {
   count                       = "${var.db-instance-count}"
   allocated_storage           = "${var.db-storage-gb}"
+  storage_type                = "gp2"
   engine                      = "mysql"
   engine_version              = "5.7.16"
   allow_major_version_upgrade = true

--- a/govwifi-backend/db.tf
+++ b/govwifi-backend/db.tf
@@ -28,6 +28,7 @@ resource "aws_db_instance" "db" {
   depends_on                  = ["aws_iam_role.rds-monitoring-role"]
   monitoring_role_arn         = "${aws_iam_role.rds-monitoring-role.arn}"
   monitoring_interval         = "${var.db-monitoring-interval}"
+  maintenance_window          = "${var.db-maintenance-window}"
 
   tags {
     Name = "wifi-${var.Env-Name}-db"

--- a/govwifi-backend/ecs-autoscaling.tf
+++ b/govwifi-backend/ecs-autoscaling.tf
@@ -1,4 +1,3 @@
-# TODO: review the settings here - registry???
 module "ecs-autoscaling" {
   source                     = "./modules/ecs-autoscaling"
   Env-Name                   = "${var.Env-Name}"
@@ -13,9 +12,6 @@ module "ecs-autoscaling" {
   max_size                   = "10"
   desired_capacity           = "${var.backend-instance-count}"
   instance-profile-id        = "${aws_iam_instance_profile.ecs-instance-profile.id}"
-  registry_url               = "https://index.docker.io/v1/"
-  registry_email             = "your_email@"
-  registry_auth              = "your_registry_auth_token"
   ami                        = "${var.ami}"
   critical-notifications-arn = "${var.critical-notifications-arn}"
 }

--- a/govwifi-backend/modules/ecs-autoscaling/ecs-autoscaling.tf
+++ b/govwifi-backend/modules/ecs-autoscaling/ecs-autoscaling.tf
@@ -8,6 +8,16 @@ resource "aws_autoscaling_group" "ecs-cluster" {
   health_check_type         = "EC2"
   launch_configuration      = "${aws_launch_configuration.ecs.name}"
   health_check_grace_period = "${var.health_check_grace_period}"
+  enabled_metrics           = [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ]
 
   lifecycle {
     create_before_destroy = true

--- a/govwifi-backend/modules/ecs-autoscaling/variables.tf
+++ b/govwifi-backend/modules/ecs-autoscaling/variables.tf
@@ -54,21 +54,6 @@ variable "instance-profile-id" {
   description = "The IAM Instance Profile (e.g. right side of Name=AmazonECSContainerInstanceRole)"
 }
 
-variable "registry_url" {
-  default     = "https://index.docker.io/v1/"
-  description = "Docker private registry URL, defaults to Docker index"
-}
-
-variable "registry_email" {
-  default     = ""
-  description = "Docker private registry login email address"
-}
-
-variable "registry_auth" {
-  default     = ""
-  description = "Docker private registry login auth token (from ~/.dockercgf)"
-}
-
 variable "Env-Name" {}
 
 variable "critical-notifications-arn" {}

--- a/govwifi-backend/route53.tf
+++ b/govwifi-backend/route53.tf
@@ -3,6 +3,7 @@
 
 # CNAME for the database for this environment
 resource "aws_route53_record" "db" {
+  count   = "${var.db-instance-count}"
   zone_id = "${var.route53-zone-id}"
   name    = "db.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
   type    = "CNAME"

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -60,6 +60,8 @@ variable "db-monitoring-interval" {}
 
 variable "db-storage-gb" {}
 
+variable "db-maintenance-window" {}
+
 variable "cache-node-type" {}
 
 variable "elb-sg-list" {

--- a/govwifi-emails/emails.tf
+++ b/govwifi-emails/emails.tf
@@ -23,7 +23,6 @@ resource "aws_ses_receipt_rule" "incoming-ses-rule" {
     "newsite@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
     "logrequest@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
     "sponsor@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
-    "verify@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
   ]
 
   s3_action {


### PR DESCRIPTION
- Remove unused registry settings.
- Follow up manual changes to autoscaling group metrics.
- Remove unused email address.
- Add variable for DB maintenance window.
- Set database storage type to SSD
- Remove database DNS record if we don't have an instance