### PR TITLE
lower the memory requirement of the frontend task definition

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -22,7 +22,7 @@ resource "aws_ecs_task_definition" "radius-task" {
 [
   {
     "volumesFrom": [],
-    "memory": 2000,
+    "memory": 1500,
     "extraHosts": null,
     "dnsServers": null,
     "disableNetworking": null,


### PR DESCRIPTION
By having the memory requirement set to 2000, we always get reports that
there aren't enough resources to spin up a new instance.

Lower to 1500 to easily fit 2 instances within one server of 4000mb.

This solves the slow rotation problem.