### PR TITLE
Fix performance platform logging statistics

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_event_rule" "daily_statistics_logging_event" {
   name                = "${var.Env-Name}-daily-statistics-frequency-logging"
-  description         = "Triggers daily 04:25 am UTC"
+  description         = "Triggers daily 04:15 am UTC"
   schedule_expression = "cron(15 4 * * ? *)"
   is_enabled          = true
 }


### PR DESCRIPTION
We switched to Fargate for the Logging API.
Turns out that scheduled tasks with Fargate are not supported in London yet.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduled_tasks.html

This means that we have to continue to run our scheduled tasks on EC2
instead of Fargate.  This introduces some complexity as we need 2 task
definitions to achieve this.

One for ECS Tasks and one for ECS Scheduled tasks.

This is temporary until Fargate for Scheduled events is available in
London.