### PR TITLE
Disable Anacron

### DIFF
--- a/govwifi-api/launch-configuration.tf
+++ b/govwifi-api/launch-configuration.tf
@@ -182,6 +182,13 @@ EOF
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
+# Disable Anacron
+chmod a-x $(which anacron)
+
+--==BOUNDARY==
+MIME-Version: 1.0
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
 # Set the region to send CloudWatch Logs data to (the region where the container instance is located)
 # region=$(curl 169.254.169.254/latest/meta-data/placement/availability-zone | sed s'/.$//')
 region=${var.aws-region}


### PR DESCRIPTION
Our Route53 healthchecks are going off at midnight in Dublin.

We stagger daily reboots with cron (security-updates), but Anacron is also running these at
midnight.  This means that instead of a staggered restart, Anacron
restarts all the docker processes at exactly the same time, causing the
healthchecks to go off.

Ensure that Anacron is disabled, so we only run our intended staggered
security update restarts.