### PR TITLE
Make www the canonical domain for wifi.service.gov.uk

### DIFF
--- a/govwifi-admin/acm.tf
+++ b/govwifi-admin/acm.tf
@@ -15,21 +15,3 @@ resource "aws_acm_certificate_validation" "certificate" {
   certificate_arn = "${aws_acm_certificate.admin_cert.arn}"
   validation_record_fqdns = ["${aws_route53_record.admin_cert_validation.fqdn}"]
 }
-
-resource "aws_acm_certificate" "admin_cert_www" {
-  domain_name = "${aws_route53_record.admin_www.name}"
-  validation_method = "DNS"
-}
-
-resource "aws_route53_record" "admin_cert_www_validation" {
-  name = "${aws_acm_certificate.admin_cert_www.domain_validation_options.0.resource_record_name}"
-  type = "${aws_acm_certificate.admin_cert_www.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
-  records = ["${aws_acm_certificate.admin_cert_www.domain_validation_options.0.resource_record_value}"]
-  ttl = 60
-}
-
-resource "aws_acm_certificate_validation" "certificate_www" {
-  certificate_arn = "${aws_acm_certificate.admin_cert_www.arn}"
-  validation_record_fqdns = ["${aws_route53_record.admin_cert_www_validation.fqdn}"]
-}

--- a/govwifi-admin/loadbalancer.tf
+++ b/govwifi-admin/loadbalancer.tf
@@ -22,8 +22,3 @@ resource "aws_alb_listener" "alb_listener" {
     type             = "forward"
   }
 }
-
-resource "aws_lb_listener_certificate" "admin_www_cert" {
-  listener_arn    = "${aws_alb_listener.alb_listener.arn}"
-  certificate_arn = "${aws_acm_certificate.admin_cert_www.arn}"
-}

--- a/govwifi-admin/route53.tf
+++ b/govwifi-admin/route53.tf
@@ -9,28 +9,12 @@ resource "aws_route53_record" "admin" {
   }
 }
 
-resource "aws_route53_record" "admin_www" {
-  zone_id = "${data.aws_route53_zone.zone.id}"
-  name    = "www.admin.${var.Env-Subdomain}.service.gov.uk"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["admin.${var.Env-Subdomain}.service.gov.uk"]
-}
-
-resource "aws_route53_record" "docs_www" {
-  zone_id = "${data.aws_route53_zone.zone.id}"
-  name    = "www.docs.${var.Env-Subdomain}.service.gov.uk"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["docs.${var.Env-Subdomain}.service.gov.uk"]
-}
-
 resource "aws_route53_record" "www" {
   zone_id = "${data.aws_route53_zone.zone.id}"
   name    = "www.${var.Env-Subdomain}.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
-  records = ["${var.Env-Subdomain}.service.gov.uk"]
+  records = ["d2j0ojhs7n2cwa.cloudfront.net"]
 }
 
 data "aws_route53_zone" "zone" {


### PR DESCRIPTION
Remove www DNS for docs and admin, these won't be needed.