### PR TITLE
Populate Radius IP environment variables

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -73,6 +73,12 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "RAILS_SERVE_STATIC_FILES",
           "value": "1"
+        },{
+          "name": "LONDON_RADIUS_IPS",
+          "value": "${join(",", var.london-radius-ip-addresses)}"
+        },{
+          "name": "DUBLIN_RADIUS_IPS",
+          "value": "${join(",", var.dublin-radius-ip-addresses)}"
         }
       ],
       "links": null,

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -115,3 +115,11 @@ variable "authorised-email-domains-regex" {
 }
 
 variable "notify-api-key" {}
+
+variable "london-radius-ip-addresses" {
+  type = "list"
+}
+
+variable "dublin-radius-ip-addresses" {
+  type = "list"
+}


### PR DESCRIPTION
This will be used to display them in the admin platform so network
administrators can configure their infrastructure.