### PR TITLE
Update Terraform version to 0.9.6

### DIFF
--- a/govwifi-backend/db.tf
+++ b/govwifi-backend/db.tf
@@ -30,6 +30,7 @@ resource "aws_db_instance" "db" {
   monitoring_role_arn         = "${aws_iam_role.rds-monitoring-role.arn}"
   monitoring_interval         = "${var.db-monitoring-interval}"
   maintenance_window          = "${var.db-maintenance-window}"
+  skip_final_snapshot         = true
 
   tags {
     Name = "wifi-${var.Env-Name}-db"

--- a/govwifi-backend/iam-roles.tf
+++ b/govwifi-backend/iam-roles.tf
@@ -62,7 +62,7 @@ EOF
 
 resource "aws_iam_instance_profile" "ecs-instance-profile" {
   name  = "${var.aws-region-name}-ecs-instance-profile-${var.Env-Name}"
-  roles = ["${aws_iam_role.ecs-instance-role.name}"]
+  role  = "${aws_iam_role.ecs-instance-role.name}"
 }
 
 resource "aws_iam_role_policy" "ecs-service-policy" {

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -187,6 +187,6 @@ EOF
 
 resource "aws_iam_instance_profile" "bastion-instance-profile" {
   name       = "${var.aws-region-name}-${var.Env-Name}-backend-bastion-instance-profile"
-  roles      = ["${aws_iam_role.bastion-instance-role.name}"]
+  role       = "${aws_iam_role.bastion-instance-role.name}"
   depends_on = ["aws_iam_role.bastion-instance-role"]
 }

--- a/govwifi-backend/modules/ecs-autoscaling/scaling-policy.tf
+++ b/govwifi-backend/modules/ecs-autoscaling/scaling-policy.tf
@@ -20,6 +20,7 @@ resource "aws_cloudwatch_metric_alarm" "cpualarm" {
     AutoScalingGroupName = "${aws_autoscaling_group.ecs-cluster.name}"
   }
 
-  alarm_description = "This metric monitors ec2 cpu utilization"
-  alarm_actions     = ["${aws_autoscaling_policy.scale-policy.arn}", "${var.critical-notifications-arn}"]
+  alarm_description  = "This metric monitors ec2 cpu utilization"
+  alarm_actions      = ["${aws_autoscaling_policy.scale-policy.arn}", "${var.critical-notifications-arn}"]
+  treat_missing_data = "breaching"
 }

--- a/govwifi-frontend/iam-roles.tf
+++ b/govwifi-frontend/iam-roles.tf
@@ -62,7 +62,7 @@ EOF
 
 resource "aws_iam_instance_profile" "ecs-instance-profile" {
   name  = "${var.aws-region-name}-frontend-ecs-instance-profile-${var.Env-Name}"
-  roles = ["${aws_iam_role.ecs-instance-role.name}"]
+  role  = "${aws_iam_role.ecs-instance-role.name}"
 }
 
 # Unused until a loadbalancer is set up


### PR DESCRIPTION
- Modify the deprecated roles attribute on the IAM Instance profile to contain a single value (and rename to role)
- Add default true value for the DB's skip_final_snapshot attribute
- Add treat_missing_data attribute for CPU alarms as "breaching" 