### PR TITLE
Suppress background jobs from being run in Dublin

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_event_rule" "daily_statistics_logging_event" {
+  count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-daily-statistics-frequency-logging"
   description         = "Triggers daily 04:15 am UTC"
   schedule_expression = "cron(15 4 * * ? *)"
@@ -6,6 +7,7 @@ resource "aws_cloudwatch_event_rule" "daily_statistics_logging_event" {
 }
 
 resource "aws_cloudwatch_event_rule" "daily_statistics_user_signup_event" {
+  count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-daily-statistics-frequency-user-signup"
   description         = "Triggers daily 04:45 am UTC"
   schedule_expression = "cron(45 4 * * ? *)"
@@ -13,6 +15,7 @@ resource "aws_cloudwatch_event_rule" "daily_statistics_user_signup_event" {
 }
 
 resource "aws_cloudwatch_event_rule" "weekly_statistics_logging_event" {
+  count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-weekly-statistics-frequency-logging"
   description         = "Triggers every SUN 05:15 am UTC"
   schedule_expression = "cron(15 5 ? * 7 *)"
@@ -20,6 +23,7 @@ resource "aws_cloudwatch_event_rule" "weekly_statistics_logging_event" {
 }
 
 resource "aws_cloudwatch_event_rule" "weekly_statistics_user_signup_event" {
+  count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-weekly-statistics-frequency-user-signup"
   description         = "Triggers every SUN 05:45 am UTC"
   schedule_expression = "cron(45 5 ? * 7 *)"
@@ -27,6 +31,7 @@ resource "aws_cloudwatch_event_rule" "weekly_statistics_user_signup_event" {
 }
 
 resource "aws_cloudwatch_event_rule" "monthly_statistics_logging_event" {
+  count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-monthly-statistics-frequency-logging"
   description         = "Triggers on the first of each month at 06:00 am UTC"
   schedule_expression = "cron(0 6 1 * ? *)"
@@ -34,6 +39,7 @@ resource "aws_cloudwatch_event_rule" "monthly_statistics_logging_event" {
 }
 
 resource "aws_cloudwatch_event_rule" "monthly_statistics_user_signup_event" {
+  count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-monthly-statistics-frequency-user-signup"
   description         = "Triggers on the first of each month at 06:30 am UTC"
   schedule_expression = "cron(30 6 1 * ? *)"
@@ -41,6 +47,7 @@ resource "aws_cloudwatch_event_rule" "monthly_statistics_user_signup_event" {
 }
 
 resource "aws_cloudwatch_event_rule" "daily_session_deletion_event" {
+  count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-daily-session-deletion"
   description         = "Triggers daily 22:00 pm UTC"
   schedule_expression = "cron(0 22 * * ? *)"
@@ -48,6 +55,7 @@ resource "aws_cloudwatch_event_rule" "daily_session_deletion_event" {
 }
 
 resource "aws_cloudwatch_event_rule" "daily_user_deletion_event" {
+  count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-daily-user-deletion"
   description         = "Triggers daily 23:00 pm UTC"
   schedule_expression = "cron(0 23 * * ? *)"

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -127,6 +127,7 @@ EOF
 }
 
 resource "aws_cloudwatch_event_target" "logging-daily-session-deletion" {
+  count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-daily-session-deletion"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
   rule      = "${aws_cloudwatch_event_rule.daily_session_deletion_event.name}"
@@ -135,11 +136,7 @@ resource "aws_cloudwatch_event_target" "logging-daily-session-deletion" {
   ecs_target = {
     task_count = 1
     task_definition_arn = "${aws_ecs_task_definition.logging-api-scheduled-task.arn}"
-
-    network_configuration = {
-      security_groups = ["${var.backend-sg-list}"]
-      subnets         = ["${var.subnet-ids}"]
-    }
+    launch_type  = "EC2"
   }
 
   input = <<EOF

--- a/govwifi-api/safe-restart-scheduled-task.tf
+++ b/govwifi-api/safe-restart-scheduled-task.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_event_rule" "daily_safe_restart" {
+  count               = "${var.safe-restart-enabled}"
   name                = "${var.Env-Name}-daily-safe-restart"
   description         = "Triggers at midnight Daily"
   schedule_expression = "cron(0 0 * * ? *)"
@@ -6,6 +7,7 @@ resource "aws_cloudwatch_event_rule" "daily_safe_restart" {
 }
 
 resource "aws_cloudwatch_log_group" "safe-restart-log-group" {
+  count = "${var.safe-restart-enabled}"
   name = "${var.Env-Name}-safe-restart-docker-log-group"
 
   retention_in_days = 90
@@ -17,6 +19,7 @@ resource "aws_ecr_repository" "safe-restarter-ecr" {
 }
 
 resource "aws_ecs_task_definition" "safe-restart-task-definition" {
+  count = "${var.safe-restart-enabled}"
   family = "safe-restart-task-${var.Env-Name}"
   task_role_arn = "${aws_iam_role.safe-restart-task-role.arn}"
 

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -97,6 +97,7 @@ EOF
 }
 
 resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
+  count     = "${var.user-signup-enabled}"
   target_id = "${var.Env-Name}-user-signup-daily-user-deletion"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
   rule      = "${aws_cloudwatch_event_rule.daily_user_deletion_event.name}"

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -12,6 +12,10 @@ variable "alarm-count" {
   default = 1
 }
 
+variable "event-rule-count" {
+  default = 1
+}
+
 variable "ami" {
   description = "AMI id to launch, must be in the region specified by the region variable"
 }


### PR DESCRIPTION
These run in London so don't need to be run there.
Also change the launch type of the logging background task to be EC2
since Fargate background jobs aren't supported yet.