### PR TITLE
Set Sentry environment variables

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -79,6 +79,9 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "DUBLIN_RADIUS_IPS",
           "value": "${join(",", var.dublin-radius-ip-addresses)}"
+        },{
+          "name": "SENTRY_DSN",
+          "value": "${var.sentry-dsn}"
         }
       ],
       "links": null,

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -123,3 +123,5 @@ variable "london-radius-ip-addresses" {
 variable "dublin-radius-ip-addresses" {
   type = "list"
 }
+
+variable "sentry-dsn" {}


### PR DESCRIPTION
The task definition will contain the Sentry DSN to use in the admin