### PR TITLE
Add S3 bucket for storing the wordlist

### DIFF
--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -87,4 +87,14 @@ variable "ecr-repository-count" {
   description = "Whether or not to create ECR repository"
 }
 
+variable "wordlist-bucket-count" {
+  default     = 0
+  description = "Whether or not to create wordlist bucket"
+}
+
+variable "wordlist-file-path" {
+  default     = ""
+  description = "The local path of the wordlist which gets uploaded to S3"
+}
+
 variable "vpc-id" {}

--- a/govwifi-api/wordlist.tf
+++ b/govwifi-api/wordlist.tf
@@ -1,0 +1,42 @@
+resource "aws_s3_bucket" "wordlist" {
+  bucket = "govwifi-wordlist"
+  count  = "${var.wordlist-bucket-count}"
+  acl    = "private"
+
+  tags {
+    Name = "wordlist-bucket"
+  }
+}
+
+resource "aws_s3_bucket_object" "wordlist" {
+  bucket = "${aws_s3_bucket.wordlist.bucket}"
+  count  = "${var.wordlist-bucket-count}"
+  key    = "wordlist-short"
+  source = "${var.wordlist-file-path}"
+  etag   = "${md5(file(var.wordlist-file-path))}"
+}
+
+resource "aws_iam_user_policy" "jenkins-read-wordlist-policy" {
+  user   = "${aws_iam_user.jenkins-read-wordlist-bucket.name}"
+  name   = "jenkins-read-wordlist-policy"
+  count  = "${var.wordlist-bucket-count}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.wordlist.bucket}/${aws_s3_bucket_object.wordlist.key}"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user" "jenkins-read-wordlist-bucket" {
+  name  = "jenkins-read-wordlist-user"
+  count = "${var.wordlist-bucket-count}"
+}


### PR DESCRIPTION
The wordlist gets used during signup to generate a random password for the user.  We don't want to expose the wordlist in GitHub, so to avoid this we'll push it into S3 and give permission to Jenkins to pull it down while building the image.
