### PR TITLE
Ec2 launch type sched

### DIFF
--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -83,6 +83,7 @@ resource "aws_cloudwatch_event_target" "logging-publish-weekly-statistics" {
   ecs_target = {
     task_count = 1
     task_definition_arn = "${aws_ecs_task_definition.logging-api-scheduled-task.arn}"
+    launch_type  = "EC2"
   }
 
   input = <<EOF
@@ -107,11 +108,7 @@ resource "aws_cloudwatch_event_target" "logging-publish-monthly-statistics" {
   ecs_target = {
     task_count = 1
     task_definition_arn = "${aws_ecs_task_definition.logging-api-scheduled-task.arn}"
-
-    network_configuration = {
-      security_groups = ["${var.backend-sg-list}"]
-      subnets         = ["${var.subnet-ids}"]
-    }
+    launch_type  = "EC2"
   }
 
   input = <<EOF

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -58,6 +58,7 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-daily-statistics" {
   ecs_target = {
     task_count = 1
     task_definition_arn = "${aws_ecs_task_definition.user-signup-api-task.arn}"
+    launch_type  = "EC2"
   }
 
   input = <<EOF
@@ -82,6 +83,7 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-weekly-statistics" {
   ecs_target = {
     task_count = 1
     task_definition_arn = "${aws_ecs_task_definition.user-signup-api-task.arn}"
+    launch_type  = "EC2"
   }
 
   input = <<EOF
@@ -106,6 +108,7 @@ resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
   ecs_target = {
     task_count = 1
     task_definition_arn = "${aws_ecs_task_definition.user-signup-api-task.arn}"
+    launch_type  = "EC2"
   }
 
   input = <<EOF


### PR DESCRIPTION
Create an EC2 task definition for the scheduled tasks

We cannot reuse the Fargate specific task definition for the user signup background tasks.  
Create an EC2 task definition that we can use until Fargate supports scheduled tasks in London
