### PR TITLE
Populate environment variables for old db in Admin

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -41,6 +41,18 @@ resource "aws_ecs_task_definition" "admin-task" {
       "dockerSecurityOptions": null,
       "environment": [
         {
+          "name": "RR_DB_NAME",
+          "value": "govwifi_${var.Env-Name}"
+        },{
+          "name": "RR_DB_PASS",
+          "value": "${var.db-password}"
+        },{
+          "name": "RR_DB_USER",
+          "value": "${var.db-user}"
+        },{
+          "name": "RR_DB_HOSTNAME",
+          "value": "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
+        },{
           "name": "DB_USER",
           "value": "${var.admin-db-user}"
         },{

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -90,6 +90,10 @@ variable "admin-db-user" {}
 
 variable "admin-db-password" {}
 
+variable "db-user" {}
+
+variable "db-password" {}
+
 variable "db-backup-retention-days" {}
 
 variable "db-encrypt-at-rest" {}


### PR DESCRIPTION
We need to access the old db to ensure IP addresses are unique
Populate ENV variables that Rails can use