### PR TITLE
Remove the SMS template ID from the user signup API task definition

### DIFF
--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -66,9 +66,6 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
         },{
           "name": "NOTIFY_USER_SIGNUP_EMAIL_TEMPLATE_ID",
           "value": "${var.notify-user-signup-email-template-id}"
-        },{
-          "name": "NOTIFY_USER_SIGNUP_SMS_TEMPLATE_ID",
-          "value": "${var.notify-user-signup-sms-template-id}"
         }
       ],
       "links": null,

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -88,10 +88,6 @@ variable "notify-user-signup-email-template-id" {
   description = "GOV.UK Notify template ID for the user signup email template"
 }
 
-variable "notify-user-signup-sms-template-id" {
-  description = "GOV.UK Notify template ID for the user signup SMS template"
-}
-
 variable "ecr-repository-count" {
   default     = 0
   description = "Whether or not to create ECR repository"


### PR DESCRIPTION
These are no longer passed into the app as environment variables, but complied into the image as yaml configuration files