### PR TITLE
Remove burst balance alarm for user database

### DIFF
--- a/govwifi-backend/user-db-alarms.tf
+++ b/govwifi-backend/user-db-alarms.tf
@@ -58,26 +58,6 @@ resource "aws_cloudwatch_metric_alarm" "user_db_storagealarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "user_db_burstbalancealarm" {
-  count               = "${var.db-instance-count}"
-  alarm_name          = "${var.env}-user-db-burstbalanace-alarm"
-  comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "BurstBalance"
-  namespace           = "AWS/RDS"
-  period              = "180"
-  statistic           = "Minimum"
-  threshold           = "45"
-
-  dimensions {
-    DBInstanceIdentifier = "${aws_db_instance.users_db.identifier}"
-  }
-
-  alarm_description  = "This metric monitors the IOPS burst balance available for the DB."
-  alarm_actions      = ["${var.critical-notifications-arn}"]
-  treat_missing_data = "missing"
-}
-
 resource "aws_cloudwatch_metric_alarm" "user_rr_burstbalancealarm" {
   count               = "${var.db-replica-count}"
   alarm_name          = "${var.env}-user-rr-burstbalanace-alarm"


### PR DESCRIPTION
We initially set this alarm up for the sessions database which was
having trouble with the read replica lagging behind by about 10 minutes.

We found that this lag was tied to the available burst balance credits.

We don't need to monitor this for the users database as it doesn't
contain as much data.  Replicating will be fast.