### PR TITLE
Add authorised emails domains regex variable to API

### DIFF
--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -57,6 +57,9 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
         },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.Env-Name}"
+        },{
+          "name": "AUTHORISED_EMAIL_DOMAINS_REGEX",
+          "value": ${jsonencode(var.authorised-email-domains-regex)}
         }
       ],
       "links": null,

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -74,6 +74,10 @@ variable "auth-docker-image" {}
 
 variable "user-signup-docker-image" {}
 
+variable "authorised-email-domains-regex" {
+  description = "Regex used as matcher for whether an incoming email is from a government address."
+}
+
 variable "ecr-repository-count" {
   default     = 0
   description = "Whether or not to create ECR repository"


### PR DESCRIPTION
This variable gets used by the user signup API as matcher for whether an incoming email is from a government address.