### PR TITLE
Run session deletion in ECS

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -39,3 +39,11 @@ resource "aws_cloudwatch_event_rule" "monthly_statistics_user_signup_event" {
   schedule_expression = "cron(30 6 1 * ? *)"
   is_enabled          = true
 }
+
+resource "aws_cloudwatch_event_rule" "daily_session_deletion_event" {
+  name                = "${var.Env-Name}-daily-session-deletion"
+  description         = "Triggers daily 22:00 pm UTC"
+  schedule_expression = "cron(0 22 * * ? *)"
+  is_enabled          = true
+}
+


### PR DESCRIPTION
We are decommissioning the lambdas that keep us GDPR compliant.

We will run session deletion as an ECS scheduled task instead.