### PR TITLE
Autoscaling auth

### DIFF
--- a/govwifi-api/scaling-policy.tf
+++ b/govwifi-api/scaling-policy.tf
@@ -25,3 +25,91 @@ resource "aws_cloudwatch_metric_alarm" "cpualarm" {
   alarm_actions      = ["${aws_autoscaling_policy.scale-policy.arn}", "${var.critical-notifications-arn}"]
   treat_missing_data = "breaching"
 }
+
+resource "aws_cloudwatch_metric_alarm" "auth_service_high" {
+  alarm_name          = "${var.Env-Name}-api-cpu-alarm-high-30"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "30"
+
+  dimensions {
+    ClusterName = "${aws_ecs_cluster.api-cluster.name}"
+    ServiceName = "${aws_ecs_service.authorisation-api-service.name}"
+  }
+
+  alarm_description  = "This metric monitors ecs cpu utilization"
+  alarm_actions      = ["${aws_appautoscaling_policy.ecs_policy_up.arn}", "${var.critical-notifications-arn}"]
+  treat_missing_data = "breaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "auth_service_low" {
+  alarm_name          = "${var.Env-Name}-api-cpu-alarm-low-5"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "5"
+
+  dimensions {
+    ClusterName = "${aws_ecs_cluster.api-cluster.name}"
+    ServiceName = "${aws_ecs_service.authorisation-api-service.name}"
+  }
+
+  alarm_description  = "Low CPU API ECS"
+  alarm_actions      = ["${aws_appautoscaling_policy.ecs_policy_down.arn}", "${var.critical-notifications-arn}"]
+  treat_missing_data = "breaching"
+}
+resource "aws_appautoscaling_target" "auth_ecs_target" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
+  max_capacity       = 4
+  min_capacity       = 2
+  role_arn           = "${var.ecs-service-role}"
+  scalable_dimension = "ecs:service:DesiredCount"
+}
+
+resource "aws_appautoscaling_policy" "ecs_policy_up" {
+  name               = "ECS Scale Up"
+  service_namespace  = "ecs"
+  policy_type        = "StepScaling"
+  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type    = "ChangeInCapacity"
+    metric_aggregation_type   = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment = 1
+    }
+  }
+
+  depends_on = ["aws_appautoscaling_target.auth_ecs_target"]
+}
+
+resource "aws_appautoscaling_policy" "ecs_policy_down" {
+  name               = "ECS Scale Down"
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
+  policy_type        = "StepScaling"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type    = "ChangeInCapacity"
+    metric_aggregation_type   = "Average"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment = -1
+    }
+  }
+
+  depends_on = ["aws_appautoscaling_target.auth_ecs_target"]
+}

