### PR TITLE
Update to re-enable ECS agent update

### DIFF
--- a/govwifi-allowed-sites-api/launch-configuration.tf
+++ b/govwifi-allowed-sites-api/launch-configuration.tf
@@ -15,7 +15,7 @@ MIME-Version: 1.0
 Content-Type: text/cloud-config; charset="us-ascii"
 #cloud-config
 repo_update: true
-# temporary disable repo_upgrade: all
+repo_upgrade: all
 
 --==BOUNDARY==
 MIME-Version: 1.0
@@ -83,7 +83,7 @@ sudo cp ./crontab /etc/crontab
 cat <<'EOF' > ./security-updates
 #!/bin/bash
 sudo yum update -y --security
-# temporary disable sudo yum update -y ecs-init
+sudo yum update -y ecs-init
 sudo service docker restart
 sleep 5
 sudo start ecs

--- a/govwifi-api/launch-configuration.tf
+++ b/govwifi-api/launch-configuration.tf
@@ -15,7 +15,7 @@ MIME-Version: 1.0
 Content-Type: text/cloud-config; charset="us-ascii"
 #cloud-config
 repo_update: true
-# temporary disable repo_upgrade: all
+repo_upgrade: all
 
 --==BOUNDARY==
 MIME-Version: 1.0

--- a/govwifi-backend/modules/ecs-autoscaling/launch-configuration.tf
+++ b/govwifi-backend/modules/ecs-autoscaling/launch-configuration.tf
@@ -15,7 +15,7 @@ MIME-Version: 1.0
 Content-Type: text/cloud-config; charset="us-ascii"
 #cloud-config
 repo_update: true
-# temporary disable repo_upgrade: all
+repo_upgrade: all
 
 --==BOUNDARY==
 MIME-Version: 1.0
@@ -69,7 +69,7 @@ sudo cp ./crontab /etc/crontab
 cat <<'EOF' > ./security-updates
 #!/bin/bash
 sudo yum update -y --security
-# temporary disable sudo yum update -y ecs-init
+sudo yum update -y ecs-init
 sudo service docker restart
 sleep 5
 sudo start ecs

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -19,7 +19,7 @@ MIME-Version: 1.0
 Content-Type: text/cloud-config; charset="us-ascii"
 #cloud-config
 repo_update: true
-# temporary disable repo_upgrade: all
+repo_upgrade: all
 
 --==BOUNDARY==
 MIME-Version: 1.0
@@ -70,7 +70,7 @@ sudo cp ./crontab /etc/crontab
 cat <<'EOF' > ./security-updates
 #!/bin/bash
 sudo yum update -y --security
-# temporary disable sudo yum update -y ecs-init
+sudo yum update -y ecs-init
 sudo service docker restart
 sleep 5
 sudo start ecs


### PR DESCRIPTION
We've been receiving warnings that the ECS agents are out of date on
containers, we've confirmed the upgrade works with the authentication
containers so are rolling this out to the remaining containers.