### PR TITLE
The ECS instance count can be double the EC2 instance count since the re are 2 per EC2 instance

### DIFF
--- a/govwifi-api/scaling-policy.tf
+++ b/govwifi-api/scaling-policy.tf
@@ -95,7 +95,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
 resource "aws_appautoscaling_target" "auth-ecs-target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
-  max_capacity       = 10
+  max_capacity       = 20
   min_capacity       = 2
   role_arn           = "${var.ecs-service-role}"
   scalable_dimension = "ecs:service:DesiredCount"


### PR DESCRIPTION
We allow 2 ECS containers to run on an EC2 instance.  We allow a maximum of up to 10 EC2 instances so we should allow up to 20 ECS instances to exist.