### PR TITLE
Add infrastructure for hosting the admin platform

### DIFF
--- a/govwifi-admin/acm.tf
+++ b/govwifi-admin/acm.tf
@@ -1,0 +1,17 @@
+resource "aws_acm_certificate" "admin_platform_cert" {
+  domain_name = "${aws_route53_record.admin_platform.name}"
+  validation_method = "DNS"
+}
+
+resource "aws_route53_record" "admin_platform_cert_validation" {
+  name = "${aws_acm_certificate.admin_platform_cert.domain_validation_options.0.resource_record_name}"
+  type = "${aws_acm_certificate.admin_platform_cert.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.admin_platform_cert.domain_validation_options.0.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.admin_platform_cert.arn}"
+  validation_record_fqdns = ["${aws_route53_record.admin_platform_cert_validation.fqdn}"]
+}

--- a/govwifi-admin/auto-scaling-group.tf
+++ b/govwifi-admin/auto-scaling-group.tf
@@ -1,0 +1,36 @@
+resource "aws_autoscaling_group" "ecs-admin-cluster" {
+  vpc_zone_identifier       = ["${var.subnet-ids}"]
+  name                      = "${var.Env-Name}-admin-cluster"
+  min_size                  = "${var.min-size}"
+  max_size                  = "10"
+  desired_capacity          = "${var.instance-count}"
+  health_check_type         = "EC2"
+  launch_configuration      = "${aws_launch_configuration.ecs.name}"
+  health_check_grace_period = "${var.health_check_grace_period}"
+  enabled_metrics           = [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tag {
+    key                 = "Env"
+    value               = "${var.Env-Name}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${title(var.Env-Name)} Admin"
+    propagate_at_launch = true
+  }
+}

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -1,0 +1,109 @@
+resource "aws_ecs_cluster" "admin-cluster" {
+  name = "${var.Env-Name}-admin-cluster"
+}
+
+resource "aws_cloudwatch_log_group" "admin-log-group" {
+  name = "${var.Env-Name}-admin-log-group"
+
+  retention_in_days = 90
+}
+
+resource "aws_ecr_repository" "govwifi-admin-ecr" {
+  count = "${var.ecr-repository-count}"
+  name  = "govwifi/admin"
+}
+
+resource "aws_ecs_task_definition" "admin-task" {
+  family = "allowed-sites-api-task-${var.Env-Name}"
+
+  container_definitions = <<EOF
+[
+    {
+      "volumesFrom": [],
+      "memory": 950,
+      "extraHosts": null,
+      "dnsServers": null,
+      "disableNetworking": null,
+      "dnsSearchDomains": null,
+      "portMappings": [
+        {
+          "hostPort": 0,
+          "containerPort": 3000,
+          "protocol": "tcp"
+        }
+      ],
+      "hostname": null,
+      "essential": true,
+      "entryPoint": null,
+      "mountPoints": [],
+      "name": "admin",
+      "ulimits": null,
+      "dockerSecurityOptions": null,
+      "environment": [
+        {
+          "name": "RACK_ENV",
+          "value": "${var.rack-env}"
+        },{
+          "name": "SECRET_KEY_BASE",
+          "value": "${var.secret-key-base}"
+        }
+      ],
+      "links": null,
+      "workingDirectory": null,
+      "readonlyRootFilesystem": null,
+      "image": "${var.admin-docker-image}",
+      "command": null,
+      "user": null,
+      "dockerLabels": null,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "${aws_cloudwatch_log_group.admin-log-group.name}",
+          "awslogs-region": "${var.aws-region}",
+          "awslogs-stream-prefix": "${var.Env-Name}-admin-docker-logs"
+        }
+      },
+      "cpu": 0,
+      "privileged": null,
+      "expanded": true
+    }
+]
+EOF
+}
+
+resource "aws_ecs_service" "admin-service" {
+  depends_on      = ["aws_alb_listener.alb_listener"]
+  name            = "admin-${var.Env-Name}"
+  cluster         = "${aws_ecs_cluster.admin-cluster.id}"
+  task_definition = "${aws_ecs_task_definition.admin-task.arn}"
+  desired_count   = "${var.instance-count}"
+  iam_role        = "${var.ecs-service-role}"
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.admin-tg.arn}"
+    container_name = "admin"
+    container_port = "3000"
+  }
+}
+
+
+resource "aws_alb_target_group" "admin-tg" {
+  depends_on   = ["aws_lb.admin-alb"]
+  name     = "admin-${var.Env-Name}"
+  port     = "3000"
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc-id}"
+
+  health_check {
+    healthy_threshold   = 3
+    unhealthy_threshold = 10
+    timeout             = 5
+    interval            = 10
+    path                = "/healthcheck"
+  }
+}

