### PR TITLE
Set count to 0 so that additional ECR repositories

### DIFF
--- a/govwifi-allowed-sites-api/cluster.tf
+++ b/govwifi-allowed-sites-api/cluster.tf
@@ -9,6 +9,7 @@ resource "aws_cloudwatch_log_group" "allowed-sites-api-log-group" {
 }
 
 resource "aws_ecr_repository" "govwifi-allowed-sites-api-ecr" {
+  count = "${var.ecr-repository-count}"
   name = "govwifi/allowed-sites-api"
 }
 

--- a/govwifi-allowed-sites-api/variables.tf
+++ b/govwifi-allowed-sites-api/variables.tf
@@ -62,3 +62,8 @@ variable "subnet-ids" {
 
 variable "ecs-instance-profile-id" {}
 variable "ecs-service-role" {}
+
+variable "ecr-repository-count" {
+  default = 0
+  description = "Whether or not to create ECR repository"
+}


### PR DESCRIPTION
If this isn't done, the repo created during staging provisioning wouldn't allow the production to try create it again.  Overwrite the default to 1 to create.