### PR TITLE
Set RACK_ENV

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -79,6 +79,9 @@ resource "aws_ecs_task_definition" "radius-task" {
       },{
         "name": "RADIUSD_PARAMS",
         "value": "${var.radiusd-params}"
+      },{
+        "name": "RACK_ENV",
+        "value": "${var.rack-env}"
       }
     ],
     "links": null,

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -78,3 +78,7 @@ variable "radiusd-params" {
 variable "users" {
   type   = "list"
 }
+
+variable "rack-env" {
+  default   = ""
+}


### PR DESCRIPTION
We are about to replace the PHP Route53 healthchecks with Ruby and
Sinatra has to know which ENV to boot up in