### PR TITLE
Create Route53 Latency Alarm

### DIFF
--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -91,3 +91,22 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
 
   treat_missing_data = "breaching"
 }
+
+resource "aws_cloudwatch_metric_alarm" "route-53-healthcheck-latency-high" {
+  alarm_name          = "${var.Env-Name}-route-53-healthcheck-latency-high"
+  alarm_description   = "High Latency on Route53 Health Check"
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "TimeToFirstByte"
+  namespace           = "AWS/Route53"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "1000"
+
+  alarm_actions      = [
+    "${var.critical-notifications-arn}"
+  ]
+
+  treat_missing_data = "breaching"
+}


### PR DESCRIPTION
We want to be notified when the Route53 healthcheck latency is more than
1000ms.  This will send a notification to the critical-notifications-arn
endpoint, and we will receive an email about it.

Ultimately we want to receive an sms as well but this will be done in
the console so we don't have to embed our contact details in Terraform.