### PR TITLE
add a global dns name for the api cluster

### DIFF
--- a/govwifi-api/certs.tf
+++ b/govwifi-api/certs.tf
@@ -1,0 +1,15 @@
+resource "aws_acm_certificate" "api-elb-global" {
+  count             = "${aws_lb.api-alb.count}"
+  domain_name       = "${aws_route53_record.elb_global.fqdn}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "api-elb-global" {
+  count                   = "${aws_acm_certificate.api-elb-global.count}"
+  certificate_arn         = "${aws_acm_certificate.api-elb-global.arn}"
+  validation_record_fqdns = ["${aws_route53_record.elb_global_cert_validation.fqdn}"]
+}

--- a/govwifi-api/elb.tf
+++ b/govwifi-api/elb.tf
@@ -23,3 +23,13 @@ resource "aws_alb_listener" "alb_listener" {
     type             = "forward"
   }
 }
+
+resource "aws_lb_listener_certificate" "api-elb-global" {
+  count           = "${aws_lb.api-alb.count}"
+  listener_arn    = "${aws_alb_listener.alb_listener.arn}"
+  certificate_arn = "${aws_acm_certificate.api-elb-global.arn}"
+
+  depends_on = [
+    "aws_acm_certificate_validation.api-elb-global",
+  ]
+}

--- a/govwifi-api/outputs.tf
+++ b/govwifi-api/outputs.tf
@@ -1,0 +1,6 @@
+output "api-base-url" {
+  description = "Global base url for API endpoints"
+
+  # port 8443 is defined by by the ECS
+  value = "https://${aws_route53_record.elb_global.0.fqdn}:8443"
+}

--- a/govwifi-api/outputs.tf
+++ b/govwifi-api/outputs.tf
@@ -2,5 +2,5 @@ output "api-base-url" {
   description = "Global base url for API endpoints"
 
   # port 8443 is defined by by the ECS
-  value = "https://${aws_route53_record.elb_global.0.fqdn}:8443"
+  value = "https://${aws_route53_record.elb_global.0.fqdn}:${aws_alb_listener.alb_listener.port}"
 }

--- a/govwifi-api/outputs.tf
+++ b/govwifi-api/outputs.tf
@@ -1,6 +1,4 @@
 output "api-base-url" {
   description = "Global base url for API endpoints"
-
-  # port 8443 is defined by by the ECS
-  value = "https://${aws_route53_record.elb_global.0.fqdn}:${aws_alb_listener.alb_listener.port}"
+  value       = "https://${aws_route53_record.elb_global.0.fqdn}:${aws_alb_listener.alb_listener.port}"
 }

--- a/govwifi-api/route53.tf
+++ b/govwifi-api/route53.tf
@@ -3,9 +3,28 @@ resource "aws_route53_record" "elb" {
   zone_id = "${var.route53-zone-id}"
   name    = "api-elb.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   type    = "A"
+
   alias {
     name                   = "${aws_lb.api-alb.dns_name}"
     zone_id                = "${aws_lb.api-alb.zone_id}"
     evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "elb_global" {
+  count          = "${var.backend-elb-count}"
+  zone_id        = "${var.route53-zone-id}"
+  name           = "api-elb.${var.Env-Subdomain}.service.gov.uk"
+  type           = "A"
+  set_identifier = "${var.aws-region}"
+
+  alias {
+    name                   = "${aws_route53_record.elb.name}"
+    zone_id                = "${aws_route53_record.elb.zone_id}"
+    evaluate_target_health = true
+  }
+
+  latency_routing_policy {
+    region = "${var.aws-region}"
   }
 }

--- a/govwifi-api/route53.tf
+++ b/govwifi-api/route53.tf
@@ -28,3 +28,12 @@ resource "aws_route53_record" "elb_global" {
     region = "${var.aws-region}"
   }
 }
+
+resource "aws_route53_record" "elb_global_cert_validation" {
+  count   = "${aws_acm_certificate.api-elb-global.count}"
+  name    = "${aws_acm_certificate.api-elb-global.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.api-elb-global.domain_validation_options.0.resource_record_type}"
+  zone_id = "${var.route53-zone-id}"
+  records = ["${aws_acm_certificate.api-elb-global.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}


### PR DESCRIPTION
This allows us to have a single point of entry, and let Route53 deal with what the best target is.