### PR TITLE
Clean up old database connection details

### DIFF
--- a/govwifi-allowed-sites-api/cluster.tf
+++ b/govwifi-allowed-sites-api/cluster.tf
@@ -46,18 +46,6 @@ resource "aws_ecs_task_definition" "allowed-sites-api-task" {
       "dockerSecurityOptions": null,
       "environment": [
         {
-          "name": "DB_NAME",
-          "value": "govwifi_${var.Env-Name}"
-        },{
-          "name": "DB_PASS",
-          "value": "${var.db-password}"
-        },{
-          "name": "DB_USER",
-          "value": "${var.db-user}"
-        },{
-          "name": "DB_HOSTNAME",
-          "value": "${var.db-hostname}"
-        },{
           "name": "ADMIN_DB_NAME",
           "value": "govwifi_admin_${var.rack-env}"
         },{

--- a/govwifi-allowed-sites-api/variables.tf
+++ b/govwifi-allowed-sites-api/variables.tf
@@ -26,12 +26,6 @@ variable "aws-account-id" {}
 
 variable "elb-ssl-cert-arn" {}
 
-variable "db-user" {}
-
-variable "db-password" {}
-
-variable "db-hostname" {}
-
 variable "admin-db-name" {}
 
 variable "admin-db-user" {}


### PR DESCRIPTION
We no longer connect to the old database to create the whitelist for
allowed sites API.  Don't populate the environment variables for this.