### PR TITLE
Ensure we always have instances to place tasks on when autoscaling

### DIFF
--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -95,15 +95,15 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
 resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-high" {
   alarm_name          = "${var.Env-Name}-ecs-api-memory-reservation-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "2"
   metric_name         = "MemoryReservation"
   namespace           = "AWS/ECS"
-  period              = "120"
+  period              = "60"
   statistic           = "Average"
   threshold           = "75"
 
   dimensions {
-    AutoScalingGroupName = "${aws_autoscaling_group.api-asg.name}"
+    ClusterName = "${aws_ecs_cluster.api-cluster.name}"
   }
 
   alarm_description  = "Cluster memory reservation above 75%"
@@ -117,15 +117,15 @@ resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-high" {
 resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-low" {
   alarm_name          = "${var.Env-Name}-ecs-api-memory-reservation-low"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "2"
   metric_name         = "MemoryReservation"
   namespace           = "AWS/ECS"
-  period              = "120"
+  period              = "60"
   statistic           = "Average"
   threshold           = "50"
 
   dimensions {
-    AutoScalingGroupName = "${aws_autoscaling_group.api-asg.name}"
+    ClusterName = "${aws_ecs_cluster.api-cluster.name}"
   }
 
   alarm_description  = "Cluster memory reservation below 50%"

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -91,3 +91,47 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
 
   treat_missing_data = "breaching"
 }
+
+resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-high" {
+  alarm_name          = "${var.Env-Name}-ecs-api-memory-reservation-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "MemoryReservation"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "75"
+
+  dimensions {
+    AutoScalingGroupName = "${aws_autoscaling_group.api-asg.name}"
+  }
+
+  alarm_description  = "Cluster memory reservation above 75%"
+  alarm_actions      = [
+    "${aws_autoscaling_policy.api-ec2-scale-up-policy.arn}"
+  ]
+
+  treat_missing_data = "breaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-low" {
+  alarm_name          = "${var.Env-Name}-ecs-api-memory-reservation-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "MemoryReservation"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "50"
+
+  dimensions {
+    AutoScalingGroupName = "${aws_autoscaling_group.api-asg.name}"
+  }
+
+  alarm_description  = "Cluster memory reservation below 50%"
+  alarm_actions      = [
+    "${aws_autoscaling_policy.api-ec2-scale-down-policy.arn}"
+  ]
+
+  treat_missing_data = "breaching"
+}

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -132,6 +132,4 @@ resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-low" {
   alarm_actions      = [
     "${aws_autoscaling_policy.api-ec2-scale-down-policy.arn}"
   ]
-
-  treat_missing_data = "breaching"
 }

--- a/govwifi-api/auto-scaling-group.tf
+++ b/govwifi-api/auto-scaling-group.tf
@@ -3,7 +3,6 @@ resource "aws_autoscaling_group" "api-asg" {
   name                      = "${var.Env-Name}-api-cluster"
   min_size                  = "${var.backend-min-size}"
   max_size                  = "10"
-  desired_capacity          = "${var.backend-instance-count}"
   health_check_type         = "EC2"
   launch_configuration      = "${aws_launch_configuration.ecs.name}"
   health_check_grace_period = "${var.health_check_grace_period}"


### PR DESCRIPTION
Create 2 cloudwatch alarms which trigger an EC2 autoscaling action, up
and down.
This ensures there is always at least 1 free instance to place tasks on,
and cleans up when there are too many cluster instances.