### PR TITLE
Introduce a new variable name for the read replica database

### DIFF
--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -42,7 +42,7 @@ resource "aws_ecs_task_definition" "authorisation-api-task" {
           "value": "${var.db-user}"
         },{
           "name": "DB_HOSTNAME",
-          "value": "${var.db-hostname}"
+          "value": "${var.db-read-replica-hostname}"
         },{
           "name": "RACK_ENV",
           "value": "${var.rack-env}"

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -32,6 +32,8 @@ variable "db-password" {}
 
 variable "db-hostname" {}
 
+variable "db-read-replica-hostname" {}
+
 variable "rack-env" {}
 
 variable "radius-server-ips" {}


### PR DESCRIPTION
Previously we were overwriting the db hostname with a read replica
value for production.  This was causing trouble for user signups
as we need to insert data.  Inserting data into a read replica
blows up when running that on a read replica.

By separating out the two variables we can specify the read replica
for the authroisations task, and the master for the user signup
task.