### PR TITLE
Add Autoscaling to Logging API

### DIFF
--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -1,0 +1,45 @@
+resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
+  alarm_name          = "${var.Env-Name}-logging-ecs-cpu-alarm-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "50"
+
+  dimensions {
+    ClusterName = "${aws_ecs_cluster.api-cluster.name}"
+    ServiceName = "${aws_ecs_service.logging-api-service.name}"
+  }
+
+  alarm_description  = "This alarm tells ECS to scale up based on high CPU - Logging"
+  alarm_actions      = [
+    "${aws_appautoscaling_policy.ecs-policy-up-logging.arn}",
+    "${var.critical-notifications-arn}"
+  ]
+
+  treat_missing_data = "breaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
+  alarm_name          = "${var.Env-Name}-logging-ecs-cpu-alarm-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "10"
+
+  dimensions {
+    ClusterName = "${aws_ecs_cluster.api-cluster.name}"
+    ServiceName = "${aws_ecs_service.logging-api-service.name}"
+  }
+
+  alarm_description  = "This alarm tells ECS to scale in based on low CPU usage - Logging"
+  alarm_actions      = [
+    "${aws_appautoscaling_policy.ecs-policy-down-logging.arn}",
+    "${var.critical-notifications-arn}"
+  ]
+}

--- a/govwifi-api/logging-scaling-policy.tf
+++ b/govwifi-api/logging-scaling-policy.tf
@@ -1,0 +1,48 @@
+resource "aws_appautoscaling_target" "logging-ecs-target" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.logging-api-service.name}"
+  max_capacity       = 20
+  min_capacity       = 2
+  role_arn           = "${var.ecs-service-role}"
+  scalable_dimension = "ecs:service:DesiredCount"
+}
+
+resource "aws_appautoscaling_policy" "ecs-policy-up-logging" {
+  name               = "ECS Scale Up Logging"
+  service_namespace  = "ecs"
+  policy_type        = "StepScaling"
+  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.logging-api-service.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment = 1
+    }
+  }
+
+  depends_on = ["aws_appautoscaling_target.logging-ecs-target"]
+}
+
+resource "aws_appautoscaling_policy" "ecs-policy-down-logging" {
+  name               = "ECS Scale Down"
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.logging-api-service.name}"
+  policy_type        = "StepScaling"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type    = "ChangeInCapacity"
+    metric_aggregation_type   = "Average"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment = -1
+    }
+  }
+
+  depends_on = ["aws_appautoscaling_target.logging-ecs-target"]
+}


### PR DESCRIPTION
This adds 2 Cloudwatch alarms, one when the CPU is above 50% for 5
minutes and another when the CPU is below 10% for 10 minutes.

These alarms will trigger an autoscaling action, adding or removing
another task.