### PR TITLE
Create S3 bucket policy for Radius whitelist config

### DIFF
--- a/govwifi-admin/s3.tf
+++ b/govwifi-admin/s3.tf
@@ -14,3 +14,29 @@ resource "aws_s3_bucket" "admin-bucket" {
     enabled = true
   }
 }
+
+resource "aws_s3_bucket_policy" "admin-bucket-policy" {
+bucket = "${aws_s3_bucket.admin-bucket.id}"
+policy =<<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "WhitelistFetch",
+  "Statement": [
+    {
+      "Sid": "Get Frontend Whitelist",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::govwifi-${var.rack-env}-admin/clients.conf",
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": [
+            ${join(",", formatlist("\"%s\"", concat(var.london-radius-ip-addresses, var.dublin-radius-ip-addresses)))}
+          ]
+        }
+      }
+    }
+  ]
+}
+POLICY
+}


### PR DESCRIPTION
We will be getting the radius whitelist configuration from S3 instead of
the allowed sites API.

This allows the frontends to get this configuration from bucket.