### PR TITLE
Modules timed job updates

### DIFF
--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -38,10 +38,7 @@ variable "bastion-auth-keys" {}
 
 variable "bastion-identity" {}
 
-variable "bastion-set-cronjobs" {
-  type = "string"
-  default = 1
-}
+variable "bastion-set-cronjobs" {}
 
 variable "ssh-key-name" {}
 


### PR DESCRIPTION
- Add -t 1 to wget calls, use cronjobs variable, auto update fixes.
- Add scripts to wait for apt-get race conditions, separate out update and install scripts, add all conceivable options for non-interactive running of upgrades, finally mark libpam-systemd as "hold" since it can not be upgraded without direct user interaction.