### PR TITLE
set up route53 health checks + alarms

### DIFF
--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "radius-hc" {
   }
 
   alarm_actions = [
-    "${var.critical-notifications-arn}",
+    "${var.route53-critical-notifications-arn}",
   ]
 }
 
@@ -37,6 +37,6 @@ resource "aws_cloudwatch_metric_alarm" "radius-latency" {
   }
 
   alarm_actions = [
-    "${var.critical-notifications-arn}",
+    "${var.route53-critical-notifications-arn}",
   ]
 }

--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -1,0 +1,33 @@
+resource "aws_cloudwatch_metric_alarm" "radius-hc" {
+  provider            = "aws.route53-alarms"
+  count               = "${aws_route53_health_check.radius.count}"
+  alarm_name          = "${element(aws_route53_health_check.radius.*.reference_name, count.index)}-hc"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "1"
+
+  dimensions {
+    HealthCheckId = "${element(aws_route53_health_check.radius.*.id, count.index)}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "radius-latency" {
+  provider            = "aws.route53-alarms"
+  count               = "${aws_route53_health_check.radius.count}"
+  alarm_name          = "${element(aws_route53_health_check.radius.*.reference_name, count.index)}-latency"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "TimeToFirstByte"
+  namespace           = "AWS/Route53"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "1000"
+
+  dimensions {
+    HealthCheckId = "${element(aws_route53_health_check.radius.*.id, count.index)}"
+  }
+}

--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -9,10 +9,15 @@ resource "aws_cloudwatch_metric_alarm" "radius-hc" {
   period              = "60"
   statistic           = "Minimum"
   threshold           = "1"
+  treat_missing_data  = "breaching"
 
   dimensions {
     HealthCheckId = "${element(aws_route53_health_check.radius.*.id, count.index)}"
   }
+
+  alarm_actions = [
+    "${var.critical-notifications-arn}",
+  ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "radius-latency" {
@@ -30,4 +35,8 @@ resource "aws_cloudwatch_metric_alarm" "radius-latency" {
   dimensions {
     HealthCheckId = "${element(aws_route53_health_check.radius.*.id, count.index)}"
   }
+
+  alarm_actions = [
+    "${var.critical-notifications-arn}",
+  ]
 }

--- a/govwifi-frontend/route53.tf
+++ b/govwifi-frontend/route53.tf
@@ -8,3 +8,18 @@ resource "aws_route53_record" "radius" {
   records    = ["${element(aws_instance.radius.*.public_dns, count.index)}"]
   depends_on = ["aws_instance.radius", "aws_eip_association.eip_assoc"]
 }
+
+resource "aws_route53_health_check" "radius" {
+  count             = "${aws_eip_association.eip_assoc.count}"
+  reference_name    = "${format("${var.Env-Name}-${var.aws-region-name}-frontend-%d", count.index + 1)}"
+  ip_address        = "${element(aws_eip_association.eip_assoc.*.public_ip, count.index)}"
+  port              = 3000
+  type              = "HTTP"
+  request_interval  = "30"
+  failure_threshold = "3"
+  measure_latency   = true
+
+  tags {
+    Name = "${format("${var.Env-Name}-${var.aws-region-name}-%d", count.index + 1)}"
+  }
+}

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -101,6 +101,6 @@ variable "bastion-ips" {
   default     = []
 }
 
-variable "critical-notifications-arn" {
+variable "route53-critical-notifications-arn" {
   type = "string"
 }

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -100,3 +100,7 @@ variable "bastion-ips" {
   type        = "list"
   default     = []
 }
+
+variable "critical-notifications-arn" {
+  type = "string"
+}


### PR DESCRIPTION
These were originally snowflakes; move them into terraform.

This introduces needing a new provider for us-east-1, named 'route53-alarms'.