### PR TITLE
Add environment variable that the radius servers will use for authorisation

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -48,6 +48,9 @@ resource "aws_ecs_task_definition" "radius-task" {
     "dockerSecurityOptions": null,
     "environment": [
       {
+        "name": "API_BASE_URL",
+        "value": "${var.api-base-url}"
+      },{
         "name": "BACKEND_BASEURL",
         "value": "${var.backend-base-url}"
       },{


### PR DESCRIPTION
This will be used by the rest module for the radius servers to decide where to send authentication requests.  Stubbed out for production right now, staging will use our Authentication API.