### PR TITLE
Disable anacron daemon

### DIFF
--- a/govwifi-allowed-sites-api/launch-configuration.tf
+++ b/govwifi-allowed-sites-api/launch-configuration.tf
@@ -31,6 +31,10 @@ rm CloudWatchMonitoringScripts-1.2.2.zip
 mv aws-scripts-mon /home/ec2-user/scripts/mon
 
 --==BOUNDARY==
+# Disable anacron which runs at 3am by default each morning
+sudo chmod a-x $(which anacron)
+
+--==BOUNDARY==
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash

--- a/govwifi-api/launch-configuration.tf
+++ b/govwifi-api/launch-configuration.tf
@@ -31,6 +31,10 @@ rm CloudWatchMonitoringScripts-1.2.2.zip
 mv aws-scripts-mon /home/ec2-user/scripts/mon
 
 --==BOUNDARY==
+# Disable anacron which runs at 3am by default each morning
+sudo chmod a-x $(which anacron)
+
+--==BOUNDARY==
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash

--- a/govwifi-backend/modules/ecs-autoscaling/launch-configuration.tf
+++ b/govwifi-backend/modules/ecs-autoscaling/launch-configuration.tf
@@ -18,6 +18,10 @@ repo_update: true
 repo_upgrade: all
 
 --==BOUNDARY==
+# Disable anacron which runs at 3am by default each morning
+sudo chmod a-x $(which anacron)
+
+--==BOUNDARY==
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -22,6 +22,10 @@ repo_update: true
 repo_upgrade: all
 
 --==BOUNDARY==
+# Disable anacron which runs at 3am by default each morning
+sudo chmod a-x $(which anacron)
+
+--==BOUNDARY==
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash


### PR DESCRIPTION
We have a cron that runs daily at around midnight.
Amazon Linux comes with anacron which runs at 3am by default.

This is undesirable as it restarts all the docker containers for the
frontend, backend, API and allowed sites.

This creates a race condition as the frontends depend on allowed sites
to pull in configuration