### PR TITLE
Add an alarm based on the number of user rejections we're getting

### DIFF
--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -14,9 +14,10 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
     ServiceName = "${aws_ecs_service.logging-api-service.name}"
   }
 
-  alarm_description  = "This alarm tells ECS to scale up based on high CPU - Logging"
-  alarm_actions      = [
-    "${aws_appautoscaling_policy.ecs-policy-up-logging.arn}"
+  alarm_description = "This alarm tells ECS to scale up based on high CPU - Logging"
+
+  alarm_actions = [
+    "${aws_appautoscaling_policy.ecs-policy-up-logging.arn}",
   ]
 
   treat_missing_data = "breaching"
@@ -38,8 +39,66 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
     ServiceName = "${aws_ecs_service.logging-api-service.name}"
   }
 
-  alarm_description  = "This alarm tells ECS to scale in based on low CPU usage - Logging"
-  alarm_actions      = [
-    "${aws_appautoscaling_policy.ecs-policy-down-logging.arn}"
+  alarm_description = "This alarm tells ECS to scale in based on low CPU usage - Logging"
+
+  alarm_actions = [
+    "${aws_appautoscaling_policy.ecs-policy-down-logging.arn}",
+  ]
+}
+
+/*
+resource "aws_cloudwatch_metric_alarm" "radius-access-reject" {
+  count               = "${var.alarm-count}"
+  alarm_name          = "${var.Env-Name}-radius-access-reject"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  threshold           = "0.2"
+  alarm_description   = "Access rejections has exceeded 20%"
+
+  metric_query {
+    id          = "e1"
+    expression  = "rejected"
+    label       = "Rejection rate"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "accepted"
+
+    metric {
+      metric_name = "${aws_cloudwatch_log_metric_filter.radius-access-accept.name}"
+      namespace   = "${local.logging_api_namespace}"
+      period      = "300"
+      stat        = "Sum"
+    }
+  }
+
+  metric_query {
+    id = "rejected"
+
+    metric {
+      metric_name = "${aws_cloudwatch_log_metric_filter.radius-access-reject.name}"
+      namespace   = "${local.logging_api_namespace}"
+      period      = "300"
+      stat        = "Sum"
+    }
+  }
+}
+*/
+
+resource "aws_cloudwatch_metric_alarm" "radius-access-reject" {
+  count               = "${var.alarm-count}"
+  alarm_name          = "${var.Env-Name}-radius-access-reject"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "3"
+  period              = "60"
+  threshold           = "1000"
+  alarm_description   = "Access rejections has exceeded 1000"
+  metric_name         = "${aws_cloudwatch_log_metric_filter.radius-access-reject.metric_transformation.0.name}"
+  namespace           = "${local.logging_api_namespace}"
+  statistic           = "Sum"
+
+  alarm_actions = [
+    "${var.devops-notifications-arn}",
   ]
 }

--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -46,46 +46,6 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
   ]
 }
 
-/*
-resource "aws_cloudwatch_metric_alarm" "radius-access-reject" {
-  count               = "${var.alarm-count}"
-  alarm_name          = "${var.Env-Name}-radius-access-reject"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "2"
-  threshold           = "0.2"
-  alarm_description   = "Access rejections has exceeded 20%"
-
-  metric_query {
-    id          = "e1"
-    expression  = "rejected"
-    label       = "Rejection rate"
-    return_data = "true"
-  }
-
-  metric_query {
-    id = "accepted"
-
-    metric {
-      metric_name = "${aws_cloudwatch_log_metric_filter.radius-access-accept.name}"
-      namespace   = "${local.logging_api_namespace}"
-      period      = "300"
-      stat        = "Sum"
-    }
-  }
-
-  metric_query {
-    id = "rejected"
-
-    metric {
-      metric_name = "${aws_cloudwatch_log_metric_filter.radius-access-reject.name}"
-      namespace   = "${local.logging_api_namespace}"
-      period      = "300"
-      stat        = "Sum"
-    }
-  }
-}
-*/
-
 resource "aws_cloudwatch_metric_alarm" "radius-access-reject" {
   count               = "${var.alarm-count}"
   alarm_name          = "${var.Env-Name}-radius-access-reject"

--- a/govwifi-api/locals.tf
+++ b/govwifi-api/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  logging_api_namespace = "${var.Env-Name}-logging-api"
+}

--- a/govwifi-api/logging-metrics.tf
+++ b/govwifi-api/logging-metrics.tf
@@ -1,0 +1,29 @@
+resource "aws_cloudwatch_log_metric_filter" "radius-access-reject" {
+  count          = "${aws_cloudwatch_log_group.logging-api-log-group.count}"
+  name           = "${var.Env-Name}-radius-access-reject"
+  pattern        = "\"\\\"authentication_result\\\": \\\"Access-Reject\\\"\""
+  log_group_name = "${aws_cloudwatch_log_group.logging-api-log-group.name}"
+
+  metric_transformation {
+    name          = "${var.Env-Name}-radius-access-reject-count"
+    namespace     = "${local.logging_api_namespace}"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "radius-access-accept" {
+  count = "${aws_cloudwatch_log_group.logging-api-log-group.count}"
+  name  = "${var.Env-Name}-radius-access-accept"
+
+  # match all accepts, but not the healthchecks
+  pattern        = "\"\\\"authentication_result\\\": \\\"Access-Accept\\\"\" -\"\\\"username\\\": \\\"HEALTH\\\"\""
+  log_group_name = "${aws_cloudwatch_log_group.logging-api-log-group.name}"
+
+  metric_transformation {
+    name          = "${var.Env-Name}-radius-access-accept-count"
+    namespace     = "${local.logging_api_namespace}"
+    value         = "1"
+    default_value = "0"
+  }
+}


### PR DESCRIPTION
While pinning it to a hard number isn't ideal, it gives us a rough alarm to work with for a while.

Large amounts of rejections can signify issues with the infrastructure, and is more of a "finger in the air" test. We'd normally expect other alarms to go off at the same time, such as a database going out of sync.