### PR TITLE
Add devise secret key environment variable

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -46,6 +46,9 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "SECRET_KEY_BASE",
           "value": "${var.secret-key-base}"
+        },{
+          "name": "DEVISE_SECRET_KEY",
+          "value": "${var.secret-key-base}"
         }
       ],
       "links": null,

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -14,7 +14,7 @@ resource "aws_ecr_repository" "govwifi-admin-ecr" {
 }
 
 resource "aws_ecs_task_definition" "admin-task" {
-  family = "allowed-sites-api-task-${var.Env-Name}"
+  family = "admin-task-${var.Env-Name}"
 
   container_definitions = <<EOF
 [


### PR DESCRIPTION
Fix a typo in the task definition while I'm here

The admin application uses Devise, which requires a secret key for
generating hashed tokens for confirmation, password reset and unlock
tokens.  Rotating this key will invalidate all of the above.

We'll reuse the rails secret_key_base which is being used for
encrypting and signing session cookies.

For more information on the DEVISE_SECRET_KEY see:
https://github.com/plataformatec/devise/blob/f220b992c338122226f6fd396056d5a1adf28df8/lib/generators/templates/devise.rb#L11
449c409