### PR TITLE
Create Authorisation API cluster in Ireland

### DIFF
--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
+  count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-logging-ecs-cpu-alarm-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -23,6 +24,7 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
+  count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-logging-ecs-cpu-alarm-low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "2"

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-low" {
+  count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-ec2-api-cpu-alarm-low"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "2"
@@ -22,6 +23,7 @@ resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-high" {
+  count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-ec2-api-cpu-alarm-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
@@ -45,6 +47,7 @@ resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-high" {
+  count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-auth-ecs-cpu-alarm-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -69,6 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
+  count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-auth-ecs-cpu-alarm-low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -93,6 +97,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-high" {
+  count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-ecs-api-memory-reservation-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -115,6 +120,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-low" {
+  count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-ecs-api-memory-reservation-low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_log_group" "logging-api-log-group" {
+  count = "${var.logging-enabled}"
   name = "${var.Env-Name}-logging-api-docker-log-group"
 
   retention_in_days = 90
@@ -10,6 +11,7 @@ resource "aws_ecr_repository" "logging-api-ecr" {
 }
 
 resource "aws_ecs_task_definition" "logging-api-task" {
+  count = "${var.logging-enabled}"
   family   = "logging-api-task-${var.Env-Name}"
   task_role_arn = "${aws_iam_role.logging-api-task-role.arn}"
 
@@ -105,6 +107,7 @@ EOF
 }
 
 resource "aws_ecs_service" "logging-api-service" {
+  count           = "${var.logging-enabled}"
   name            = "logging-api-service-${var.Env-Name}"
   cluster         = "${aws_ecs_cluster.api-cluster.id}"
   task_definition = "${aws_ecs_task_definition.logging-api-task.arn}"
@@ -129,6 +132,7 @@ resource "aws_ecs_service" "logging-api-service" {
 }
 
 resource "aws_alb_target_group" "logging-api-tg" {
+  count = "${var.logging-enabled}"
   depends_on   = ["aws_lb.api-alb"]
   name     = "logging-api-${var.Env-Name}"
   port     = "8080"
@@ -149,6 +153,7 @@ resource "aws_alb_target_group" "logging-api-tg" {
 }
 
 resource "aws_alb_listener_rule" "logging-api-lr" {
+  count = "${var.logging-enabled}"
   depends_on   = ["aws_alb_target_group.logging-api-tg"]
   listener_arn = "${aws_alb_listener.alb_listener.arn}"
   priority     = 3
@@ -164,6 +169,7 @@ resource "aws_alb_listener_rule" "logging-api-lr" {
 }
 
 resource "aws_iam_role" "logging-api-task-role" {
+  count = "${var.logging-enabled}"
   name = "${var.Env-Name}-logging-api-task-role"
 
   assume_role_policy = <<EOF
@@ -184,6 +190,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "logging-api-task-policy" {
+  count      = "${var.logging-enabled}"
   name       = "${var.Env-Name}-logging-api-task-policy"
   role       = "${aws_iam_role.logging-api-task-role.id}"
   depends_on = ["aws_iam_role.logging-api-task-role"]

--- a/govwifi-api/logging-scaling-policy.tf
+++ b/govwifi-api/logging-scaling-policy.tf
@@ -1,4 +1,5 @@
 resource "aws_appautoscaling_target" "logging-ecs-target" {
+  count              = "${var.logging-enabled}"
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.logging-api-service.name}"
   max_capacity       = 20
@@ -8,6 +9,7 @@ resource "aws_appautoscaling_target" "logging-ecs-target" {
 }
 
 resource "aws_appautoscaling_policy" "ecs-policy-up-logging" {
+  count              = "${var.logging-enabled}"
   name               = "ECS Scale Up Logging"
   service_namespace  = "ecs"
   policy_type        = "StepScaling"
@@ -28,6 +30,7 @@ resource "aws_appautoscaling_policy" "ecs-policy-up-logging" {
 }
 
 resource "aws_appautoscaling_policy" "ecs-policy-down-logging" {
+  count              = "${var.logging-enabled}"
   name               = "ECS Scale Down"
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.logging-api-service.name}"

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -1,4 +1,5 @@
 resource "aws_iam_role" "logging-scheduled-task-role" {
+  count = "${var.logging-enabled}"
   name = "${var.Env-Name}-logging-scheduled-task-role"
   assume_role_policy = <<DOC
 {
@@ -18,6 +19,7 @@ DOC
 }
 
 resource "aws_iam_role_policy" "logging-scheduled-task-policy" {
+  count = "${var.logging-enabled}"
   name = "${var.Env-Name}-logging-scheduled-task-policy"
   role = "${aws_iam_role.logging-scheduled-task-role.id}"
   policy = <<DOC
@@ -47,6 +49,7 @@ DOC
 }
 
 resource "aws_cloudwatch_event_target" "logging-publish-daily-statistics" {
+  count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-daily-statistics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
   rule      = "${aws_cloudwatch_event_rule.daily_statistics_event.name}"
@@ -70,6 +73,7 @@ EOF
 }
 
 resource "aws_cloudwatch_event_target" "logging-publish-weekly-statistics" {
+  count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-weekly-statistics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
   rule      = "${aws_cloudwatch_event_rule.weekly_statistics_event.name}"
@@ -93,6 +97,7 @@ EOF
 }
 
 resource "aws_cloudwatch_event_target" "logging-publish-monthly-statistics" {
+  count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-monthly-statistics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
   rule      = "${aws_cloudwatch_event_rule.monthly_statistics_event.name}"

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_log_group" "user-signup-api-log-group" {
+  count = "${var.user-signup-enabled}"
   name = "${var.Env-Name}-user-signup-api-docker-log-group"
 
   retention_in_days = 90
@@ -10,6 +11,7 @@ resource "aws_ecr_repository" "user-signup-api-ecr" {
 }
 
 resource "aws_iam_role" "user-signup-api-task-role" {
+  count = "${var.user-signup-enabled}"
   name = "${var.Env-Name}-user-signup-api-task-role"
 
   assume_role_policy = <<EOF
@@ -30,6 +32,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "user-signup-api-task-policy" {
+  count      = "${var.user-signup-enabled}"
   name       = "${var.Env-Name}-user-signup-api-task-policy"
   role       = "${aws_iam_role.user-signup-api-task-role.id}"
   depends_on = ["aws_iam_role.user-signup-api-task-role"]
@@ -51,6 +54,7 @@ EOF
 }
 
 resource "aws_ecs_task_definition" "user-signup-api-task" {
+  count = "${var.user-signup-enabled}"
   family = "user-signup-api-task-${var.Env-Name}"
   task_role_arn = "${aws_iam_role.user-signup-api-task-role.arn}"
 
@@ -143,6 +147,7 @@ EOF
 }
 
 resource "aws_ecs_service" "user-signup-api-service" {
+  count           = "${var.user-signup-enabled}"
   name            = "user-signup-api-service-${var.Env-Name}"
   cluster         = "${aws_ecs_cluster.api-cluster.id}"
   task_definition = "${aws_ecs_task_definition.user-signup-api-task.arn}"
@@ -167,11 +172,12 @@ resource "aws_ecs_service" "user-signup-api-service" {
 }
 
 resource "aws_alb_target_group" "user-signup-api-tg" {
-  depends_on   = ["aws_lb.api-alb"]
-  name     = "user-signup-api-${var.Env-Name}"
-  port     = "8080"
-  protocol = "HTTP"
-  vpc_id   = "${var.vpc-id}"
+  count       = "${var.user-signup-enabled}"
+  depends_on  = ["aws_lb.api-alb"]
+  name        = "user-signup-api-${var.Env-Name}"
+  port        = "8080"
+  protocol    = "HTTP"
+  vpc_id      = "${var.vpc-id}"
 
   tags {
     Name = "user-signup-api-tg-${var.Env-Name}"
@@ -187,6 +193,7 @@ resource "aws_alb_target_group" "user-signup-api-tg" {
 }
 
 resource "aws_alb_listener_rule" "user-signup-api-lr" {
+  count        = "${var.user-signup-enabled}"
   depends_on   = ["aws_alb_target_group.user-signup-api-tg"]
   listener_arn = "${aws_alb_listener.alb_listener.arn}"
   priority     = 2

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -1,5 +1,6 @@
 
 resource "aws_iam_role" "user-signup-scheduled-task-role" {
+  count = "${var.user-signup-enabled}"
   name = "${var.Env-Name}-user-signup-scheduled-task-role"
   assume_role_policy = <<DOC
 {
@@ -19,6 +20,7 @@ DOC
 }
 
 resource "aws_iam_role_policy" "user-signup-scheduled-task-policy" {
+  count = "${var.user-signup-enabled}"
   name = "${var.Env-Name}-user-signup-scheduled-task-policy"
   role = "${aws_iam_role.user-signup-scheduled-task-role.id}"
   policy = <<DOC
@@ -48,6 +50,7 @@ DOC
 }
 
 resource "aws_cloudwatch_event_target" "user-signup-publish-daily-statistics" {
+  count     = "${var.user-signup-enabled}"
   target_id = "${var.Env-Name}-user-signup-daily-statistics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
   rule      = "${aws_cloudwatch_event_rule.daily_statistics_event.name}"
@@ -71,6 +74,7 @@ EOF
 }
 
 resource "aws_cloudwatch_event_target" "user-signup-publish-weekly-statistics" {
+  count     = "${var.user-signup-enabled}"
   target_id = "${var.Env-Name}-user-signup-weekly-statistics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
   rule      = "${aws_cloudwatch_event_rule.weekly_statistics_event.name}"

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -8,6 +8,10 @@ variable "aws-region" {}
 
 variable "aws-region-name" {}
 
+variable "alarm-count" {
+  default = 1
+}
+
 variable "ami" {
   description = "AMI id to launch, must be in the region specified by the region variable"
 }
@@ -26,6 +30,14 @@ variable "aws-account-id" {}
 
 variable "elb-ssl-cert-arn" {}
 
+variable "user-signup-enabled" {
+  default = 1
+}
+
+variable "logging-enabled" {
+  default = 1
+}
+
 variable "db-user" {}
 
 variable "db-password" {}
@@ -36,17 +48,29 @@ variable "db-read-replica-hostname" {}
 
 variable "rack-env" {}
 
-variable "performance-url" {}
+variable "performance-url" {
+  default = ""
+}
 
-variable "performance-dataset" {}
+variable "performance-dataset" {
+  default = ""
+}
 
-variable "performance-bearer-volumetrics" {}
+variable "performance-bearer-volumetrics" {
+  default = ""
+}
 
-variable "performance-bearer-completion-rate" {}
+variable "performance-bearer-completion-rate" {
+  default = ""
+}
 
-variable "performance-bearer-account-usage" {}
+variable "performance-bearer-account-usage" {
+  default = ""
+}
 
-variable "performance-bearer-unique-users" {}
+variable "performance-bearer-unique-users" {
+  default = ""
+}
 
 variable "radius-server-ips" {}
 
@@ -99,6 +123,7 @@ variable "authorised-email-domains-regex" {
 }
 
 variable "notify-api-key" {
+  default     = ""
   description = "API key used to authenticate with GOV.UK Notify"
 }
 


### PR DESCRIPTION
Currently the authentication backend only runs in London.
Spin up another API cluster in Ireland to make it more robust.

This adds flags for infrastructure we want to supress in Ireland
ie. Logging and User Signup