### PR TITLE
Allow setting backend min size and cpualarm count.

### DIFF
--- a/govwifi-backend/ecs-autoscaling.tf
+++ b/govwifi-backend/ecs-autoscaling.tf
@@ -8,7 +8,7 @@ module "ecs-autoscaling" {
   availability_zones         = "${join(",", values(var.zone-names))}"
   subnet_ids                 = "${join(",", aws_subnet.wifi-backend-subnet.*.id)}"
   security_group_ids         = "${join(",", var.backend-sg-list)}"
-  min_size                   = "1"
+  min_size                   = "${var.backend-min-size}"
   max_size                   = "10"
   desired_capacity           = "${var.backend-instance-count}"
   instance-profile-id        = "${aws_iam_instance_profile.ecs-instance-profile.id}"

--- a/govwifi-backend/ecs-autoscaling.tf
+++ b/govwifi-backend/ecs-autoscaling.tf
@@ -8,6 +8,7 @@ module "ecs-autoscaling" {
   availability_zones         = "${join(",", values(var.zone-names))}"
   subnet_ids                 = "${join(",", aws_subnet.wifi-backend-subnet.*.id)}"
   security_group_ids         = "${join(",", var.backend-sg-list)}"
+  backend-cpualarm-count     = "${var.backend-cpualarm-count}"
   min_size                   = "${var.backend-min-size}"
   max_size                   = "10"
   desired_capacity           = "${var.backend-instance-count}"

--- a/govwifi-backend/modules/ecs-autoscaling/scaling-policy.tf
+++ b/govwifi-backend/modules/ecs-autoscaling/scaling-policy.tf
@@ -7,6 +7,7 @@ resource "aws_autoscaling_policy" "scale-policy" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpualarm" {
+  count               = "${var.backend-cpualarm-count}"
   alarm_name          = "${var.Env-Name}-backend-cpu-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"

--- a/govwifi-backend/modules/ecs-autoscaling/variables.tf
+++ b/govwifi-backend/modules/ecs-autoscaling/variables.tf
@@ -30,6 +30,8 @@ variable "instance_type" {
   description = "Name of the AWS instance type"
 }
 
+variable "backend-cpualarm-count" {}
+
 variable "min_size" {
   default     = "1"
   description = "Minimum number of instances to run in the group"

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -44,6 +44,8 @@ variable "ssh-key-name" {}
 
 variable "backend-instance-count" {}
 
+variable "backend-min-size" {}
+
 variable "aws-account-id" {}
 
 variable "elb-ssl-cert-arn" {}

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -46,6 +46,8 @@ variable "backend-instance-count" {}
 
 variable "backend-min-size" {}
 
+variable "backend-cpualarm-count" {}
+
 variable "aws-account-id" {}
 
 variable "elb-ssl-cert-arn" {}


### PR DESCRIPTION
Necessary in order to disable backends for a given region. 