### PR TITLE
Use Alias record for ELB

### DIFF
--- a/govwifi-backend/route53.tf
+++ b/govwifi-backend/route53.tf
@@ -34,7 +34,10 @@ resource "aws_route53_record" "cache" {
 resource "aws_route53_record" "elb" {
   zone_id = "${var.route53-zone-id}"
   name    = "elb.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["${aws_elb.backend-elb.dns_name}"]
+  type    = "A"
+  alias {
+    name                   = "${aws_elb.backend-elb.dns_name}"
+    zone_id                = "${aws_elb.backend-elb.zone_id}"
+    evaluate_target_health = true
+  }
 }


### PR DESCRIPTION
Use an alias record for the ELB. Alias records provide a pointer to the
ELB, and there are advantages to using it over a CNAME - more info in

http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html

Trusted advisor also recommends doing this.

THe evaluate target health parameter appears to check the underlying
health of the instances in the ELB and wont' route traffic to an
unhealthy instance at the DNS level - I found
https://aws.amazon.com/blogs/aws/amazon-route-53-elb-integration-dns-failover/
the best for understanding this. In a more complex configuration you
could route traffic to another ELB in another region using this feature.