### PR TITLE
Don't bring down memory

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -22,7 +22,7 @@ resource "aws_ecs_task_definition" "radius-task" {
 [
   {
     "volumesFrom": [],
-    "memory": 1000,
+    "memory": 2000,
     "extraHosts": null,
     "dnsServers": null,
     "disableNetworking": null,


### PR DESCRIPTION
This was a typo, keep memory at 2000 units.