### PR TITLE
Populate the S3 object key for the whitelist

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -88,6 +88,9 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
+        },{
+          "name": "S3_WHITELIST_OBJECT_KEY",
+          "value": "clients.conf"
         }
       ],
       "links": null,


### PR DESCRIPTION
Our admin platform will populate this configuration file.
Eventually the Radius servers will read this file to populate the IP
whitelist.