### PR TITLE
Add Env tag to all instances

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -160,6 +160,7 @@ DATA
 
   tags {
     Name = "${title(var.Env-Name)} Bastion - backend (${aws_vpc.wifi-backend.id})"
+    Env = "${title(var.Env-Name)}"
   }
 }
 

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -168,6 +168,7 @@ DATA
 
   tags {
     Name = "${title(var.Env-Name)} Frontend Radius-${var.dns-numbering-base + count.index + 1}"
+    Env  = "${title(var.Env-Name)}"
   }
 }
 


### PR DESCRIPTION
## What

The Env tag was included on instances within the autoscaling group, but
not these instances that are created outside of ASGs.

https://trello.com/c/JLiabybS/731-pb8-tm-add-amend-environment-variable-to-all-instances

## How to review

Run terraform plan in each of staging, staging-london, wif, and wifi-london
verify the instance tag count changes to 2 and the env tag is added to the
instance

## Who can review

Anyone but me