### PR TITLE
Bump the SSL Policy on our application load balancers

### DIFF
--- a/govwifi-admin/loadbalancer.tf
+++ b/govwifi-admin/loadbalancer.tf
@@ -15,7 +15,7 @@ resource "aws_alb_listener" "alb_listener" {
   port              = "443"
   protocol          = "HTTPS"
   certificate_arn   = "${aws_acm_certificate_validation.certificate.certificate_arn}"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
 
   default_action {
     target_group_arn = "${aws_alb_target_group.admin-tg.arn}"

--- a/govwifi-api/elb.tf
+++ b/govwifi-api/elb.tf
@@ -16,7 +16,7 @@ resource "aws_alb_listener" "alb_listener" {
   port              = "8443"
   protocol          = "HTTPS"
   certificate_arn   = "${var.elb-ssl-cert-arn}"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
 
   default_action {
     target_group_arn = "${aws_alb_target_group.alb_target_group.arn}"


### PR DESCRIPTION
The pentest suggested we stop supporting older versions of TLS and
certain Cipher suites.

This updates the ELB policy to do that.

More details of this policy can be found here:

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html