### PR TITLE
Populate environment variables and use Rack env

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -73,6 +73,12 @@ resource "aws_ecs_task_definition" "logging-api-task" {
         },{
           "name": "PERFORMANCE_BEARER_UNIQUE_USERS",
           "value": "${var.performance-bearer-unique-users}"
+        },{
+          "name": "S3_PUBLISHED_LOCATIONS_IPS_BUCKET",
+          "value": "govwifi-${var.rack-env}-admin"
+        },{
+          "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
+          "value": "ips-and-locations.json"
         }
       ],
       "links": null,
@@ -191,7 +197,7 @@ resource "aws_iam_role_policy" "logging-api-task-policy" {
       "Action": [
         "s3:GetObject"
       ],
-      "Resource": "arn:aws:s3:::govwifi-${var.Env-Name}-admin/*"
+      "Resource": "arn:aws:s3:::govwifi-${var.rack-env}-admin/*"
     }
   ]
 }


### PR DESCRIPTION
The logging API needs to know which bucket and object to read from to
get locations and IPs data.  Populate this as an environment variable in
the ECS service.

Also correct Rack env "production" instead of Env name "wifi" for allowing
access to the bucket IAM policy.