### PR TITLE
Increase Dublin Authorisation tasks to 4

### DIFF
--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -97,7 +97,6 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-high" {
-  count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-ecs-api-memory-reservation-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -120,7 +119,6 @@ resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-low" {
-  count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-ecs-api-memory-reservation-low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"

--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -81,7 +81,7 @@ resource "aws_ecs_service" "authorisation-api-service" {
   name            = "authorisation-api-service-${var.Env-Name}"
   cluster         = "${aws_ecs_cluster.api-cluster.id}"
   task_definition = "${aws_ecs_task_definition.authorisation-api-task.arn}"
-  desired_count   = "${var.backend-instance-count}"
+  desired_count   = "${var.authorisation-api-count}"
   iam_role        = "${var.ecs-service-role}"
 
   ordered_placement_strategy {

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -20,6 +20,10 @@ variable "ssh-key-name" {}
 
 variable "backend-instance-count" {}
 
+variable "authorisation-api-count" {
+  default = 2
+}
+
 variable "backend-min-size" {}
 
 variable "backend-cpualarm-count" {}


### PR DESCRIPTION
We do nightly reboots and need the cluster to span at least 2 ec2
instances.

When one reboots, the other one serves as a backup to handle traffic.
Currently we only have 2 authorisation tasks in Dublin meaning that they
only occupy 1 EC2 instance.  By increasing this desired count to 4, they
will span 2 EC2 instances.