### PR TITLE
Add new configuration for getting allowed clients

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -14,7 +14,7 @@ resource "aws_ecs_task_definition" "radius-task" {
   family = "radius-task-${var.Env-Name}"
 
   container_definitions = <<EOF
-[ 
+[
   {
     "volumesFrom": [],
     "memory": 2000,
@@ -50,6 +50,9 @@ resource "aws_ecs_task_definition" "radius-task" {
       {
         "name": "BACKEND_BASEURL",
         "value": "${var.backend-base-url}"
+      },{
+        "name": "ALLOWED_SITES_API_BASE_URL",
+        "value": "${var.allowed-sites-api-base-url}"
       },{
         "name": "BACKEND_API_KEY",
         "value": "${var.shared-key}"

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -42,6 +42,8 @@ variable "dns-numbering-base" {}
 
 variable "backend-base-url" {}
 
+variable "allowed-sites-api-base-url" {}
+
 variable "elastic-ip-list" {
   type = "list"
 }


### PR DESCRIPTION
Boot up ECS Cluster with new environment variable which points to the location where you get a list of clients.  Staging uses a new ruby api, and production will continue to use the php backend.