--- a/govwifi-admin/launch-configuration.tf
+++ b/govwifi-admin/launch-configuration.tf
@@ -1,0 +1,233 @@
+resource "aws_launch_configuration" "ecs" {
+  name_prefix          = "${var.Env-Name}-admin-lc-"
+  image_id             = "${var.ami}"
+  instance_type        = "t2.small"
+  iam_instance_profile = "${var.ecs-instance-profile-id}"
+  key_name             = "${var.ssh-key-name}"
+  security_groups      = ["${var.ec2-sg-list}"]
+
+  user_data = <<DATA
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/cloud-config; charset="us-ascii"
+#cloud-config
+repo_update: true
+repo_upgrade: all
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+sudo yum install perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https -y
+sudo yum -y install perl-Digest-SHA perl-URI perl-libwww-perl perl-MIME-tools perl-Crypt-SSLeay perl-XML-LibXML unzip curl
+mkdir -p /home/ec2-user/scripts
+cd /home/ec2-user/scripts
+curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O
+unzip CloudWatchMonitoringScripts-1.2.2.zip
+rm CloudWatchMonitoringScripts-1.2.2.zip
+mv aws-scripts-mon /home/ec2-user/scripts/mon
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+sudo yum install perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https -y
+sudo yum -y install perl-Digest-SHA perl-URI perl-libwww-perl perl-MIME-tools perl-Crypt-SSLeay perl-XML-LibXML unzip
+mkdir -p /home/ec2-user/scripts
+cd /home/ec2-user/scripts
+curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O
+unzip CloudWatchMonitoringScripts-1.2.2.zip
+rm CloudWatchMonitoringScripts-1.2.2.zip
+mv aws-scripts-mon /home/ec2-user/scripts/mon
+cd /home/ec2-user/scripts/mon
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+# Set up daily security updates
+# Stagger restart time based on local IP (assigned randomly)
+# Restarting all backends before the frontends start their staggered nighly restarts
+
+IP=`hostname | sed -r 's/.*-([0-9]+)$/\1/'`
+MINS=$(( $IP % 59 ))
+
+cat <<EOF > ./crontab
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+HOME=/
+
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+
+* * * * * root /home/ec2-user/scripts/mon/mon-put-instance-data.pl --mem-used --from-cron --mem-avail --swap-used --mem-used-incl-cache-buff
+42 * * * * root   run-parts /etc/cron.hourly
+$MINS 0 * * * root   run-parts /etc/cron.daily
+
+EOF
+
+sudo cp ./crontab /etc/crontab
+
+cat <<'EOF' > ./security-updates
+#!/bin/bash
+sudo yum update -y --security
+sudo yum update -y ecs-init
+sudo service docker restart
+sleep 5
+sudo start ecs
+# Forcefully restart the instance if the docker daemon has failed to restart
+# see https://github.com/docker/docker/issues/25382
+docker ps || sudo reboot
+
+EOF
+
+chmod +x ./security-updates
+sudo cp ./security-updates /etc/cron.daily
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+# Add extra users
+
+oldIFS=$IFS
+IFS='|' read -r -a userlist <<< "${join("|", var.users)}"
+
+for credentials in "$${userlist[@]}"; do
+  IFS=';' read -r -a credsarray <<< $credentials
+  username="$${credsarray[0]}"
+  sshkey="$${credsarray[1]}"
+
+  sudo adduser "$username"
+  sudo mkdir "/home/$username/.ssh"
+  sudo chown "$username:$username" "/home/$username/.ssh"
+  echo "$sshkey" > ./tempkey
+  sudo mv ./tempkey "/home/$username/.ssh/authorized_keys"
+  sudo chown "$username:$username" "/home/$username/.ssh/authorized_keys"
+  sudo chmod 600 "/home/$username/.ssh/authorized_keys"
+
+done
+
+IFS=$oldIFS
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+# Set cluster name
+echo ECS_CLUSTER=${var.Env-Name}-admin-cluster >> /etc/ecs/ecs.config
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+# Install awslogs and the jq JSON parser
+yum install -y awslogs jq
+
+# Inject the CloudWatch Logs configuration file contents
+cat > /etc/awslogs/awslogs.conf <<- EOF
+[general]
+state_file = /var/lib/awslogs/agent-state
+
+[/var/log/dmesg]
+file = /var/log/dmesg
+log_group_name = ${var.Env-Name}/var/log/dmesg
+log_stream_name = {cluster}/{container_instance_id}
+
+[/var/log/messages]
+file = /var/log/messages
+log_group_name = ${var.Env-Name}/var/log/messages
+log_stream_name = {cluster}/{container_instance_id}
+datetime_format = %b %d %H:%M:%S
+
+[/var/log/docker]
+file = /var/log/docker
+log_group_name = ${var.Env-Name}/var/log/docker
+log_stream_name = {cluster}/{container_instance_id}
+datetime_format = %Y-%m-%dT%H:%M:%S.%f
+
+[/var/log/ecs/ecs-init.log]
+file = /var/log/ecs/ecs-init.log.*
+log_group_name = ${var.Env-Name}/var/log/ecs/ecs-init.log
+log_stream_name = {cluster}/{container_instance_id}
+datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+[/var/log/ecs/ecs-agent.log]
+file = /var/log/ecs/ecs-agent.log.*
+log_group_name = ${var.Env-Name}/var/log/ecs/ecs-agent.log
+log_stream_name = {cluster}/{container_instance_id}
+datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+[/var/log/ecs/audit.log]
+file = /var/log/ecs/audit.log.*
+log_group_name = ${var.Env-Name}/var/log/ecs/audit.log
+log_stream_name = {cluster}/{container_instance_id}
+datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+EOF
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+# Set the region to send CloudWatch Logs data to (the region where the container instance is located)
+# region=$(curl 169.254.169.254/latest/meta-data/placement/availability-zone | sed s'/.$//')
+region=${var.aws-region}
+sed -i -e "s/region = us-east-1/region = $region/g" /etc/awslogs/awscli.conf
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/upstart-job; charset="us-ascii"
+
+#upstart-job
+description "Configure and start CloudWatch Logs agent on Amazon ECS container instance"
+author "Amazon Web Services"
+start on started ecs
+
+script
+	exec 2>>/var/log/ecs/cloudwatch-logs-start.log
+	set -x
+
+	until curl -s http://localhost:51678/v1/metadata
+	do
+		sleep 1
+	done
+
+	# Grab the cluster and container instance ARN from instance metadata
+	cluster=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .Cluster')
+	container_instance_id=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .ContainerInstanceArn' | awk -F/ '{print $2}' )
+
+	# Replace the cluster name and container instance ID placeholders with the actual values
+	sed -i -e "s/{cluster}/$cluster/g" /etc/awslogs/awslogs.conf
+	sed -i -e "s/{container_instance_id}/$container_instance_id/g" /etc/awslogs/awslogs.conf
+
+	service awslogs start
+	chkconfig awslogs on
+end script
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+# Disable anacron which runs at 3am by default each morning
+sudo chmod a-x /usr/sbin/anacron
+
+--==BOUNDARY==--
+DATA
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/govwifi-admin/loadbalancer.tf
+++ b/govwifi-admin/loadbalancer.tf
@@ -1,0 +1,25 @@
+resource "aws_lb" "admin-alb" {
+  name               = "admin-alb-${var.Env-Name}"
+  internal           = false
+  subnets            = ["${var.subnet-ids}"]
+  security_groups    = ["${var.elb-sg-list}"]
+  load_balancer_type = "application"
+
+  tags {
+    Name = "admin-alb-${var.Env-Name}"
+  }
+}
+
+resource "aws_alb_listener" "alb_listener" {
+  load_balancer_arn = "${aws_lb.admin-alb.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+
+  default_action {
+    target_group_arn = "${aws_alb_target_group.admin-tg.arn}"
+    type             = "forward"
+  }
+}
+

--- a/govwifi-admin/route53.tf
+++ b/govwifi-admin/route53.tf
@@ -1,0 +1,15 @@
+resource "aws_route53_record" "admin_platform" {
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  name    = "admin-platform.${var.Env-Subdomain}.service.gov.uk"
+  type    = "A"
+  alias {
+    name                   = "${aws_lb.admin-alb.dns_name}"
+    zone_id                = "${aws_lb.admin-alb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+data "aws_route53_zone" "zone" {
+  name = "wifi.service.gov.uk."
+  private_zone = false
+}

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -1,0 +1,81 @@
+variable "Env-Name" {
+  description = "E.g. staging"
+}
+
+variable "Env-Subdomain" {
+  description = "E.g. staging.wifi"
+}
+
+variable "aws-region" {
+  description = "E.g. eu-west-2"
+}
+
+variable "aws-region-name" {
+  description = "E.g. London"
+}
+
+variable "ec2-sg-list" {
+  description = "Security groups to apply to the EC2 instances used by ECS"
+  type = "list"
+}
+
+variable "elb-sg-list" {
+  description = "Security groups to apply to the ELB in front of the admin"
+  type = "list"
+}
+
+variable "subnet-ids" {
+  description = "List of AWS subnet IDs to place the EC2 instances and ELB into"
+  type = "list"
+}
+
+variable "users" {
+  description = "List of users to be added to the EC2 instance"
+  type = "list"
+}
+
+variable "ami" {
+  description = "AMI id to launch, must be in the region specified by the region variable"
+}
+
+variable "ecr-repository-count" {
+  description = "Whether or not to create ECR repository"
+  default     = 0
+}
+
+variable "ecs-service-role" {}
+
+variable "ecs-instance-profile-id" {}
+
+variable "rack-env" {
+  description = "E.g. staging"
+}
+
+variable "secret-key-base" {
+  description = "Rails secret key base variable used for the admin platform"
+}
+
+variable "ssh-key-name" {
+  description = "SSH key applied to the EC2 instance"
+}
+
+variable "vpc-id" {
+  description = "VPC ID used for placing the ALB into"
+}
+
+variable "min-size" {
+  description = "Minimum number of EC2 hosts"
+}
+
+variable "instance-count" {
+  description = "Number of EC2 hosts and ECS containers to be running"
+}
+
+variable "admin-docker-image" {
+  description = "Docker image URL pointing to the admin platform application"
+}
+
+variable "health_check_grace_period" {
+  default     = "300"
+  description = "Time after instance comes into service before checking health"
+}


### PR DESCRIPTION
We're placing this into a new EC2 container cluster as it will be a public application vs the API cluster which is private.

Any DOS attacks to the public admin platform shouldn't affect the rest of the service.