### PR TITLE
Make ELB count configurable.

### DIFF
--- a/govwifi-backend/loadbalancer.tf
+++ b/govwifi-backend/loadbalancer.tf
@@ -1,5 +1,6 @@
 # Create a new load balancer
 resource "aws_elb" "backend-elb" {
+  count           = "${var.backend-elb-count}"
   name            = "wifi-backend-elb-${var.Env-Name}"
   subnets         = ["${aws_subnet.wifi-backend-subnet.*.id}"]
   security_groups = ["${var.elb-sg-list}"]

--- a/govwifi-backend/route53.tf
+++ b/govwifi-backend/route53.tf
@@ -32,6 +32,7 @@ resource "aws_route53_record" "cache" {
 
 # CNAME for the elb for this environment
 resource "aws_route53_record" "elb" {
+  count   = "${var.backend-elb-count}"
   zone_id = "${var.route53-zone-id}"
   name    = "elb.${lower(var.aws-region-name)}.${var.Env-Name}${var.Env-Subdomain}.service.gov.uk"
   type    = "A"

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -48,6 +48,8 @@ variable "backend-min-size" {}
 
 variable "backend-cpualarm-count" {}
 
+variable "backend-elb-count" {}
+
 variable "aws-account-id" {}
 
 variable "elb-ssl-cert-arn" {}


### PR DESCRIPTION
The addition of the backend-elb-count variable allows for independent management (re-creation) of the backend load balancer and the associated CNAME record.