### PR TITLE
Change bastion AMI and security groups, cleanup

### DIFF
--- a/govwifi-backend/backend.tf
+++ b/govwifi-backend/backend.tf
@@ -7,7 +7,9 @@ provider "aws" {
 # CREATE VPC
 
 resource "aws_vpc" "wifi-backend" {
-  cidr_block = "${var.vpc-cidr-block}"
+  cidr_block           = "${var.vpc-cidr-block}"
+  # Hostnames required by the CIS hardened image.
+  enable_dns_hostnames = true
 
   tags {
     Name = "GovWifi Backend - ${var.Env-Name}"

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -51,8 +51,12 @@ sudo cp ./periodic-updates-setup /etc/apt/apt.conf.d/10periodic
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
-# Add extra authorised keys
+# Add extra authorised keys and ssh identity
 echo -n "${var.bastion-auth-keys}" >> /home/ubuntu/.ssh/authorized_keys
+
+echo -n "${var.bastion-identity}" > /home/ubuntu/.ssh/id_rsa
+chown ubuntu:ubuntu /home/ubuntu/.ssh/id_rsa
+chmod 600 /home/ubuntu/.ssh/id_rsa
 
 --==BOUNDARY==
 MIME-Version: 1.0

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -2,7 +2,7 @@
 resource "aws_instance" "management" {
   ami                    = "${var.bastion-ami}"
   instance_type          = "${var.bastion-instance-type}"
-  key_name               = "${var.ssh-key-name}"
+  key_name               = "${var.bastion-ssh-key-name}"
   subnet_id              = "${aws_subnet.wifi-backend-subnet.0.id}"
   vpc_security_group_ids = ["${var.mgt-sg-list}"]
   iam_instance_profile   = "${aws_iam_instance_profile.bastion-instance-profile.id}"

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -51,6 +51,13 @@ sudo cp ./periodic-updates-setup /etc/apt/apt.conf.d/10periodic
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
+# Add extra authorised keys
+echo -n "${var.bastion-auth-keys}" >> /home/ubuntu/.ssh/authorized_keys
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
 # Set up cron scripts for timed jobs
 
 cat <<'EOF' > ./ping-survey

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -174,3 +174,8 @@ resource "aws_iam_instance_profile" "bastion-instance-profile" {
   role       = "${aws_iam_role.bastion-instance-role.name}"
   depends_on = ["aws_iam_role.bastion-instance-role"]
 }
+
+resource "aws_eip_association" "eip_assoc" {
+  instance_id = "${aws_instance.management.id}"
+  public_ip   = "${replace(var.bastion-server-ip, "/32", "")}"
+}

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -36,6 +36,8 @@ variable "bastion-ssh-key-name" {}
 
 variable "bastion-auth-keys" {}
 
+variable "bastion-identity" {}
+
 variable "ssh-key-name" {}
 
 variable "backend-instance-count" {}

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -30,6 +30,8 @@ variable "bastion-ami" {}
 
 variable "bastion-instance-type" {}
 
+variable "bastion-server-ip" {}
+
 variable "ssh-key-name" {}
 
 variable "backend-instance-count" {}

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -32,6 +32,8 @@ variable "bastion-instance-type" {}
 
 variable "bastion-server-ip" {}
 
+variable "bastion-ssh-key-name" {}
+
 variable "ssh-key-name" {}
 
 variable "backend-instance-count" {}

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -34,6 +34,8 @@ variable "bastion-server-ip" {}
 
 variable "bastion-ssh-key-name" {}
 
+variable "bastion-auth-keys" {}
+
 variable "ssh-key-name" {}
 
 variable "backend-instance-count" {}


### PR DESCRIPTION
- Remove deprecated logic for legacy data migration, add cron scripts for timed jobs.
- Assign fixed EIP to the staging bastion server, make sure it's automatically assigned for both staging and live.
- Alter bastion user data configurations and switch on DNS hostnames for the backend VPC to support the new bastion AMI.