### PR TITLE
Update allowed sites and auth to use Read Replica

### DIFF
--- a/govwifi-allowed-sites-api/cluster.tf
+++ b/govwifi-allowed-sites-api/cluster.tf
@@ -56,7 +56,7 @@ resource "aws_ecs_task_definition" "allowed-sites-api-task" {
           "value": "${var.db-user}"
         },{
           "name": "DB_HOSTNAME",
-          "value": "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
+          "value": "${var.db-hostname}"
         },{
           "name": "RACK_ENV",
           "value": "${var.rack-env}"

--- a/govwifi-allowed-sites-api/variables.tf
+++ b/govwifi-allowed-sites-api/variables.tf
@@ -30,6 +30,8 @@ variable "db-user" {}
 
 variable "db-password" {}
 
+variable "db-hostname" {}
+
 variable "docker-image" {}
 
 variable "rack-env" {}

--- a/govwifi-api/cluster.tf
+++ b/govwifi-api/cluster.tf
@@ -46,7 +46,7 @@ resource "aws_ecs_task_definition" "authorisation-api-task" {
           "value": "${var.db-user}"
         },{
           "name": "DB_HOSTNAME",
-          "value": "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
+          "value": "${var.db-hostname}"
         },{
           "name": "RACK_ENV",
           "value": "${var.rack-env}"

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -30,6 +30,8 @@ variable "db-user" {}
 
 variable "db-password" {}
 
+variable "db-hostname" {}
+
 variable "rack-env" {}
 
 variable "radius-server-ips" {}


### PR DESCRIPTION
We noticed the two new API apps were using the live database rather than
the Read Replica, given they aren't updating anything we don't need to
access live.

Staging still needs to use the live DB as it doesn't have a Read Replica
set up.