### PR TITLE
Rename delete_users to delete_inactive_users

### DIFF
--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
   "containerOverrides": [
     {
       "name": "logging",
-      "command": ["bundle", "exec", "rake", "delete_users"]
+      "command": ["bundle", "exec", "rake", "delete_inactive_users"]
     }
   ]
 }


### PR DESCRIPTION
It is not obvious, from the name that this is a safe operation and
only removes users to keep use GDPR compliant