### PR TITLE
Remove notify user signup email template id environment variable

### DIFF
--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -105,9 +105,6 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
         },{
           "name": "NOTIFY_API_KEY",
           "value": "${var.notify-api-key}"
-        },{
-          "name": "NOTIFY_USER_SIGNUP_EMAIL_TEMPLATE_ID",
-          "value": "${var.notify-user-signup-email-template-id}"
         }
       ],
       "links": null,

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -84,10 +84,6 @@ variable "notify-api-key" {
   description = "API key used to authenticate with GOV.UK Notify"
 }
 
-variable "notify-user-signup-email-template-id" {
-  description = "GOV.UK Notify template ID for the user signup email template"
-}
-
 variable "ecr-repository-count" {
   default     = 0
   description = "Whether or not to create ECR repository"


### PR DESCRIPTION
This isn't needed anymore because we store this config locally in the
user signup API application