### PR TITLE
Remove ECS scale in notifications to developers

### DIFF
--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -16,8 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
 
   alarm_description  = "This alarm tells ECS to scale up based on high CPU - Logging"
   alarm_actions      = [
-    "${aws_appautoscaling_policy.ecs-policy-up-logging.arn}",
-    "${var.devops-notifications-arn}"
+    "${aws_appautoscaling_policy.ecs-policy-up-logging.arn}"
   ]
 
   treat_missing_data = "breaching"

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -15,8 +15,7 @@ resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-low" {
 
   alarm_description  = "This alarm tells EC2 to scale in based on low CPU usage"
   alarm_actions      = [
-    "${aws_autoscaling_policy.api-ec2-scale-down-policy.arn}",
-    "${var.devops-notifications-arn}"
+    "${aws_autoscaling_policy.api-ec2-scale-down-policy.arn}"
   ]
 
   treat_missing_data = "breaching"
@@ -89,8 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
 
   alarm_description  = "This alarm tells ECS to scale in based on low CPU usage"
   alarm_actions      = [
-    "${aws_appautoscaling_policy.ecs-policy-down.arn}",
-    "${var.devops-notifications-arn}"
+    "${aws_appautoscaling_policy.ecs-policy-down.arn}"
   ]
 
   treat_missing_data = "breaching"


### PR DESCRIPTION
This is just noise, and we don't have to do anything when ECS scales in.
Silence these alarms, they were initially created to facilitate
debugging.