### PR TITLE
Create SES receipt rule for log requests

### DIFF
--- a/govwifi-emails/emails.tf
+++ b/govwifi-emails/emails.tf
@@ -42,7 +42,6 @@ resource "aws_ses_receipt_rule" "all-mail-rule" {
   ]
 
   recipients = [
-    "logrequest@${var.Env-Subdomain}.service.gov.uk",
     "newsite@${var.Env-Subdomain}.service.gov.uk",
     "verify@${var.Env-Subdomain}.service.gov.uk",
   ]
@@ -72,6 +71,23 @@ resource "aws_ses_receipt_rule" "admin-email-rule" {
 
   s3_action {
     bucket_name = "${var.Env-Name}-admin-emailbucket"
+    position    = 1
+  }
+}
+
+resource "aws_ses_receipt_rule" "log-request-rule" {
+  name          = "${var.Env-Name}-log-request-rule"
+  rule_set_name = "GovWifiRuleSet"
+  enabled       = true
+  scan_enabled  = true
+  after         = "${var.Env-Name}-admin-email-rule"
+
+  recipients = [
+    "logrequest@${var.Env-Subdomain}.service.gov.uk"
+  ]
+
+  sns_action {
+    topic_arn   = "${var.devops-notifications-arn}"
     position    = 1
   }
 }

--- a/govwifi-emails/variables.tf
+++ b/govwifi-emails/variables.tf
@@ -19,3 +19,5 @@ variable "sns-endpoint" {}
 variable "user-signup-notifications-endpoint" {
   description = "HTTP endpoint used by SNS to send user signup email notifications"
 }
+
+variable "devops-notifications-arn" {}


### PR DESCRIPTION
We are switching off logrequests because it is very rarely used.
Instead we will redirect the request to our support inbox where it can
be picked up manually for now.