### PR TITLE
Remove Unused Recipients from SES Rules

### DIFF
--- a/govwifi-emails/emails.tf
+++ b/govwifi-emails/emails.tf
@@ -41,10 +41,7 @@ resource "aws_ses_receipt_rule" "all-mail-rule" {
   ]
 
   recipients = [
-    "enrol@${var.Env-Subdomain}.service.gov.uk",
-    "enroll@${var.Env-Subdomain}.service.gov.uk",
     "logrequest@${var.Env-Subdomain}.service.gov.uk",
-    "signup@${var.Env-Subdomain}.service.gov.uk",
     "newsite@${var.Env-Subdomain}.service.gov.uk",
     "sponsor@${var.Env-Subdomain}.service.gov.uk",
     "verify@${var.Env-Subdomain}.service.gov.uk",


### PR DESCRIPTION
Since the first rule already includes these emails and then stops
processing any further rules in the rule set, these emails will never
trigger this rule.