### PR TITLE
Create s3 bucket and allow admin to publish to it

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -82,6 +82,12 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "SENTRY_DSN",
           "value": "${var.sentry-dsn}"
+        },{
+          "name": "S3_PUBLISHED_LOCATIONS_IPS_BUCKET",
+          "value": "govwifi-${var.rack-env}-admin"
+        },{
+          "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
+          "value": "ips-and-locations.json"
         }
       ],
       "links": null,

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_role_policy" "ecs-admin-instance-policy" {
   name = "${var.aws-region-name}-ecs-admin-instance-policy-${var.Env-Name}"
   role = "${aws_iam_role.ecs-admin-instance-role.id}"
+  depends_on = ["aws_s3_bucket.admin-bucket"]
 
   policy = <<EOF
 {
@@ -51,6 +52,12 @@ resource "aws_iam_role_policy" "ecs-admin-instance-policy" {
         "route53:GetHealthCheckStatus"
       ],
       "Resource": "*"
+    },{
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": ["${aws_s3_bucket.admin-bucket.arn}/*"]
     }
   ]
 }

--- a/govwifi-admin/s3.tf
+++ b/govwifi-admin/s3.tf
@@ -1,0 +1,16 @@
+resource "aws_s3_bucket" "admin-bucket" {
+  count         = 1
+  bucket        = "govwifi-${var.rack-env}-admin"
+  force_destroy = true
+  acl           = "private"
+
+  tags {
+    Name        = "${title(var.Env-Name)} Admin data"
+    Region      = "${title(var.aws-region-name)}"
+    Environment = "${title(var.rack-env)}"
+  }
+
+  versioning {
+    enabled = true
+  }
+}


### PR DESCRIPTION
In order to preserve the performance platform stats, we need to
replicate ips and locations into the logging api.

This allows the admin to publish them to the bucket