### PR TITLE
Populate env variables to whitelist signup bucket

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -87,6 +87,12 @@ resource "aws_ecs_task_definition" "admin-task" {
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
         },{
+          "name": "S3_SIGNUP_WHITELIST_BUCKET",
+          "value": "govwifi-${var.rack-env}-admin"
+        },{
+          "name": "S3_SIGNUP_WHITELIST_OBJECT_KEY",
+          "value": "signup-whitelist.conf"
+        },{
           "name": "S3_WHITELIST_OBJECT_KEY",
           "value": "clients.conf"
         },{


### PR DESCRIPTION
The admin will use this to store the user signup whitelist of domains

This can be refactored to be more general in the future as the env
variables often point to the same bucket but have different names.