### PR TITLE
Disable bouncing emails and redirect to support

### DIFF
--- a/govwifi-emails/emails.tf
+++ b/govwifi-emails/emails.tf
@@ -69,12 +69,9 @@ resource "aws_ses_receipt_rule" "newsite-mail-rule" {
     "newsite@${var.Env-Subdomain}.service.gov.uk"
   ]
 
-  bounce_action {
-    message         = "THIS FEATURE IS TEMPORARILY TURNED OFF - PLEASE CONTACT support@${var.Env-Subdomain}.service.gov.uk"
-    sender          = "support@${var.Env-Subdomain}.service.gov.uk"
-    smtp_reply_code = "550"
-    status_code     = "5.1.1"
-    position        = 1
+  sns_action {
+    topic_arn   = "${var.devops-notifications-arn}"
+    position    = 1
   }
 }
 


### PR DESCRIPTION
We are in the process of getting organisation administrators onto the
new admin platform.  Until then, we need to handle adding of IP
addresses to locations manually.

This forwards these requests to our support inbox where we can pick them
up.