### PR TITLE
Populate Allowed Sites API environment variables

### DIFF
--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -1,5 +1,4 @@
 resource "aws_db_parameter_group" "db-parameters" {
-  count       = "${var.db-instance-count}"
   name        = "${var.Env-Name}-admin-db-parameter-group"
   family      = "mysql5.7"
   description = "DB parameter configuration for govwifi-admin"
@@ -30,8 +29,6 @@ resource "aws_db_parameter_group" "db-parameters" {
 }
 
 resource "aws_db_option_group" "mariadb-audit" {
-  # No harm in keeping the parameter group even if there is DB instance currently
-  #count                    = "${var.db-instance-count}"
   name = "${var.Env-Name}-admin-db-audit"
 
   option_group_description = "Mariadb audit configuration for govwifi-admin"
@@ -48,7 +45,6 @@ resource "aws_db_option_group" "mariadb-audit" {
 }
 
 resource "aws_db_instance" "admin_db" {
-  count                       = "${var.db-instance-count}"
   allocated_storage           = "${var.db-storage-gb}"
   storage_type                = "gp2"
   engine                      = "mysql"
@@ -82,7 +78,6 @@ resource "aws_db_instance" "admin_db" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "db_cpualarm" {
-  count               = "${var.db-instance-count}"
   alarm_name          = "${var.Env-Name}-admin-db-cpu-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -103,7 +98,6 @@ resource "aws_cloudwatch_metric_alarm" "db_cpualarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "db_memoryalarm" {
-  count               = "${var.db-instance-count}"
   alarm_name          = "${var.Env-Name}-admin-db-memory-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -124,7 +118,6 @@ resource "aws_cloudwatch_metric_alarm" "db_memoryalarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "db_storagealarm" {
-  count               = "${var.db-instance-count}"
   alarm_name          = "${var.Env-Name}-admin-db-storage-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -145,7 +138,6 @@ resource "aws_cloudwatch_metric_alarm" "db_storagealarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "db_burstbalancealarm" {
-  count               = "${var.db-instance-count}"
   alarm_name          = "${var.Env-Name}-admin-db-burstbalanace-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"

--- a/govwifi-admin/outputs.tf
+++ b/govwifi-admin/outputs.tf
@@ -1,0 +1,3 @@
+output "db-hostname" {
+  value = "${aws_db_instance.admin_db.address}"
+}

--- a/govwifi-allowed-sites-api/cluster.tf
+++ b/govwifi-allowed-sites-api/cluster.tf
@@ -58,6 +58,18 @@ resource "aws_ecs_task_definition" "allowed-sites-api-task" {
           "name": "DB_HOSTNAME",
           "value": "${var.db-hostname}"
         },{
+          "name": "ADMIN_DB_NAME",
+          "value": "govwifi_admin_${var.rack-env}"
+        },{
+          "name": "ADMIN_DB_PASS",
+          "value": "${var.admin-db-password}"
+        },{
+          "name": "ADMIN_DB_USER",
+          "value": "${var.admin-db-user}"
+        },{
+          "name": "ADMIN_DB_HOSTNAME",
+          "value": "${var.admin-db-hostname}"
+        },{
           "name": "RACK_ENV",
           "value": "${var.rack-env}"
         },{

--- a/govwifi-allowed-sites-api/variables.tf
+++ b/govwifi-allowed-sites-api/variables.tf
@@ -32,6 +32,14 @@ variable "db-password" {}
 
 variable "db-hostname" {}
 
+variable "admin-db-name" {}
+
+variable "admin-db-user" {}
+
+variable "admin-db-password" {}
+
+variable "admin-db-hostname" {}
+
 variable "docker-image" {}
 
 variable "rack-env" {}


### PR DESCRIPTION
We need access to the admin database in the allowed sites API.
This is so we can populate the radius configuration from 2 datasources
as we are in the process of going live with the admin.

Also delete the db-instance-count variable which was unused and defaults
to 1.  This was raising a warning.