### PR TITLE
Update to ensure all clusters create new resources before destroy

### DIFF
--- a/govwifi-allowed-sites-api/cluster.tf
+++ b/govwifi-allowed-sites-api/cluster.tf
@@ -92,6 +92,10 @@ resource "aws_ecs_task_definition" "allowed-sites-api-task" {
     }
 ]
 EOF
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_ecs_service" "allowed-sites-api-service" {

--- a/govwifi-api/cluster.tf
+++ b/govwifi-api/cluster.tf
@@ -79,6 +79,10 @@ resource "aws_ecs_task_definition" "authorisation-api-task" {
     }
 ]
 EOF
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_ecs_service" "authorisation-api-service" {

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -210,6 +210,10 @@ DATA
     Name = "${title(var.Env-Name)} Frontend Radius-${var.dns-numbering-base + count.index + 1}"
     Env  = "${title(var.Env-Name)}"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_eip_association" "eip_assoc" {


### PR DESCRIPTION
We've found that changes to userdata on clusters can result in the
underlying instance being destroyed and then a new one created resulting
in potential downtime. By using create before destroy we avoid this
scenario and can move to more in hours deployment.