### PR TITLE
use the implicitly defined scaling role

### DIFF
--- a/govwifi-api/logging-scaling-policy.tf
+++ b/govwifi-api/logging-scaling-policy.tf
@@ -4,7 +4,6 @@ resource "aws_appautoscaling_target" "logging-ecs-target" {
   resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.logging-api-service.name}"
   max_capacity       = 20
   min_capacity       = 2
-  role_arn           = "${var.ecs-service-role}"
   scalable_dimension = "ecs:service:DesiredCount"
 }
 
@@ -22,7 +21,7 @@ resource "aws_appautoscaling_policy" "ecs-policy-up-logging" {
 
     step_adjustment {
       metric_interval_lower_bound = 0
-      scaling_adjustment = 1
+      scaling_adjustment          = 1
     }
   }
 
@@ -38,12 +37,12 @@ resource "aws_appautoscaling_policy" "ecs-policy-down-logging" {
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
-    adjustment_type    = "ChangeInCapacity"
-    metric_aggregation_type   = "Average"
+    adjustment_type         = "ChangeInCapacity"
+    metric_aggregation_type = "Average"
 
     step_adjustment {
       metric_interval_upper_bound = 0
-      scaling_adjustment = -1
+      scaling_adjustment          = -1
     }
   }
 

--- a/govwifi-api/scaling-policy.tf
+++ b/govwifi-api/scaling-policy.tf
@@ -19,7 +19,6 @@ resource "aws_appautoscaling_target" "auth-ecs-target" {
   resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
   max_capacity       = 20
   min_capacity       = 2
-  role_arn           = "${var.ecs-service-role}"
   scalable_dimension = "ecs:service:DesiredCount"
 }
 
@@ -36,7 +35,7 @@ resource "aws_appautoscaling_policy" "ecs-policy-up" {
 
     step_adjustment {
       metric_interval_lower_bound = 0
-      scaling_adjustment = 1
+      scaling_adjustment          = 1
     }
   }
 
@@ -51,12 +50,12 @@ resource "aws_appautoscaling_policy" "ecs-policy-down" {
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
-    adjustment_type    = "ChangeInCapacity"
-    metric_aggregation_type   = "Average"
+    adjustment_type         = "ChangeInCapacity"
+    metric_aggregation_type = "Average"
 
     step_adjustment {
       metric_interval_upper_bound = 0
-      scaling_adjustment = -1
+      scaling_adjustment          = -1
     }
   }
 


### PR DESCRIPTION
We've actually been trying to assign a role without permission to autoscale.
AWS, in their wisdom, has been assigning the autoscaling service role automatically for us.

This is why we've been seeing state changes.

Let AWS assign the role based on the service namespace