### PR TITLE
Append allowed Ciphers to sshd config

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -94,6 +94,7 @@ done
 IFS=$oldIFS
 
 sudo sed -i -e "s/AllowUsers ubuntu/AllowUsers $allowedUsers/g" /etc/ssh/sshd_config
+sudo sed -i -e "\$a Ciphers\ aes128-ctr,aes192-ctr,aes256-ctr" /etc/ssh/sshd_config
 sudo /etc/init.d/ssh reload
 
 --==BOUNDARY==


### PR DESCRIPTION
My `sed-fu` is weak, but I think this does what we want.

I'd like to test this on staging first, to make sure we still have SSH clients that can connect to it. It might require some tweaking of config for clients.