### PR TITLE
Reduce memory for containers in our API cluster

### DIFF
--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -11,7 +11,7 @@ resource "aws_ecs_task_definition" "authorisation-api-task" {
 [
     {
       "volumesFrom": [],
-      "memory": 1900,
+      "memory": 950,
       "extraHosts": null,
       "dnsServers": null,
       "disableNetworking": null,

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -16,7 +16,7 @@ resource "aws_ecs_task_definition" "logging-api-task" {
 [
     {
       "volumesFrom": [],
-      "memory": 1900,
+      "memory": 950,
       "extraHosts": null,
       "dnsServers": null,
       "disableNetworking": null,

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
 [
     {
       "volumesFrom": [],
-      "memory": 1900,
+      "memory": 950,
       "extraHosts": null,
       "dnsServers": null,
       "disableNetworking": null,


### PR DESCRIPTION
Currently we have just under 2Gb (1900MB) memory reserved for each container.
The memory utilisation never goes above 5%.
Reduce this memory reservation by half to 950MB per container.

This will save on AWS costs as we need less EC2 instances.
We could reduce this further but would do that
as a separate task after having seen this work in production for a
while.