### PR TITLE
make a load balancer specific for the user signup api

### DIFF
--- a/govwifi-api/user-signup-api-certs.tf
+++ b/govwifi-api/user-signup-api-certs.tf
@@ -1,0 +1,31 @@
+resource "aws_acm_certificate" "user-signup-api-global" {
+  count             = "${aws_lb.user-signup-api.count}"
+  domain_name       = "${aws_route53_record.user-signup-api-global.fqdn}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "user-signup-api-global" {
+  count                   = "${aws_acm_certificate.user-signup-api-global.count}"
+  certificate_arn         = "${aws_acm_certificate.user-signup-api-global.arn}"
+  validation_record_fqdns = ["${aws_route53_record.user-signup-api-global-verification.fqdn}"]
+}
+
+resource "aws_acm_certificate" "user-signup-api-regional" {
+  count             = "${aws_lb.user-signup-api.count}"
+  domain_name       = "${aws_route53_record.user-signup-api-regional.fqdn}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "user-signup-api-regional" {
+  count                   = "${aws_acm_certificate.user-signup-api-regional.count}"
+  certificate_arn         = "${aws_acm_certificate.user-signup-api-regional.arn}"
+  validation_record_fqdns = ["${aws_route53_record.user-signup-api-regional-verification.fqdn}"]
+}

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -206,20 +206,3 @@ resource "aws_alb_target_group" "user-signup-api-tg" {
     path                = "/healthcheck"
   }
 }
-
-resource "aws_alb_listener_rule" "user-signup-api-lr" {
-  count        = "${var.user-signup-enabled}"
-  depends_on   = ["aws_alb_target_group.user-signup-api-tg"]
-  listener_arn = "${aws_alb_listener.alb_listener.arn}"
-  priority     = 2
-
-  action {
-    type             = "forward"
-    target_group_arn = "${aws_alb_target_group.user-signup-api-tg.id}"
-  }
-
-  condition {
-    field  = "path-pattern"
-    values = ["/user-signup/*"]
-  }
-}

--- a/govwifi-api/user-signup-api-lb.tf
+++ b/govwifi-api/user-signup-api-lb.tf
@@ -1,0 +1,36 @@
+resource "aws_lb" "user-signup-api" {
+  count              = "${var.user-signup-enabled}"
+  name               = "user-signup-api-${var.Env-Name}"
+  internal           = false
+  subnets            = ["${var.subnet-ids}"]
+  security_groups    = ["${var.elb-sg-list}"]
+  load_balancer_type = "application"
+
+  tags {
+    Name = "user-signup-api-${var.Env-Name}"
+  }
+}
+
+resource "aws_lb_listener" "user-signup-api" {
+  count             = "${aws_lb.user-signup-api.count}"
+  load_balancer_arn = "${aws_lb.user-signup-api.arn}"
+  port              = "8443"
+  protocol          = "HTTPS"
+  certificate_arn   = "${aws_acm_certificate.user-signup-api-global.arn}"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+
+  default_action {
+    target_group_arn = "${aws_alb_target_group.user-signup-api-tg.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener_certificate" "user-signup-api-regional" {
+  count           = "${aws_lb.user-signup-api.count}"
+  listener_arn    = "${aws_lb_listener.user-signup-api.arn}"
+  certificate_arn = "${aws_acm_certificate.user-signup-api-regional.arn}"
+
+  depends_on = [
+    "aws_acm_certificate_validation.user-signup-api-regional",
+  ]
+}

--- a/govwifi-api/user-signup-api-route53.tf
+++ b/govwifi-api/user-signup-api-route53.tf
@@ -1,0 +1,48 @@
+resource "aws_route53_record" "user-signup-api-regional" {
+  count   = "${aws_lb.user-signup-api.count}"
+  zone_id = "${var.route53-zone-id}"
+  name    = "user-signup-api.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.user-signup-api.dns_name}"
+    zone_id                = "${aws_lb.user-signup-api.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "user-signup-api-global" {
+  count          = "${aws_lb.user-signup-api.count}"
+  zone_id        = "${var.route53-zone-id}"
+  name           = "user-signup-api.${var.Env-Subdomain}.service.gov.uk"
+  type           = "A"
+  set_identifier = "${var.aws-region}"
+
+  alias {
+    name                   = "${aws_route53_record.user-signup-api-regional.name}"
+    zone_id                = "${aws_route53_record.user-signup-api-regional.zone_id}"
+    evaluate_target_health = true
+  }
+
+  latency_routing_policy {
+    region = "${var.aws-region}"
+  }
+}
+
+resource "aws_route53_record" "user-signup-api-regional-verification" {
+  count   = "${aws_acm_certificate.user-signup-api-regional.count}"
+  name    = "${aws_acm_certificate.user-signup-api-regional.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.user-signup-api-regional.domain_validation_options.0.resource_record_type}"
+  zone_id = "${var.route53-zone-id}"
+  records = ["${aws_acm_certificate.user-signup-api-regional.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}
+
+resource "aws_route53_record" "user-signup-api-global-verification" {
+  count   = "${aws_acm_certificate.user-signup-api-global.count}"
+  name    = "${aws_acm_certificate.user-signup-api-global.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.user-signup-api-global.domain_validation_options.0.resource_record_type}"
+  zone_id = "${var.route53-zone-id}"
+  records = ["${aws_acm_certificate.user-signup-api-global.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}


### PR DESCRIPTION
This is an internet facing API, so move it to a seperate load balancer.
It will allow us to lock down the other services so only our services can use them.

This is part of the move to Gov Notify.