### PR TITLE
Use aws_iam_role_policy_attachment for LambdaVPCAccessExecutionRole

### DIFF
--- a/govwifi-lambda/iam-roles.tf
+++ b/govwifi-lambda/iam-roles.tf
@@ -18,8 +18,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 
-resource "aws_iam_policy_attachment" "lambda-execute-policy-attachment" {
-  name       = "Lamba cloudwatch and VPC execution policy"
-  roles      = ["${aws_iam_role.iam_for_lambda.name}"]
+resource "aws_iam_role_policy_attachment" "lambda-execute-role-policy-attachment" {
+  role       = "${aws_iam_role.iam_for_lambda.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }


### PR DESCRIPTION
Taken from the Terraform website:

    WARNING: The aws_iam_policy_attachment resource creates exclusive attachments of IAM policies. Across the entire AWS account, all of the users/roles/groups to which a single policy is attached must be declared by a single aws_iam_policy_attachment resource. This means that even any users/roles/groups that have the attached policy via some mechanism other than Terraform will have that attached policy revoked by Terraform. Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead. These resources do not enforce exclusive attachment of an IAM policy.

By using the aws_iam_policy_attachment we are causing conflicts
between production and staging environments removing each other
when they are applied.
