### PR TITLE
NOOP Dublin trying to access the admin S3 bucket

### DIFF
--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -60,6 +60,7 @@ EOF
 }
 
 data "aws_s3_bucket" "admin-bucket" {
+  count  = "${var.user-signup-enabled}"
   bucket = "${var.admin-bucket-name}"
 }
 

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -184,6 +184,7 @@ variable "iam-count" {
 }
 
 variable "admin-bucket-name" {
+  default = ""
   type = "string"
   description = "Name of the admin S3 bucket"
 }


### PR DESCRIPTION
There is no user signup API in Dublin so it's fine to ignore this