### PR TITLE
Bump Mysql engine version to 5.7.23

### DIFF
--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -48,7 +48,7 @@ resource "aws_db_instance" "admin_db" {
   allocated_storage           = "${var.db-storage-gb}"
   storage_type                = "gp2"
   engine                      = "mysql"
-  engine_version              = "5.7.16"
+  engine_version              = "5.7.23"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true


### PR DESCRIPTION
AWS has upgraded this for us, and this just catches up the Terraform