### PR TITLE
Default to using the new user database

### DIFF
--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -88,27 +88,15 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
       "environment": [
         {
           "name": "DB_NAME",
-          "value": "govwifi_${var.Env-Name}"
-        },{
-          "name": "DB_PASS",
-          "value": "${var.db-password}"
-        },{
-          "name": "DB_USER",
-          "value": "${var.db-user}"
-        },{
-          "name": "DB_HOSTNAME",
-          "value": "${var.db-hostname}"
-        },{
-          "name": "USER_DB_NAME",
           "value": "govwifi_${var.env}_users"
         },{
-          "name": "USER_DB_PASS",
+          "name": "DB_PASS",
           "value": "${var.user-db-password}"
         },{
-          "name": "USER_DB_USER",
+          "name": "DB_USER",
           "value": "${var.user-db-username}"
         },{
-          "name": "USER_DB_HOSTNAME",
+          "name": "DB_HOSTNAME",
           "value": "${var.user-db-hostname}"
         },{
           "name": "RACK_ENV",


### PR DESCRIPTION
We were writing to both, but this isn't necessary anymore as the new
database has fully taken over.