### PR TITLE
Replication, expiry and encryption setup for S3 access logs and tfstate buckets, also re-categorise alarms

### DIFF
--- a/global-dns/global-dns.tf
+++ b/global-dns/global-dns.tf
@@ -1,7 +1,7 @@
 # CNAME for the service status page
 resource "aws_route53_record" "statuspage" {
   zone_id = "${var.route53-zone-id}"
-  name    = "status.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+  name    = "status.${var.Env-Subdomain}.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
   records = ["${var.status-page-domain}"]

--- a/govwifi-backend/backend.tf
+++ b/govwifi-backend/backend.tf
@@ -1,11 +1,4 @@
 # AWS Configuration
-
-provider "aws" {
-  # Workaround for import issue, see https://github.com/hashicorp/terraform/issues/13018#issuecomment-291547317
-  alias = "AWS region"
-  region = "${var.aws-region}"
-}
-
 # CREATE VPC
 
 resource "aws_vpc" "wifi-backend" {

--- a/govwifi-backend/backend.tf
+++ b/govwifi-backend/backend.tf
@@ -1,6 +1,8 @@
 # AWS Configuration
 
 provider "aws" {
+  # Workaround for import issue, see https://github.com/hashicorp/terraform/issues/13018#issuecomment-291547317
+  alias = "AWS region"
   region = "${var.aws-region}"
 }
 

--- a/govwifi-backend/cache.tf
+++ b/govwifi-backend/cache.tf
@@ -13,5 +13,5 @@ resource "aws_elasticache_cluster" "cache" {
   parameter_group_name   = "default.memcached1.4"
   subnet_group_name      = "wifi-${var.Env-Name}-subnets"
   security_group_ids     = ["${var.cache-sg-list}"]
-  notification_topic_arn = "${var.critical-notifications-arn}"
+  notification_topic_arn = "${var.capacity-notifications-arn}"
 }

--- a/govwifi-backend/cluster.tf
+++ b/govwifi-backend/cluster.tf
@@ -53,7 +53,7 @@ resource "aws_ecs_task_definition" "backend-task" {
           "value": "${var.db-user}"
         },{
           "name": "DB_HOSTNAME",
-          "value": "db.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+          "value": "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
         },{
           "name": "RR_DB_NAME",
           "value": "govwifi_${var.Env-Name}"
@@ -65,16 +65,16 @@ resource "aws_ecs_task_definition" "backend-task" {
           "value": "${var.db-user}"
         },{
           "name": "RR_DB_HOSTNAME",
-          "value": "rr.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+          "value": "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
         },{
           "name": "CACHE_HOSTNAME",
-          "value": "cache.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+          "value": "cache.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
         },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.Env-Name}"
         },{
           "name": "RADIUS_HOSTNAME",
-          "value": "radius*n*.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+          "value": "radius*n*.${var.Env-Subdomain}.service.gov.uk"
         },{
           "name": "RADIUS_SERVER_IPS",
           "value": "${var.radius-server-ips}"

--- a/govwifi-backend/db.tf
+++ b/govwifi-backend/db.tf
@@ -207,7 +207,7 @@ resource "aws_cloudwatch_metric_alarm" "db_storagealarm" {
   }
 
   alarm_description  = "This metric monitors the storage space available for the DB."
-  alarm_actions      = ["${var.critical-notifications-arn}"]
+  alarm_actions      = ["${var.capacity-notifications-arn}"]
   treat_missing_data = "breaching"
 }
 
@@ -227,7 +227,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_cpualarm" {
   }
 
   alarm_description  = "This metric monitors the cpu utilization of the DB read replica."
-  alarm_actions      = ["${var.critical-notifications-arn}"]
+  alarm_actions      = ["${var.capacity-notifications-arn}"]
   treat_missing_data = "breaching"
 }
 
@@ -247,7 +247,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_memoryalarm" {
   }
 
   alarm_description  = "This metric monitors the freeable memory available for the DB read replica."
-  alarm_actions      = ["${var.critical-notifications-arn}"]
+  alarm_actions      = ["${var.capacity-notifications-arn}"]
   treat_missing_data = "breaching"
 }
 
@@ -267,6 +267,6 @@ resource "aws_cloudwatch_metric_alarm" "rr_storagealarm" {
   }
 
   alarm_description  = "This metric monitors the storage space available for the DB read replica."
