### PR TITLE
reduce the draining time

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -170,6 +170,7 @@ resource "aws_alb_target_group" "admin-tg" {
   port     = "3000"
   protocol = "HTTP"
   vpc_id   = "${var.vpc-id}"
+  deregistration_delay = 10
 
   health_check {
     healthy_threshold   = 3
@@ -177,5 +178,9 @@ resource "aws_alb_target_group" "admin-tg" {
     timeout             = 5
     interval            = 10
     path                = "/healthcheck"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }


### PR DESCRIPTION
we're preparing a change which will destroy the admin. reduce the outage by lowering the draining time.

Due to a [bug in terraform](https://github.com/terraform-providers/terraform-provider-aws/issues/2283), we can't create a new service before destroying as we're
removing placement orders too