### PR TITLE
Introduce AUTHORISATION_API_BASE_URL

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -51,6 +51,9 @@ resource "aws_ecs_task_definition" "radius-task" {
         "name": "API_BASE_URL",
         "value": "${var.api-base-url}"
       },{
+        "name": "AUTHORISATION_API_BASE_URL",
+        "value": "${var.api-base-url}"
+      },{
         "name": "LOGGING_API_BASE_URL",
         "value": "${var.api-base-url}"
       },{


### PR DESCRIPTION
We will remove the general API_BASE_URL which isn't sufficient for
localstack testing.

AUTHORISATION_API_BASE_URL points at the same location as API_BASE_URL
in production but allows us to point it at a specific service running
locally in the absence of a loadbalancer.