### PR TITLE
Create new SNS topic for the Ruby version of the user-signup handler

### DIFF
--- a/govwifi-emails/s3sns.tf
+++ b/govwifi-emails/s3sns.tf
@@ -119,7 +119,7 @@ EOF
   }
 }
 
-# SNS topic to notify the backend when an email arrives
+# SNS topic to notify the old backend when an email arrives
 resource "aws_sns_topic" "govwifi-email-notifications" {
   name         = "${var.Env-Name}-email-notifications"
   display_name = "${title(var.Env-Name)} GovWifi email notifications"
@@ -183,4 +183,18 @@ resource "aws_sns_topic_subscription" "email-notifications-target" {
   endpoint_auto_confirms          = true
   confirmation_timeout_in_minutes = 2
   depends_on                      = ["aws_sns_topic.govwifi-email-notifications"]
+}
+
+# SNS topic to notify the new user-signup API when an email arrives
+resource "aws_sns_topic" "user-signup-notifications" {
+  name         = "${var.Env-Name}-user-signup-notifications"
+  display_name = "${title(var.Env-Name)} user signup email notifications"
+}
+
+resource "aws_sns_topic_subscription" "user-signup-notifications-target" {
+  topic_arn                       = "${aws_sns_topic.user-signup-notifications.arn}"
+  protocol                        = "https"
+  endpoint                        = "${var.user-signup-notifications-endpoint}"
+  endpoint_auto_confirms          = true
+  depends_on                      = ["aws_sns_topic.user-signup-notifications"]
 }

--- a/govwifi-emails/variables.tf
+++ b/govwifi-emails/variables.tf
@@ -15,3 +15,7 @@ variable "aws-region-name" {}
 variable "mail-exchange-server" {}
 
 variable "sns-endpoint" {}
+
+variable "user-signup-notifications-endpoint" {
+  description = "HTTP endpoint used by SNS to send user signup email notifications"
+}


### PR DESCRIPTION
As we convert different email flows to Ruby, this SNS topic will handle more of the notifications, and the older "govwifi-email-notifications" will slowly become unused.