### PR TITLE
Add LOGGING_API_BASE_URL environment variable to the frontends

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -51,6 +51,9 @@ resource "aws_ecs_task_definition" "radius-task" {
         "name": "API_BASE_URL",
         "value": "${var.api-base-url}"
       },{
+        "name": "LOGGING_API_BASE_URL",
+        "value": "${var.api-base-url}"
+      },{
         "name": "BACKEND_BASEURL",
         "value": "${var.backend-base-url}"
       },{


### PR DESCRIPTION
There is some complexity in replicating exactly what we have on AWS
locally.  We don't have a loadbalancer locally and have to be explicit
about the api endpoints.

By introducing the LOGGING_API_BASE_URL, we are able to point the
frontends at our logging API locally.  This value will be the same as
the API_BASE_URL when deployed, so will be a noop but gives us more
flexibility.