### PR TITLE
Disable uninteresting alarms

### DIFF
--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -41,7 +41,6 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
 
   alarm_description  = "This alarm tells ECS to scale in based on low CPU usage - Logging"
   alarm_actions      = [
-    "${aws_appautoscaling_policy.ecs-policy-down-logging.arn}",
-    "${var.devops-notifications-arn}"
+    "${aws_appautoscaling_policy.ecs-policy-down-logging.arn}"
   ]
 }

--- a/govwifi-backend/db.tf
+++ b/govwifi-backend/db.tf
@@ -266,7 +266,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_laggingalarm" {
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Minimum"
-  threshold           = "300"
+  threshold           = "600"
 
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.read_replica.identifier}"


### PR DESCRIPTION
There is no reason for us to receive notifications that the logging API
has scaled down.  This happens daily and requires no further action.
Just silence this.

Also increase the alarm for read replica alarm from 5 minutes to 10
minutes.