### PR TITLE
Pass in GOV.UK Notify API key as environment variable

### DIFF
--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -60,6 +60,9 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
         },{
           "name": "AUTHORISED_EMAIL_DOMAINS_REGEX",
           "value": ${jsonencode(var.authorised-email-domains-regex)}
+        },{
+          "name": "NOTIFY_API_KEY",
+          "value": "${var.notify-api-key}"
         }
       ],
       "links": null,

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -78,6 +78,10 @@ variable "authorised-email-domains-regex" {
   description = "Regex used as matcher for whether an incoming email is from a government address."
 }
 
+variable "notify-api-key" {
+  description = "API key used to authenticate with GOV.UK Notify"
+}
+
 variable "ecr-repository-count" {
   default     = 0
   description = "Whether or not to create ECR repository"


### PR DESCRIPTION
We need access to the Notify API key to send out emails/SMSs as part of the user signup flow.  By using environment variables this makes the app 12 factor