### PR TITLE
Run user signup and logging scheduled tasks at different times

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -1,20 +1,41 @@
-resource "aws_cloudwatch_event_rule" "daily_statistics_event" {
+resource "aws_cloudwatch_event_rule" "daily_statistics_logging_event" {
   name                = "${var.Env-Name}-daily-statistics-frequency"
   description         = "Triggers daily 0625 UTC"
-  schedule_expression = "cron(25 6 * * ? *)"
+  schedule_expression = "cron(15 4 * * ? *)"
   is_enabled          = true
 }
 
-resource "aws_cloudwatch_event_rule" "weekly_statistics_event" {
+resource "aws_cloudwatch_event_rule" "daily_statistics_user_signup_event" {
+  name                = "${var.Env-Name}-daily-statistics-frequency"
+  description         = "Triggers daily 0625 UTC"
+  schedule_expression = "cron(45 4 * * ? *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "weekly_statistics_logging_event" {
   name                = "${var.Env-Name}-weekly-statistics-frequency"
   description         = "Triggers every SUN 0647 UTC"
-  schedule_expression = "cron(47 6 ? * 7 *)"
+  schedule_expression = "cron(15 5 ? * 7 *)"
   is_enabled          = true
 }
 
-resource "aws_cloudwatch_event_rule" "monthly_statistics_event" {
+resource "aws_cloudwatch_event_rule" "weekly_statistics_user_signup_event" {
+  name                = "${var.Env-Name}-weekly-statistics-frequency"
+  description         = "Triggers every SUN 0647 UTC"
+  schedule_expression = "cron(45 5 ? * 7 *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "monthly_statistics_logging_event" {
   name                = "${var.Env-Name}-monthly-statistics-frequency"
   description         = "Triggers on the first of each month at 0652 UTC"
-  schedule_expression = "cron(52 6 1 * ? *)"
+  schedule_expression = "cron(0 6 1 * ? *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "monthly_statistics_user_signup_event" {
+  name                = "${var.Env-Name}-monthly-statistics-frequency"
+  description         = "Triggers on the first of each month at 0652 UTC"
+  schedule_expression = "cron(30 6 1 * ? *)"
   is_enabled          = true
 }

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -52,7 +52,7 @@ resource "aws_cloudwatch_event_target" "logging-publish-daily-statistics" {
   count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-daily-statistics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.daily_statistics_event.name}"
+  rule      = "${aws_cloudwatch_event_rule.daily_statistics_logging_event.name}"
   role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
 
   ecs_target = {
@@ -76,7 +76,7 @@ resource "aws_cloudwatch_event_target" "logging-publish-weekly-statistics" {
   count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-weekly-statistics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.weekly_statistics_event.name}"
+  rule      = "${aws_cloudwatch_event_rule.weekly_statistics_logging_event.name}"
   role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
 
   ecs_target = {
@@ -100,7 +100,7 @@ resource "aws_cloudwatch_event_target" "logging-publish-monthly-statistics" {
   count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-monthly-statistics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.monthly_statistics_event.name}"
+  rule      = "${aws_cloudwatch_event_rule.monthly_statistics_logging_event.name}"
   role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
 
   ecs_target = {

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -53,7 +53,7 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-daily-statistics" {
   count     = "${var.user-signup-enabled}"
   target_id = "${var.Env-Name}-user-signup-daily-statistics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.daily_statistics_event.name}"
+  rule      = "${aws_cloudwatch_event_rule.daily_statistics_user_signup_event.name}"
   role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
 
   ecs_target = {
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-weekly-statistics" {
   count     = "${var.user-signup-enabled}"
   target_id = "${var.Env-Name}-user-signup-weekly-statistics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.weekly_statistics_event.name}"
+  rule      = "${aws_cloudwatch_event_rule.weekly_statistics_user_signup_event.name}"
   role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
 
   ecs_target = {


### PR DESCRIPTION
We are seeing gaps in our performance statistics reporting.
This has been an ongoing issue, and it turns out that we are running out
of memory on the cluster.

This is due to the fact that we spin up both logging and user signup
tasks at the same time.

This changes it to run logging statistics publishing at a different time to user
signup statistics publishing.