### PR TITLE
Rolling restarts for docker containers

### DIFF
--- a/govwifi-api/launch-configuration.tf
+++ b/govwifi-api/launch-configuration.tf
@@ -84,7 +84,13 @@ cat <<'EOF' > ./security-updates
 #!/bin/bash
 sudo yum update -y --security
 sudo yum update -y ecs-init
-sudo service docker restart
+
+for containerId in `docker ps --format '{{.ID}}'`; do
+  echo "RESTARTING $container";
+  docker restart $containerId
+  sleep 60;
+done
+
 sleep 5
 sudo start ecs
 # Forcefully restart the instance if the docker daemon has failed to restart


### PR DESCRIPTION
We install security updates each night.
The time at which this happens is determined by the last numbers of the ip % 59
This is fragile and is triggering health check alarms.

Instead of the heavy handed `sudo service docker restart`, do a rolling
restart, which is faster and should ensure that there is always a task
running to serve traffic.