### PR TITLE
Create scheduled tasks for performance platform statistics creation

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -1,0 +1,20 @@
+resource "aws_cloudwatch_event_rule" "daily_statistics_event" {
+  name                = "${var.Env-Name}-daily-statistics-frequency"
+  description         = "Triggers daily 0600 UTC"
+  schedule_expression = "cron(25 6 * * ? *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "weekly_statistics_event" {
+  name                = "${var.Env-Name}-weekly-statistics-frequency"
+  description         = "Triggers every SUN 0630 UTC"
+  schedule_expression = "cron(47 6 * * 7 *)"
+  is_enabled          = false
+}
+
+resource "aws_cloudwatch_event_rule" "monthly_statistics_event" {
+  name                = "${var.Env-Name}-monthly-statistics-frequency"
+  description         = "Triggers every SUN 0630 UTC"
+  schedule_expression = "cron(52 6 1 * ? *)"
+  is_enabled          = false
+}

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -1,0 +1,116 @@
+resource "aws_iam_role" "logging-scheduled-task-role" {
+  name = "${var.Env-Name}-logging-scheduled-task-role"
+  assume_role_policy = <<DOC
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+DOC
+}
+
+resource "aws_iam_role_policy" "logging-scheduled-task-policy" {
+  name = "${var.Env-Name}-logging-scheduled-task-policy"
+  role = "${aws_iam_role.logging-scheduled-task-role.id}"
+  policy = <<DOC
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "ecs:RunTask",
+            "Resource": "${replace(aws_ecs_task_definition.logging-api-task.arn, "/:\\d+$/", ":*")}"
+        },
+        {
+          "Effect": "Allow",
+          "Action": "iam:PassRole",
+          "Resource": [
+            "*"
+          ],
+          "Condition": {
+            "StringLike": {
+              "iam:PassedToService": "ecs-tasks.amazonaws.com"
+            }
+          }
+        }
+    ]
+}
+DOC
+}
+
+resource "aws_cloudwatch_event_target" "logging-publish-daily-statistics" {
+  target_id = "${var.Env-Name}-logging-daily-statistics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.daily_statistics_event.name}"
+  role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count = 1
+    task_definition_arn = "${aws_ecs_task_definition.logging-api-task.arn}"
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "logging",
+      "command": ["bundle", "exec", "rake", "publish_daily_statistics"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "logging-publish-weekly-statistics" {
+  target_id = "${var.Env-Name}-logging-weekly-statistics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.weekly_statistics_event.name}"
+  role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count = 1
+    task_definition_arn = "${aws_ecs_task_definition.logging-api-task.arn}"
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "logging",
+      "command": ["bundle", "exec", "rake", "publish_weekly_statistics"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "logging-publish-monthly-statistics" {
+  target_id = "${var.Env-Name}-logging-monthly-statistics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.monthly_statistics_event.name}"
+  role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count = 1
+    task_definition_arn = "${aws_ecs_task_definition.logging-api-task.arn}"
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "logging",
+      "command": ["bundle", "exec", "rake", "publish_monthly_statistics"]
+    }
+  ]
+}
+EOF
+}

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -1,0 +1,94 @@
+
+resource "aws_iam_role" "user-signup-scheduled-task-role" {
+  name = "${var.Env-Name}-user-signup-scheduled-task-role"
+  assume_role_policy = <<DOC
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+DOC
+}
+
+resource "aws_iam_role_policy" "user-signup-scheduled-task-policy" {
+  name = "${var.Env-Name}-user-signup-scheduled-task-policy"
+  role = "${aws_iam_role.user-signup-scheduled-task-role.id}"
+  policy = <<DOC
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "ecs:RunTask",
+            "Resource": "${replace(aws_ecs_task_definition.user-signup-api-task.arn, "/:\\d+$/", ":*")}"
+        },
+        {
+          "Effect": "Allow",
+          "Action": "iam:PassRole",
+          "Resource": [
+            "*"
+          ],
+          "Condition": {
+            "StringLike": {
+              "iam:PassedToService": "ecs-tasks.amazonaws.com"
+            }
+          }
+        }
+    ]
+}
+DOC
+}
+
+resource "aws_cloudwatch_event_target" "user-signup-publish-daily-statistics" {
+  target_id = "${var.Env-Name}-user-signup-daily-statistics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.daily_statistics_event.name}"
+  role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count = 1
+    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-task.arn}"
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "user-signup",
+      "command": ["bundle", "exec", "rake", "publish_daily_statistics"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "user-signup-publish-weekly-statistics" {
+  target_id = "${var.Env-Name}-user-signup-weekly-statistics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.weekly_statistics_event.name}"
+  role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count = 1
+    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-task.arn}"
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "user-signup",
+      "command": ["bundle", "exec", "rake", "publish_weekly_statistics"]
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
We're using the built in ECS scheduled tasks functionality to scheduled statistics pushing from the microservices to the performance platform.