### PR TITLE
Rename production database

### DIFF
--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -58,7 +58,7 @@ resource "aws_db_instance" "admin_db" {
   apply_immediately           = true
   instance_class              = "${var.db-instance-type}"
   identifier                  = "wifi-admin-${var.Env-Name}-db"
-  name                        = "govwifi_admin_${var.Env-Name}"
+  name                        = "govwifi_admin_${var.rack-env}"
   username                    = "${var.admin-db-user}"
   password                    = "${var.admin-db-password}"
   backup_retention_period     = "${var.db-backup-retention-days}"


### PR DESCRIPTION
We want our production database to be called govwifi_admin_production,
not govwifi_admin_wifi as per the old convention.