### PR TITLE
We have a cron that runs daily at around midnight.

### DIFF
--- a/govwifi-allowed-sites-api/launch-configuration.tf
+++ b/govwifi-allowed-sites-api/launch-configuration.tf
@@ -216,6 +216,14 @@ script
 	service awslogs start
 	chkconfig awslogs on
 end script
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+# Disable anacron which runs at 3am by default each morning
+sudo chmod a-x /usr/sbin/anacron
+
 --==BOUNDARY==--
 DATA
 


### PR DESCRIPTION
Amazon Linux comes with anacron which runs at 3am by default.

This is undesirable as it restarts all the docker containers for the
frontend, backend, API and allowed sites.

This creates a race condition as the frontends depend on allowed sites
to pull in configuration changes.

Disable this for Allowed Sites for now