### PR TITLE
Disable the survey sending behaviour

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -102,11 +102,6 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
 # Set up cron scripts for timed jobs
 
-cat <<'EOF' > ./ping-survey
-#!/bin/bash
-wget -t 1 "http://elb.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk/timedjobs/survey?key=${var.shared-key}"
-EOF
-
 cat <<'EOF' > ./ping-performanceplatform
 #!/bin/bash
 wget -t 1 "http://elb.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk/timedjobs/performanceplatform?key=${var.shared-key}"
@@ -137,15 +132,13 @@ rm -r pp-backup-tmp
 EOF
 
 
-chmod +x ./ping-survey ./ping-performanceplatform ./ping-performanceplatform-weekly ./backup-performanceplatform
+chmod +x ./ping-performanceplatform ./ping-performanceplatform-weekly ./backup-performanceplatform
 mkdir /home/ubuntu/backup
-sudo cp ./ping-survey /home/ubuntu/backup/
 sudo cp ./ping-performanceplatform /home/ubuntu/backup/
 sudo cp ./ping-performanceplatform-weekly /home/ubuntu/backup/
 sudo cp ./backup-performanceplatform /home/ubuntu/backup/
 
 if [ 1 == ${var.bastion-set-cronjobs} ] ; then
-  sudo cp ./ping-survey /etc/cron.hourly/
   sudo cp ./ping-performanceplatform /etc/cron.daily/
   sudo cp ./ping-performanceplatform-weekly /etc/cron.weekly/
 fi


### PR DESCRIPTION
We're currently not reviewing the surveys received back, instead the focus of the team is feedback from organisations that are installing GovWifi into their buildings.

Additionally we have the goal of re-writing the application from PHP to Ruby.  The surveys code being something that is currently written in PHP which would need to be rewritten if we want to keep the
functionality.

In the interests of minimising waste, we have decided to not rewrite the survey behaviour now, and instead re-implement it when we want to iterate on the end-user experience.  At which point we'd have
capacity inside the team to review, and categorise feedback.