### PR TITLE
Set the performance platform environment variables

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -60,6 +60,18 @@ resource "aws_ecs_task_definition" "logging-api-task" {
         },{
           "name": "USER_SIGNUP_API_BASE_URL",
           "value": "${var.user-signup-api-base-url}"
+        },{
+          "name": "PERFORMANCE_URL",
+          "value": "${var.performance-url}"
+        },{
+          "name": "PERFORMANCE_DATASET",
+          "value": "${var.performance-dataset}"
+        },{
+          "name": "PERFORMANCE_BEARER_ACCOUNT_USAGE",
+          "value": "${var.performance-bearer-account-usage}"
+        },{
+          "name": "PERFORMANCE_BEARER_UNIQUE_USERS",
+          "value": "${var.performance-bearer-unique-users}"
         }
       ],
       "links": null,

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -44,6 +44,10 @@ variable "performance-bearer-volumetrics" {}
 
 variable "performance-bearer-completion-rate" {}
 
+variable "performance-bearer-account-usage" {}
+
+variable "performance-bearer-unique-users" {}
+
 variable "radius-server-ips" {}
 
 variable "authentication-sentry-dsn" {}


### PR DESCRIPTION
The logging API will send over statistics and it needs to know the bearer
tokens to do so.
Set them as environment variables that the service can get access to them.