### PR TITLE
Populate env variable with authorised email domains

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -47,6 +47,9 @@ resource "aws_ecs_task_definition" "admin-task" {
           "name": "DB_PASS",
           "value": "${var.admin-db-password}"
         },{
+          "name": "AUTHORISED_EMAIL_DOMAINS_REGEX",
+          "value": ${jsonencode(var.authorised-email-domains-regex)}
+        },{
           "name": "DB_NAME",
           "value": "govwifi_admin_${var.rack-env}"
         },{

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -109,3 +109,7 @@ variable "db-sg-list" {
 }
 
 variable "rds-monitoring-role" {}
+
+variable "authorised-email-domains-regex" {
+  description = "Regex used as matcher for whether an incoming email is from a government address."
+}


### PR DESCRIPTION
This will make it a bit easier for people to sign up from government
organisations.  Currently we only allow gov.uk to sign up on the admin
platform.  This passes the known authorised domain regex, so we can use
that instead.