-  alarm_actions      = ["${var.critical-notifications-arn}"]
+  alarm_actions      = ["${var.capacity-notifications-arn}"]
   treat_missing_data = "breaching"
 }

--- a/govwifi-backend/ecs-autoscaling.tf
+++ b/govwifi-backend/ecs-autoscaling.tf
@@ -15,5 +15,6 @@ module "ecs-autoscaling" {
   instance-profile-id        = "${aws_iam_instance_profile.ecs-instance-profile.id}"
   ami                        = "${var.ami}"
   critical-notifications-arn = "${var.critical-notifications-arn}"
+  capacity-notifications-arn = "${var.capacity-notifications-arn}"
   users                      = "${var.users}"
 }

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -102,17 +102,17 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 cat <<'EOF' > ./ping-survey
 #!/bin/bash
-wget -t 1 "http://elb.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk/timedjobs/survey?key=${var.shared-key}"
+wget -t 1 "http://elb.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk/timedjobs/survey?key=${var.shared-key}"
 EOF
 
 cat <<'EOF' > ./ping-performanceplatform
 #!/bin/bash
-wget -t 1 "http://elb.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk/timedjobs/performanceplatform?key=${var.shared-key}"
+wget -t 1 "http://elb.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk/timedjobs/performanceplatform?key=${var.shared-key}"
 EOF
 
 cat <<'EOF' > ./ping-performanceplatform-weekly
 #!/bin/bash
-wget -t 1 "http://elb.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk/timedjobs/performanceplatform?key=${var.shared-key}&period=weekly"
+wget -t 1 "http://elb.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk/timedjobs/performanceplatform?key=${var.shared-key}&period=weekly"
 EOF
 
 chmod +x ./ping-survey ./ping-performanceplatform ./ping-performanceplatform-weekly

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -257,6 +257,6 @@ resource "aws_cloudwatch_metric_alarm" "bastion_statusalarm" {
   }
 
   alarm_description  = "This metric monitors the status of the bastion server."
