### PR TITLE
Set environment variable for user signup API base url

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -57,6 +57,9 @@ resource "aws_ecs_task_definition" "logging-api-task" {
         },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.Env-Name}"
+        },{
+          "name": "USER_SIGNUP_API_BASE_URL",
+          "value": "${var.user-signup-api-base-url}"
         }
       ],
       "links": null,

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -112,3 +112,5 @@ variable "wordlist-file-path" {
 }
 
 variable "vpc-id" {}
+
+variable "user-signup-api-base-url" {}


### PR DESCRIPTION
The logging API will use this to call the populate-last-login
endpoint of the user signup API.

We are doing this so we don't have to share datasources between APIs,
rather make another API call to whichever API owns the datasource.