### PR TITLE
This will be used when an autoscaling action occurs.

### DIFF
--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
   alarm_description  = "This alarm tells ECS to scale up based on high CPU - Logging"
   alarm_actions      = [
     "${aws_appautoscaling_policy.ecs-policy-up-logging.arn}",
-    "${var.critical-notifications-arn}"
+    "${var.devops-notifications-arn}"
   ]
 
   treat_missing_data = "breaching"
@@ -40,6 +40,6 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
   alarm_description  = "This alarm tells ECS to scale in based on low CPU usage - Logging"
   alarm_actions      = [
     "${aws_appautoscaling_policy.ecs-policy-down-logging.arn}",
-    "${var.critical-notifications-arn}"
+    "${var.devops-notifications-arn}"
   ]
 }

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-low" {
   alarm_description  = "This alarm tells EC2 to scale in based on low CPU usage"
   alarm_actions      = [
     "${aws_autoscaling_policy.api-ec2-scale-down-policy.arn}",
-    "${var.critical-notifications-arn}"
+    "${var.devops-notifications-arn}"
   ]
 
   treat_missing_data = "breaching"
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-high" {
   alarm_description  = "This alarm tells EC2 to scale up based on high CPU usage"
   alarm_actions      = [
     "${aws_autoscaling_policy.api-ec2-scale-up-policy.arn}",
-    "${var.critical-notifications-arn}"
+    "${var.devops-notifications-arn}"
   ]
 
   treat_missing_data = "breaching"
@@ -62,7 +62,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-high" {
   alarm_description  = "This alarm tells ECS to scale up based on high CPU"
   alarm_actions      = [
     "${aws_appautoscaling_policy.ecs-policy-up.arn}",
-    "${var.critical-notifications-arn}"
+    "${var.devops-notifications-arn}"
   ]
 
   treat_missing_data = "breaching"
@@ -86,7 +86,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
   alarm_description  = "This alarm tells ECS to scale in based on low CPU usage"
   alarm_actions      = [
     "${aws_appautoscaling_policy.ecs-policy-down.arn}",
-    "${var.critical-notifications-arn}"
+    "${var.devops-notifications-arn}"
   ]
 
   treat_missing_data = "breaching"

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -66,6 +66,8 @@ variable "critical-notifications-arn" {}
 
 variable "capacity-notifications-arn" {}
 
+variable "devops-notifications-arn" {}
+
 variable "users" {
   type = "list"
 }


### PR DESCRIPTION
Previously it would send a notification to the critical SNS topic which
we don't want.