### PR TITLE
Enable logging and asset serving on the admin application

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -49,6 +49,9 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "DEVISE_SECRET_KEY",
           "value": "${var.secret-key-base}"
+        },{
+          "name": "RAILS_LOG_TO_STDOUT",
+          "value": "1"
         }
       ],
       "links": null,

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -52,6 +52,9 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "RAILS_LOG_TO_STDOUT",
           "value": "1"
+        },{
+          "name": "RAILS_SERVE_STATIC_FILES",
+          "value": "1"
         }
       ],
       "links": null,


### PR DESCRIPTION
We have configured ECS to push STDOUT logs to cloudwatch.  Rails
needs to be configured with this flag to send its logs to STDOUT
which will allow us to pull logs out from cloudwatch.

This environment variable configures Rails to serve the precompiled
assets via itself.  Given our setup of using and AWS ALB in front
of our ECS containers which is running Puma it makes sense to have
Rails serve the assets.