### PR TITLE
Split out api-base-url to be region specific

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -53,14 +53,11 @@ resource "aws_ecs_task_definition" "radius-task" {
     "dockerSecurityOptions": null,
     "environment": [
       {
-        "name": "API_BASE_URL",
-        "value": "${var.api-base-url}"
-      },{
         "name": "AUTHORISATION_API_BASE_URL",
-        "value": "${var.api-base-url}"
+        "value": "${var.auth-api-base-url}"
       },{
         "name": "LOGGING_API_BASE_URL",
-        "value": "${var.api-base-url}"
+        "value": "${var.logging-api-base-url}"
       },{
         "name": "BACKEND_BASEURL",
         "value": "${var.backend-base-url}"

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -42,7 +42,9 @@ variable "dns-numbering-base" {}
 
 variable "backend-base-url" {}
 
-variable "api-base-url" {}
+variable "logging-api-base-url" {}
+
+variable "auth-api-base-url" {}
 
 variable "elastic-ip-list" {
   type = "list"


### PR DESCRIPTION
Our Dublin Frontends will do authorisation with the Dublin Authorisation
API.  Logging will still happen on the London Logging API.

This requires splitting out the base URLs to be region specific.