### PR TITLE
Make Read Replica Lag Alarm Less Sensitive

### DIFF
--- a/govwifi-backend/db.tf
+++ b/govwifi-backend/db.tf
@@ -261,7 +261,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_laggingalarm" {
   count               = "${var.db-replica-count}"
   alarm_name          = "${var.Env-Name}-rr-lagging-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "2"
   metric_name         = "ReplicaLag"
   namespace           = "AWS/RDS"
   period              = "60"


### PR DESCRIPTION
We receive daily alarm notifications that the read replica sync lag is over 5
minutes. The data being synced across is session log data and isn't
mission critical.

Double the evaluation period so we don't receive this daily.