-  alarm_actions      = ["${var.critical-notifications-arn}"]
+  alarm_actions      = ["${var.capacity-notifications-arn}"]
   treat_missing_data = "breaching"
 }

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -242,7 +242,7 @@ resource "aws_eip_association" "eip_assoc" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "bastion_statusalarm" {
-  alarm_name          = "${var.Env-Name}-bastion-status-alarm"
+  alarm_name          = "${lower(var.Env-Name)}-bastion-status-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "StatusCheckFailed"

--- a/govwifi-backend/modules/ecs-autoscaling/variables.tf
+++ b/govwifi-backend/modules/ecs-autoscaling/variables.tf
@@ -59,6 +59,7 @@ variable "instance-profile-id" {
 variable "Env-Name" {}
 
 variable "critical-notifications-arn" {}
+variable "capacity-notifications-arn" {}
 
 variable "users" {
   type = "list"

--- a/govwifi-backend/route53.tf
+++ b/govwifi-backend/route53.tf
@@ -5,7 +5,7 @@
 resource "aws_route53_record" "db" {
   count   = "${var.db-instance-count}"
   zone_id = "${var.route53-zone-id}"
-  name    = "db.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+  name    = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
   records = ["${aws_db_instance.db.address}"]
@@ -15,7 +15,7 @@ resource "aws_route53_record" "db" {
 resource "aws_route53_record" "rr" {
   count   = "${var.db-replica-count}"
   zone_id = "${var.route53-zone-id}"
-  name    = "rr.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+  name    = "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
   records = ["${aws_db_instance.read_replica.address}"]
@@ -24,7 +24,7 @@ resource "aws_route53_record" "rr" {
 # CNAME for the cache for this environment
 resource "aws_route53_record" "cache" {
   zone_id = "${var.route53-zone-id}"
-  name    = "cache.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+  name    = "cache.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
   records = ["${aws_elasticache_cluster.cache.cache_nodes.0.address}"]
@@ -34,7 +34,7 @@ resource "aws_route53_record" "cache" {
 resource "aws_route53_record" "elb" {
   count   = "${var.backend-elb-count}"
   zone_id = "${var.route53-zone-id}"
-  name    = "elb.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+  name    = "elb.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   type    = "A"
   alias {
     name                   = "${aws_elb.backend-elb.dns_name}"

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -110,6 +110,8 @@ variable "legacy-bastion-user" {}
 
 variable "critical-notifications-arn" {}
 
+variable "capacity-notifications-arn" {}
+
 variable "enable-bastion-monitoring" {}
 
 variable "ithc-backend-instance-count" {

--- a/govwifi-emails/emails.tf
+++ b/govwifi-emails/emails.tf
@@ -17,12 +17,12 @@ resource "aws_ses_receipt_rule" "incoming-ses-rule" {
   ]
 
   recipients = [
-    "enrol@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
-    "enroll@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
-    "signup@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
-    "newsite@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
-    "logrequest@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
-    "sponsor@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
+    "enrol@${var.Env-Subdomain}.service.gov.uk",
+    "enroll@${var.Env-Subdomain}.service.gov.uk",
+    "signup@${var.Env-Subdomain}.service.gov.uk",
+    "newsite@${var.Env-Subdomain}.service.gov.uk",
+    "logrequest@${var.Env-Subdomain}.service.gov.uk",
+    "sponsor@${var.Env-Subdomain}.service.gov.uk",
   ]
 
   s3_action {
@@ -40,7 +40,7 @@ resource "aws_ses_receipt_rule" "admin-ses-rule" {
   depends_on    = ["aws_s3_bucket.admin-emailbucket"]
 
   recipients = [
-    "admin@${var.Env-Name}${var.Env-Subdomain}.service.gov.uk",
+    "admin@${var.Env-Subdomain}.service.gov.uk",
   ]
 
   s3_action {

--- a/govwifi-emails/provider.tf
+++ b/govwifi-emails/provider.tf
@@ -1,5 +1,0 @@
-# AWS Configuration
-
-provider "aws" {
-  region = "${var.aws-region}"
-}

--- a/govwifi-emails/route53.tf
+++ b/govwifi-emails/route53.tf
@@ -4,7 +4,7 @@
 # MX record for this environment
 resource "aws_route53_record" "mx" {
   zone_id = "${var.route53-zone-id}"
-  name    = "${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
+  name    = "${var.Env-Subdomain}.service.gov.uk"
   type    = "MX"
   ttl     = "300"
   records = ["${var.mail-exchange-server}"]

--- a/govwifi-emails/s3sns.tf
+++ b/govwifi-emails/s3sns.tf
@@ -42,10 +42,15 @@ EOF
 
   tags {
     Name = "${title(var.Env-Name)} Email Bucket"
+    Region      = "${title(var.aws-region-name)}"
+    #Product     = "${var.product-name}"
+    Environment = "${title(var.Env-Name)}"
+    Category    = "TFstate"
   }
 
   logging {
     target_bucket = "${var.Env-Name}-admin-accesslogs"
+    target_prefix = "user-emails"
   }
 }
 

--- a/govwifi-emails/s3sns.tf
+++ b/govwifi-emails/s3sns.tf
@@ -41,16 +41,24 @@ resource "aws_s3_bucket" "emailbucket" {
 EOF
 
   tags {
-    Name = "${title(var.Env-Name)} Email Bucket"
+    Name        = "${title(var.Env-Name)} Email Bucket"
     Region      = "${title(var.aws-region-name)}"
-    #Product     = "${var.product-name}"
+#   Product     = "${var.product-name}"
     Environment = "${title(var.Env-Name)}"
-    Category    = "TFstate"
+    Category    = "User emails"
   }
 
   logging {
-    target_bucket = "${var.Env-Name}-admin-accesslogs"
+    target_bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
     target_prefix = "user-emails"
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 30
+    }
   }
 }
 
@@ -98,11 +106,16 @@ resource "aws_s3_bucket" "admin-emailbucket" {
 EOF
 
   tags {
-    Name = "${title(var.Env-Name)} Admin Email Bucket"
+    Name        = "${title(var.Env-Name)} Admin Email Bucket"
+    Region      = "${title(var.aws-region-name)}"
+#   Product     = "${var.product-name}"
+    Environment = "${title(var.Env-Name)}"
+    Category    = "Admin emails"
   }
 
   logging {
-    target_bucket = "${var.Env-Name}-admin-accesslogs"
+    target_bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
+    target_prefix = "admin-emails"
   }
 }
 

--- a/govwifi-emails/variables.tf
+++ b/govwifi-emails/variables.tf
@@ -1,3 +1,5 @@
+variable "product-name" {}
+
 variable "Env-Name" {}
 
 variable "Env-Subdomain" {}

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_task_definition" "radius-task" {
         "value": "${var.healthcheck-radius-key}"
       },{
         "name": "SERVICE_DOMAIN",
-        "value": "${var.Env-Name}${var.Env-Subdomain}"
+        "value": "${var.Env-Subdomain}"
       },{
         "name": "RADIUSD_PARAMS",
         "value": "${var.radiusd-params}"

--- a/govwifi-frontend/frontend.tf
+++ b/govwifi-frontend/frontend.tf
@@ -1,11 +1,4 @@
 # AWS Configuration
-
-provider "aws" {
-  # Workaround for import issue, see https://github.com/hashicorp/terraform/issues/13018#issuecomment-291547317
-  alias = "AWS region"
-  region = "${var.aws-region}"
-}
-
 # CREATE VPC
 
 resource "aws_vpc" "wifi-frontend" {

--- a/govwifi-frontend/frontend.tf
+++ b/govwifi-frontend/frontend.tf
@@ -1,6 +1,8 @@
 # AWS Configuration
 
 provider "aws" {
+  # Workaround for import issue, see https://github.com/hashicorp/terraform/issues/13018#issuecomment-291547317
+  alias = "AWS region"
   region = "${var.aws-region}"
 }
 

--- a/govwifi-frontend/route53.tf
+++ b/govwifi-frontend/route53.tf
@@ -2,7 +2,7 @@
 resource "aws_route53_record" "radius" {
   count      = "${var.radius-instance-count}"
   zone_id    = "${var.route53-zone-id}"
-  name       = "${format("radius%d.%s%s.service.gov.uk", var.dns-numbering-base + count.index + 1, var.Env-Name, var.Env-Subdomain)}"
+  name       = "${format("radius%d.%s.service.gov.uk", var.dns-numbering-base + count.index + 1, var.Env-Subdomain)}"
   type       = "CNAME"
   ttl        = "300"
   records    = ["${element(aws_instance.radius.*.public_dns, count.index)}"]

--- a/terraform-state/accesslogs.tf
+++ b/terraform-state/accesslogs.tf
@@ -1,0 +1,118 @@
+# --------------------------------------------------------------
+# Access logs
+# --------------------------------------------------------------
+
+resource "aws_iam_role" "accesslogs-replication" {
+  name = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs-replication-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy" "accesslogs-replication" {
+  name = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs-replication-policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.accesslogs-bucket.arn}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.accesslogs-bucket.arn}/*"
+      ]
+    },
+    {
+      "Action": [
+         "s3:ReplicateObject",
+         "s3:ReplicateDelete"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${lower(var.product-name)}-${var.Env-Name}-${lower(var.backup-region-name)}-accesslogs/*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "accesslogs-replication" {
+  name       = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs-replication"
+  roles      = ["${aws_iam_role.accesslogs-replication.name}"]
+  policy_arn = "${aws_iam_policy.accesslogs-replication.arn}"
+}
+
+resource "aws_s3_bucket" "accesslogs-bucket" {
+  bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
+  region = "${var.aws-region}"
+  acl    = "log-delivery-write"
+
+  tags {
+    Region      = "${title(var.aws-region-name)}"
+    Product     = "${var.product-name}"
+    Environment = "${title(var.Env-Name)}"
+    Category    = "Accesslogs"
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs-lifecycle"
+    enabled = true
+
+    transition {
+      days          = "${var.accesslogs-glacier-transition-days}"
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days          = "${var.accesslogs-expiration-days}"
+    }
+  }
+
+  replication_configuration {
+    role = "${aws_iam_role.accesslogs-replication.arn}"
+
+    rules {
+      # ID is necessary to prevent continuous change issue
+      id     = "${lower(var.aws-region-name)}-to-${lower(var.backup-region-name)}-accesslogs-backup"
+      prefix = "${lower(var.aws-region-name)}-accesslogs-backup"
+      status = "Enabled"
+
+      destination {
+        bucket        = "arn:aws:s3:::${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.backup-region-name)}-accesslogs"
+        storage_class = "STANDARD"
+      }
+    }
+  }
+
+
+}

--- a/terraform-state/accesslogs.tf
+++ b/terraform-state/accesslogs.tf
@@ -113,6 +113,4 @@ resource "aws_s3_bucket" "accesslogs-bucket" {
       }
     }
   }
-
-
 }

--- a/terraform-state/tfstate.tf
+++ b/terraform-state/tfstate.tf
@@ -1,16 +1,21 @@
 # Resources for setting up s3 for terraform backend. (state storage in s3)
 resource "aws_s3_bucket" "state-bucket" {
   bucket = "govwifi-${var.Env-Name}-${lower(var.aws-region-name)}-tfstate"
-
+  region = "${var.aws-region}"
   versioning {
     enabled = true
   }
-
+  logging {
+    target_bucket = "govwifi-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
+    target_prefix = "log/"
+  }
   tags {
+    Region      = "${title(var.aws-region-name)}"
     Product     = "${var.product-name}"
     Environment = "${title(var.Env-Name)}"
+    Category    = "TFstate"
   }
-  region      = "${var.aws-region}"
+
 
   policy = <<EOF
 {
@@ -31,4 +36,18 @@ resource "aws_s3_bucket" "state-bucket" {
 }
 EOF
 
+}
+
+resource "aws_s3_bucket" "accesslogs-bucket" {
+  bucket = "govwifi-${var.Env-Name}-ireland-accesslogs"
+  versioning {
+    enabled = true
+  }
+  tags {
+    Region      = "${title(var.aws-region-name)}"
+    Product     = "${var.product-name}"
+    Environment = "${title(var.Env-Name)}"
+    Category    = "Accesslogs"
+  }
+  region      = "${var.aws-region}"
 }

--- a/terraform-state/tfstate.tf
+++ b/terraform-state/tfstate.tf
@@ -66,6 +66,23 @@ resource "aws_iam_policy_attachment" "tfstate-replication" {
   policy_arn = "${aws_iam_policy.tfstate-replication.arn}"
 }
 
+resource "aws_kms_key" "tfstate-key" {
+  description             = "KMS key for the encryption of tfstate buckets."
+  deletion_window_in_days = 10
+  is_enabled              = true
+  tags {
+    Region      = "${title(var.aws-region-name)}"
+    Product     = "${var.product-name}"
+    Environment = "${title(var.Env-Name)}"
+    Category    = "TFstate"
+  }
+}
+
+resource "aws_kms_alias" "tfstate-key-alias" {
+  name          = "alias/${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate-key"
+  target_key_id = "${aws_kms_key.tfstate-key.key_id}"
+}
+
 resource "aws_s3_bucket" "state-bucket" {
   bucket = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate"
   region = "${var.aws-region}"
@@ -116,124 +133,19 @@ EOF
 
       destination {
         bucket        = "arn:aws:s3:::${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.backup-region-name)}-tfstate"
-        storage_class = "STANDARD"
+        storage_class = "STANDARD_IA"
+      }
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = "${aws_kms_key.tfstate-key.arn}"
+        sse_algorithm     = "aws:kms"
       }
     }
   }
 }
 
-# --------------------------------------------------------------
 
-resource "aws_iam_role" "accesslogs-replication" {
-  name = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs-replication-role"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "s3.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-POLICY
-}
-
-resource "aws_iam_policy" "accesslogs-replication" {
-  name = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs-replication-policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetReplicationConfiguration",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "${aws_s3_bucket.accesslogs-bucket.arn}"
-      ]
-    },
-    {
-      "Action": [
-        "s3:GetObjectVersion",
-        "s3:GetObjectVersionAcl"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "${aws_s3_bucket.accesslogs-bucket.arn}/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::${lower(var.product-name)}-${var.Env-Name}-${lower(var.backup-region-name)}-accesslogs/*"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_policy_attachment" "accesslogs-replication" {
-  name       = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs-replication"
-  roles      = ["${aws_iam_role.accesslogs-replication.name}"]
-  policy_arn = "${aws_iam_policy.accesslogs-replication.arn}"
-}
-
-resource "aws_s3_bucket" "accesslogs-bucket" {
-  bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
-  region = "${var.aws-region}"
-  acl    = "log-delivery-write"
-
-  versioning {
-    enabled = true
-  }
-
-  tags {
-    Region      = "${title(var.aws-region-name)}"
-    Product     = "${var.product-name}"
-    Environment = "${title(var.Env-Name)}"
-    Category    = "Accesslogs"
-  }
-
-
-  lifecycle_rule {
-    id = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs-lifecycle"
-    enabled = true
-
-    transition {
-      days          = "${var.accesslogs-glacier-transition-days}"
-      storage_class = "GLACIER"
-    }
-
-    expiration {
-      days          = "${var.accesslogs-expiration-days}"
-    }
-  }
-
-  replication_configuration {
-    role = "${aws_iam_role.accesslogs-replication.arn}"
-
-    rules {
-      # ID is necessary to prevent continuous change issue
-      id     = "${lower(var.aws-region-name)}-to-${lower(var.backup-region-name)}-accesslogs-backup"
-      prefix = "${lower(var.aws-region-name)}-accesslogs-backup"
-      status = "Enabled"
-
-      destination {
-        bucket        = "arn:aws:s3:::${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.backup-region-name)}-accesslogs"
-        storage_class = "STANDARD"
-      }
-    }
-  }
-}

--- a/terraform-state/tfstate.tf
+++ b/terraform-state/tfstate.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "state-bucket" {
   }
   logging {
     target_bucket = "govwifi-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
-    target_prefix = "log/"
+    target_prefix = "${lower(var.aws-region-name)}-tfstate"
   }
   tags {
     Region      = "${title(var.aws-region-name)}"
@@ -39,7 +39,7 @@ EOF
 }
 
 resource "aws_s3_bucket" "accesslogs-bucket" {
-  bucket = "govwifi-${var.Env-Name}-ireland-accesslogs"
+  bucket = "govwifi-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
   versioning {
     enabled = true
   }

--- a/terraform-state/tfstate.tf
+++ b/terraform-state/tfstate.tf
@@ -1,6 +1,75 @@
 # Resources for setting up s3 for terraform backend. (state storage in s3)
+resource "aws_iam_role" "tfstate-replication" {
+  name = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-tfstate-replication-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+
+resource "aws_iam_policy" "tfstate-replication" {
+  name = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-tfstate-replication-policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "s3:ListBucket",
+      "Effect": "Allow",
+      "Resource": "${aws_s3_bucket.state-bucket.arn}"
+    },
+    {
+      "Action": "s3:GetReplicationConfiguration",
+      "Effect": "Allow",
+      "Resource": "${aws_s3_bucket.state-bucket.arn}"
+    },
+    {
+      "Action": "s3:GetObjectVersion",
+      "Effect": "Allow",
+      "Resource": "${aws_s3_bucket.state-bucket.arn}/*"
+    },
+    {
+      "Action": "s3:GetObjectVersionAcl",
+      "Effect": "Allow",
+      "Resource": "${aws_s3_bucket.state-bucket.arn}/*"
+    },
+    {
+      "Action": "s3:ReplicateObject",
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${lower(var.product-name)}-${var.Env-Name}-${lower(var.backup-region-name)}-tfstate/*"
+    },
+    {
+      "Action": "s3:ReplicateDelete",
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${lower(var.product-name)}-${var.Env-Name}-${lower(var.backup-region-name)}-tfstate/*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "tfstate-replication" {
+  name       = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-tfstate-replication"
+  roles      = ["${aws_iam_role.tfstate-replication.name}"]
+  policy_arn = "${aws_iam_policy.tfstate-replication.arn}"
+}
+
 resource "aws_s3_bucket" "state-bucket" {
-  bucket = "govwifi-${var.Env-Name}-${lower(var.aws-region-name)}-tfstate"
+  bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-tfstate"
   region = "${var.aws-region}"
 
   policy = <<EOF
@@ -37,6 +106,90 @@ EOF
     target_bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
     target_prefix = "${lower(var.aws-region-name)}-tfstate"
   }
+
+  replication_configuration {
+    role = "${aws_iam_role.tfstate-replication.arn}"
+
+    rules {
+      # ID is necessary to prevent continuous change issue
+      id     = "${lower(var.aws-region-name)}-to-${lower(var.backup-region-name)}-tfstate-backup"
+      prefix = "${lower(var.aws-region-name)}-tfstate-backup"
+      status = "Enabled"
+
+      destination {
+        bucket        = "arn:aws:s3:::${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.backup-region-name)}-tfstate"
+        storage_class = "STANDARD"
+      }
+    }
+  }
+}
+
+# --------------------------------------------------------------
+
+resource "aws_iam_role" "accesslogs-replication" {
+  name = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs-replication-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy" "accesslogs-replication" {
+  name = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs-replication-policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.accesslogs-bucket.arn}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.accesslogs-bucket.arn}/*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ReplicateObject",
+        "s3:ReplicateDelete"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${lower(var.product-name)}-${var.Env-Name}-${lower(var.backup-region-name)}-accesslogs/*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "accesslogs-replication" {
+  name       = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs-replication"
+  roles      = ["${aws_iam_role.accesslogs-replication.name}"]
+  policy_arn = "${aws_iam_policy.accesslogs-replication.arn}"
 }
 
 resource "aws_s3_bucket" "accesslogs-bucket" {
@@ -57,10 +210,32 @@ resource "aws_s3_bucket" "accesslogs-bucket" {
 
 
   lifecycle_rule {
+    id = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs-lifecycle"
     enabled = true
 
+    transition {
+      days          = 7
+      storage_class = "GLACIER"
+    }
+
     expiration {
-      days = 30
+      days                         = 30
+    }
+  }
+
+  replication_configuration {
+    role = "${aws_iam_role.accesslogs-replication.arn}"
+
+    rules {
+      # ID is necessary to prevent continuous change issue
+      id     = "${lower(var.aws-region-name)}-to-${lower(var.backup-region-name)}-accesslogs-backup"
+      prefix = "${lower(var.aws-region-name)}-accesslogs-backup"
+      status = "Enabled"
+
+      destination {
+        bucket        = "arn:aws:s3:::${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.backup-region-name)}-accesslogs"
+        storage_class = "STANDARD"
+      }
     }
   }
 }

--- a/terraform-state/tfstate.tf
+++ b/terraform-state/tfstate.tf
@@ -2,20 +2,6 @@
 resource "aws_s3_bucket" "state-bucket" {
   bucket = "govwifi-${var.Env-Name}-${lower(var.aws-region-name)}-tfstate"
   region = "${var.aws-region}"
-  versioning {
-    enabled = true
-  }
-  logging {
-    target_bucket = "govwifi-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
-    target_prefix = "${lower(var.aws-region-name)}-tfstate"
-  }
-  tags {
-    Region      = "${title(var.aws-region-name)}"
-    Product     = "${var.product-name}"
-    Environment = "${title(var.Env-Name)}"
-    Category    = "TFstate"
-  }
-
 
   policy = <<EOF
 {
@@ -36,18 +22,45 @@ resource "aws_s3_bucket" "state-bucket" {
 }
 EOF
 
-}
+  tags {
+    Region      = "${title(var.aws-region-name)}"
+    Product     = "${var.product-name}"
+    Environment = "${title(var.Env-Name)}"
+    Category    = "TFstate"
+  }
 
-resource "aws_s3_bucket" "accesslogs-bucket" {
-  bucket = "govwifi-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
   versioning {
     enabled = true
   }
+
+  logging {
+    target_bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
+    target_prefix = "${lower(var.aws-region-name)}-tfstate"
+  }
+}
+
+resource "aws_s3_bucket" "accesslogs-bucket" {
+  bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
+  region = "${var.aws-region}"
+  acl    = "log-delivery-write"
+
+  versioning {
+    enabled = true
+  }
+
   tags {
     Region      = "${title(var.aws-region-name)}"
     Product     = "${var.product-name}"
     Environment = "${title(var.Env-Name)}"
     Category    = "Accesslogs"
   }
-  region      = "${var.aws-region}"
+
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
 }

--- a/terraform-state/variables.tf
+++ b/terraform-state/variables.tf
@@ -6,4 +6,6 @@ variable "aws-region" {}
 
 variable "aws-region-name" {}
 
+variable "backup-region-name" {}
+
 variable "product-name" {}

--- a/terraform-state/variables.tf
+++ b/terraform-state/variables.tf
@@ -9,3 +9,7 @@ variable "aws-region-name" {}
 variable "backup-region-name" {}
 
 variable "product-name" {}
+
+variable "accesslogs-glacier-transition-days" {}
+
+variable "accesslogs-expiration-days" {}


### PR DESCRIPTION
These buckets and their replication and expiration aspects were set up manually via the console in the past. This change moves these configurations to terraform, also adds server-side encryption for the tfstate files. 

In addition to it's main goals the change requirements have grown to include the following:
- Re-categorise alarms as critical / capacity, where critical means that on-call should be paged, while capacity is an issue that can be handled during normal working hours.
- Refactoring of the  Env-subdomain handling to ensure that environment name change will not affect FQDNs, (planned change)
- Also enables the addition and adds example tags for product, environment, region and category - this is a planned change for every resource.
