### PR TITLE
Bootstrap the performance instance with eapol_test

### DIFF
--- a/performance-testing/variables.tf
+++ b/performance-testing/variables.tf
@@ -10,8 +10,6 @@ variable "performance-ami" {}
 
 variable "performance-instance-type" {}
 
-variable "performance-server-ip" {}
-
 variable "performance-ssh-key-name" {}
 
 variable "performance-subnet-id" {}


### PR DESCRIPTION
We used to install eapol_test manually on the performance testing instances.
This bootstraps and configures it so it's ready once the server has been created.