### PR TITLE
Add Zendesk API variables

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -109,6 +109,15 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "RR_DB_NAME",
           "value": "${var.rr-db-name}"
+        },{
+          "name": "ZENDESK_API_ENDPOINT",
+          "value": "${var.zendesk-api-endpoint}"
+        },{
+          "name": "ZENDESK_API_USER",
+          "value": "${var.zendesk-api-user}"
+        },{
+          "name": "ZENDESK_API_TOKEN",
+          "value": "${var.zendesk-api-token}"
         }
       ],
       "links": null,

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -135,3 +135,9 @@ variable "rr-db-password" {}
 variable "rr-db-host" {}
 
 variable "rr-db-name" {}
+
+variable "zendesk-api-endpoint" {}
+
+variable "zendesk-api-user" {}
+
+variable "zendesk-api-token" {}


### PR DESCRIPTION
Based this on other work that's added env-vars to the govwifi-admin task.

As I understand it, this needs a corresponding PR in `govwifi-build` that'll set these variables.