### PR TITLE
Populate Read Replica environment variables

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -94,6 +94,18 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "LOGGING_API_SEARCH_ENDPOINT",
           "value": "${var.logging-api-search-url}"
+        },{
+          "name": "RR_DB_USER",
+          "value": "${var.rr-db-user}"
+        },{
+          "name": "RR_DB_PASS",
+          "value": "${var.rr-db-password}"
+        },{
+          "name": "RR_DB_HOST",
+          "value": "${var.rr-db-host}"
+        },{
+          "name": "RR_DB_NAME",
+          "value": "${var.rr-db-name}"
         }
       ],
       "links": null,

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -127,3 +127,11 @@ variable "dublin-radius-ip-addresses" {
 variable "sentry-dsn" {}
 
 variable "logging-api-search-url" {}
+
+variable "rr-db-user" {}
+
+variable "rr-db-password" {}
+
+variable "rr-db-host" {}
+
+variable "rr-db-name" {}


### PR DESCRIPTION
The admin task definition now contains details about the read replica so
that the Rails application can access it to get logging information.