--- a/govwifi-api/scaling-policy.tf
+++ b/govwifi-api/scaling-policy.tf
@@ -8,7 +8,7 @@ resource "aws_autoscaling_policy" "scale-policy" {
 
 resource "aws_cloudwatch_metric_alarm" "cpualarm" {
   count               = "${var.backend-cpualarm-count}"
-  alarm_name          = "${var.Env-Name}-api-cpu-alarm"
+  alarm_name          = "${var.Env-Name}-api-cpu-alarm-ec2"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "CPUUtilization"
@@ -27,14 +27,14 @@ resource "aws_cloudwatch_metric_alarm" "cpualarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "auth_service_high" {
-  alarm_name          = "${var.Env-Name}-api-cpu-alarm-high-30"
+  alarm_name          = "${var.Env-Name}-api-cpu-alarm-high-ecs"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
   period              = "60"
   statistic           = "Average"
-  threshold           = "30"
+  threshold           = "50"
 
   dimensions {
     ClusterName = "${aws_ecs_cluster.api-cluster.name}"
@@ -47,7 +47,7 @@ resource "aws_cloudwatch_metric_alarm" "auth_service_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "auth_service_low" {
-  alarm_name          = "${var.Env-Name}-api-cpu-alarm-low-5"
+  alarm_name          = "${var.Env-Name}-api-cpu-alarm-low-ecs"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "auth_service_low" {
 resource "aws_appautoscaling_target" "auth_ecs_target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
-  max_capacity       = 4
+  max_capacity       = 6
   min_capacity       = 2
   role_arn           = "${var.ecs-service-role}"
   scalable_dimension = "ecs:service:DesiredCount"

--- a/govwifi-api/scaling-policy.tf
+++ b/govwifi-api/scaling-policy.tf
@@ -1,14 +1,40 @@
-resource "aws_autoscaling_policy" "scale-policy" {
-  name                   = "${var.Env-Name}-api-scale-policy"
+resource "aws_autoscaling_policy" "api-ec2-scale-up-policy" {
+  name                   = "${var.Env-Name}-api-ec2-scale-up-policy"
   scaling_adjustment     = 1
   adjustment_type        = "ChangeInCapacity"
   cooldown               = 300
   autoscaling_group_name = "${aws_autoscaling_group.api-asg.name}"
 }
 
-resource "aws_cloudwatch_metric_alarm" "cpualarm" {
-  count               = "${var.backend-cpualarm-count}"
-  alarm_name          = "${var.Env-Name}-api-cpu-alarm-ec2"
+resource "aws_autoscaling_policy" "api-ec2-scale-down-policy" {
+  name                   = "${var.Env-Name}-api-ec2-scale-down-policy"
+  scaling_adjustment     = -1
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  autoscaling_group_name = "${aws_autoscaling_group.api-asg.name}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-low" {
+  alarm_name          = "${var.Env-Name}-ec2-api-cpu-alarm-low"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "30"
+
+  dimensions {
+    AutoScalingGroupName = "${aws_autoscaling_group.api-asg.name}"
+  }
+
+  alarm_description  = "This alarm tells EC2 to scale in"
+  alarm_actions      = ["${aws_autoscaling_policy.api-ec2-scale-down-policy.arn}", "${var.critical-notifications-arn}"]
+  treat_missing_data = "breaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-high" {
+  alarm_name          = "${var.Env-Name}-ec2-api-cpu-alarm-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "CPUUtilization"
@@ -21,13 +47,13 @@ resource "aws_cloudwatch_metric_alarm" "cpualarm" {
     AutoScalingGroupName = "${aws_autoscaling_group.api-asg.name}"
   }
 
-  alarm_description  = "This metric monitors ec2 cpu utilization"
-  alarm_actions      = ["${aws_autoscaling_policy.scale-policy.arn}", "${var.critical-notifications-arn}"]
+  alarm_description  = "This alarm tells EC2 to scale up"
+  alarm_actions      = ["${aws_autoscaling_policy.api-ec2-scale-up-policy.arn}", "${var.critical-notifications-arn}"]
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "auth_service_high" {
-  alarm_name          = "${var.Env-Name}-api-cpu-alarm-high-ecs"
+resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-high" {
+  alarm_name          = "${var.Env-Name}-auth-ecs-cpu-alarm-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
@@ -41,13 +67,13 @@ resource "aws_cloudwatch_metric_alarm" "auth_service_high" {
     ServiceName = "${aws_ecs_service.authorisation-api-service.name}"
   }
 
-  alarm_description  = "This metric monitors ecs cpu utilization"
-  alarm_actions      = ["${aws_appautoscaling_policy.ecs_policy_up.arn}", "${var.critical-notifications-arn}"]
+  alarm_description  = "This alarm tells ECS to scale up"
+  alarm_actions      = ["${aws_appautoscaling_policy.ecs-policy-up.arn}", "${var.critical-notifications-arn}"]
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "auth_service_low" {
-  alarm_name          = "${var.Env-Name}-api-cpu-alarm-low-ecs"
+resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
+  alarm_name          = "${var.Env-Name}-auth-ecs-cpu-alarm-low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
@@ -61,20 +87,21 @@ resource "aws_cloudwatch_metric_alarm" "auth_service_low" {
     ServiceName = "${aws_ecs_service.authorisation-api-service.name}"
   }
 
-  alarm_description  = "Low CPU API ECS"
-  alarm_actions      = ["${aws_appautoscaling_policy.ecs_policy_down.arn}", "${var.critical-notifications-arn}"]
+  alarm_description  = "This alarm tells ECS to scale in"
+  alarm_actions      = ["${aws_appautoscaling_policy.ecs-policy-down.arn}", "${var.critical-notifications-arn}"]
   treat_missing_data = "breaching"
 }
-resource "aws_appautoscaling_target" "auth_ecs_target" {
+
+resource "aws_appautoscaling_target" "auth-ecs-target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
-  max_capacity       = 6
+  max_capacity       = 10
   min_capacity       = 2
   role_arn           = "${var.ecs-service-role}"
   scalable_dimension = "ecs:service:DesiredCount"
 }
 
-resource "aws_appautoscaling_policy" "ecs_policy_up" {
+resource "aws_appautoscaling_policy" "ecs-policy-up" {
   name               = "ECS Scale Up"
   service_namespace  = "ecs"
   policy_type        = "StepScaling"
@@ -91,10 +118,10 @@ resource "aws_appautoscaling_policy" "ecs_policy_up" {
     }
   }
 
-  depends_on = ["aws_appautoscaling_target.auth_ecs_target"]
+  depends_on = ["aws_appautoscaling_target.auth-ecs-target"]
 }
 
-resource "aws_appautoscaling_policy" "ecs_policy_down" {
+resource "aws_appautoscaling_policy" "ecs-policy-down" {
   name               = "ECS Scale Down"
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
@@ -111,5 +138,5 @@ resource "aws_appautoscaling_policy" "ecs_policy_down" {
     }
   }
 
-  depends_on = ["aws_appautoscaling_target.auth_ecs_target"]
+  depends_on = ["aws_appautoscaling_target.auth-ecs-target"]
 }


### PR DESCRIPTION
Allow our Authentication application to scale to meet the current demand.
Both EC2 and ECS scale up and down using autoscaling policies.