### PR TITLE
Create a new IAM policy and Role for Admin

### DIFF
--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -1,0 +1,84 @@
+resource "aws_iam_role_policy" "ecs-admin-instance-policy" {
+  name = "${var.aws-region-name}-ecs-admin-instance-policy-${var.Env-Name}"
+  role = "${aws_iam_role.ecs-admin-instance-role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:CreateCluster",
+        "ecs:DeregisterContainerInstance",
+        "ecs:DiscoverPollEndpoint",
+        "ecs:Poll",
+        "ecs:RegisterContainerInstance",
+        "ecs:StartTelemetrySession",
+        "ecs:Submit*",
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+      ],
+      "Resource": [ "*" ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:PutMetricData",
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics",
+        "ec2:DescribeTags"
+      ],
+      "Resource": "*"
+    },{
+      "Effect": "Allow",
+      "Action": [
+        "route53:ListHealthChecks",
+        "route53:GetHealthCheckStatus"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "ecs-admin-instance-role" {
+  name = "${var.aws-region-name}-ecs-admin-instance-role-${var.Env-Name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "ecs-admin-instance-profile" {
+  name  = "${var.aws-region-name}-ecs-admin-instance-profile-${var.Env-Name}"
+  role  = "${aws_iam_role.ecs-admin-instance-role.name}"
+}
+

--- a/govwifi-admin/launch-configuration.tf
+++ b/govwifi-admin/launch-configuration.tf
@@ -2,7 +2,7 @@ resource "aws_launch_configuration" "ecs" {
   name_prefix          = "${var.Env-Name}-admin-lc-"
   image_id             = "${var.ami}"
   instance_type        = "t2.small"
-  iam_instance_profile = "${var.ecs-instance-profile-id}"
+  iam_instance_profile = "${aws_iam_instance_profile.ecs-admin-instance-profile.id}"
   key_name             = "${var.ssh-key-name}"
   security_groups      = ["${var.ec2-sg-list}"]
 


### PR DESCRIPTION
We will be displaying GovWifi healthchecks to organisations.
This will use the Route53 healtcheck API.

In order to use this API, we need to allow the admin instances to make
these API calls.