### PR TITLE
Update instance to t2.small for Allowed Sites API

### DIFF
--- a/govwifi-allowed-sites-api/cluster.tf
+++ b/govwifi-allowed-sites-api/cluster.tf
@@ -20,7 +20,7 @@ resource "aws_ecs_task_definition" "allowed-sites-api-task" {
 [
     {
       "volumesFrom": [],
-      "memory": 2000,
+      "memory": 1900,
       "extraHosts": null,
       "dnsServers": null,
       "disableNetworking": null,

--- a/govwifi-allowed-sites-api/launch-configuration.tf
+++ b/govwifi-allowed-sites-api/launch-configuration.tf
@@ -1,7 +1,7 @@
 resource "aws_launch_configuration" "ecs" {
   name_prefix          = "tf-${var.Env-Name}-allowed-sites-api-lc-"
   image_id             = "${var.ami}"
-  instance_type        = "t2.micro"
+  instance_type        = "t2.small"
   iam_instance_profile = "${var.ecs-instance-profile-id}"
   key_name             = "${var.ssh-key-name}"
   security_groups      = ["${var.backend-sg-list}"]


### PR DESCRIPTION
t2.micro only has 1G of RAM.  Might not be enough for our ruby application down the line.  Also amend the Container memory to be a maximum of 1.9G