### PR TITLE
allow not creating a bastion instance when setting up the backend

### DIFF
--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -24,6 +24,10 @@ variable "zone-subnets" {
   type = "map"
 }
 
+variable "enable-bastion" {
+  default = true
+}
+
 variable "bastion-ami" {}
 
 variable "bastion-instance-type" {}


### PR DESCRIPTION
This allows us to set up a region while still utilising our pre-existing bastion servers (something we already do)