### PR TITLE
Send sponsor emails to the user signup API

### DIFF
--- a/govwifi-emails/emails.tf
+++ b/govwifi-emails/emails.tf
@@ -13,6 +13,7 @@ resource "aws_ses_receipt_rule" "user-signup-rule" {
     "enrol@${var.Env-Subdomain}.service.gov.uk",
     "enroll@${var.Env-Subdomain}.service.gov.uk",
     "signup@${var.Env-Subdomain}.service.gov.uk",
+    "sponsor@${var.Env-Subdomain}.service.gov.uk"
   ]
 
   s3_action {
@@ -43,7 +44,6 @@ resource "aws_ses_receipt_rule" "all-mail-rule" {
   recipients = [
     "logrequest@${var.Env-Subdomain}.service.gov.uk",
     "newsite@${var.Env-Subdomain}.service.gov.uk",
-    "sponsor@${var.Env-Subdomain}.service.gov.uk",
     "verify@${var.Env-Subdomain}.service.gov.uk",
   ]
 


### PR DESCRIPTION
Now that the new Ruby service handles sponsor emails route them through that instead of the PHP backend.