### PR TITLE
Set up read replica, CNAME and alarms for it 

### DIFF
--- a/govwifi-backend/cluster.tf
+++ b/govwifi-backend/cluster.tf
@@ -55,6 +55,18 @@ resource "aws_ecs_task_definition" "backend-task" {
           "name": "DB_HOSTNAME",
           "value": "db.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
         },{
+          "name": "RR_DB_NAME",
+          "value": "govwifi_${var.Env-Name}"
+        },{
+          "name": "RR_DB_PASS",
+          "value": "${var.db-password}"
+        },{
+          "name": "RR_DB_USER",
+          "value": "${var.db-user}"
+        },{
+          "name": "RR_DB_HOSTNAME",
+          "value": "rr.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+        },{
           "name": "CACHE_HOSTNAME",
           "value": "cache.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
         },{

--- a/govwifi-backend/db.tf
+++ b/govwifi-backend/db.tf
@@ -35,7 +35,37 @@ resource "aws_db_instance" "db" {
   skip_final_snapshot         = true
 
   tags {
-    Name = "wifi-${var.Env-Name}-db"
+    Name = "${title(var.Env-Name)} DB"
+  }
+}
+
+resource "aws_db_instance" "read_replica" {
+  count                       = "${var.db-replica-count}"
+  allocated_storage           = "${var.db-storage-gb}"
+  replicate_source_db         = "${aws_db_instance.db.identifier}"
+  storage_type                = "gp2"
+  engine                      = "mysql"
+  engine_version              = "5.7.16"
+  auto_minor_version_upgrade  = true
+  allow_major_version_upgrade = false
+  apply_immediately           = true
+  instance_class              = "${var.db-instance-type}"
+  identifier                  = "${var.Env-Name}-db-rr"
+  username                    = "${var.db-user}"
+  password                    = "${var.db-password}"
+  backup_retention_period     = 0
+  multi_az                    = false
+  storage_encrypted           = "${var.db-encrypt-at-rest}"
+  vpc_security_group_ids      = ["${var.db-sg-list}"]
+  depends_on                  = ["aws_iam_role.rds-monitoring-role"]
+  monitoring_role_arn         = "${aws_iam_role.rds-monitoring-role.arn}"
+  monitoring_interval         = "${var.db-monitoring-interval}"
+  maintenance_window          = "${var.db-maintenance-window}"
+  backup_window               = "${var.db-backup-window}"
+  skip_final_snapshot         = true
+
+  tags {
+    Name = "${title(var.Env-Name)} DB Read Replica"
   }
 }
 
@@ -54,7 +84,7 @@ resource "aws_cloudwatch_metric_alarm" "db_cpualarm" {
     DBInstanceIdentifier = "${aws_db_instance.db.identifier}"
   }
 
-  alarm_description  = "This metric monitors the cpu utilization of the DB"
+  alarm_description  = "This metric monitors the cpu utilization of the DB."
   alarm_actions      = ["${var.critical-notifications-arn}"]
   treat_missing_data = "breaching"
 }
@@ -95,6 +125,66 @@ resource "aws_cloudwatch_metric_alarm" "db_storagealarm" {
   }
 
   alarm_description  = "This metric monitors the storage space available for the DB."
+  alarm_actions      = ["${var.critical-notifications-arn}"]
+  treat_missing_data = "breaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "rr_cpualarm" {
+  count               = "${var.db-replica-count}"
+  alarm_name          = "${var.Env-Name}-rr-cpu-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = "80"
+
+  dimensions {
+    DBInstanceIdentifier = "${aws_db_instance.read_replica.identifier}"
+  }
+
+  alarm_description  = "This metric monitors the cpu utilization of the DB read replica."
+  alarm_actions      = ["${var.critical-notifications-arn}"]
+  treat_missing_data = "breaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "rr_memoryalarm" {
+  count               = "${var.db-replica-count}"
+  alarm_name          = "${var.Env-Name}-rr-memory-alarm"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "FreeableMemory"
+  namespace           = "AWS/RDS"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "524288000"
+
+  dimensions {
+    DBInstanceIdentifier = "${aws_db_instance.read_replica.identifier}"
+  }
+
+  alarm_description  = "This metric monitors the freeable memory available for the DB read replica."
+  alarm_actions      = ["${var.critical-notifications-arn}"]
+  treat_missing_data = "breaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "rr_storagealarm" {
+  count               = "${var.db-replica-count}"
+  alarm_name          = "${var.Env-Name}-rr-storage-alarm"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/RDS"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "21474836480"
+
+  dimensions {
+    DBInstanceIdentifier = "${aws_db_instance.read_replica.identifier}"
+  }
+
+  alarm_description  = "This metric monitors the storage space available for the DB read replica."
   alarm_actions      = ["${var.critical-notifications-arn}"]
   treat_missing_data = "breaching"
 }

--- a/govwifi-backend/route53.tf
+++ b/govwifi-backend/route53.tf
@@ -11,6 +11,16 @@ resource "aws_route53_record" "db" {
   records = ["${aws_db_instance.db.address}"]
 }
 
+# CNAME for the DB read replica for this environment
+resource "aws_route53_record" "rr" {
+  count   = "${var.db-replica-count}"
+  zone_id = "${var.route53-zone-id}"
+  name    = "rr.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${aws_db_instance.read_replica.address}"]
+}
+
 # CNAME for the cache for this environment
 resource "aws_route53_record" "cache" {
   zone_id = "${var.route53-zone-id}"

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -60,6 +60,8 @@ variable "shared-key" {}
 
 variable "db-instance-count" {}
 
+variable "db-replica-count" {}
+
 variable "db-backup-retention-days" {}
 
 variable "db-encrypt-at-rest" {}


### PR DESCRIPTION
This PR sets up the read replica with DNS record and alarms, based on the "db-replica-count" variable from https://github.com/alphagov/govwifi-build/pull/1.