### PR TITLE
Refactor security groups terraform

### DIFF
--- a/govwifi-admin/outputs.tf
+++ b/govwifi-admin/outputs.tf
@@ -2,10 +2,6 @@ output "db-hostname" {
   value = "${aws_db_instance.admin_db.address}"
 }
 
-output "admin-ec2-out-sg-id" {
-  value = "${aws_security_group.admin-ec2-out.id}"
-}
-
 output "admin-bucket-name" {
   value = "${aws_s3_bucket.admin-bucket.bucket}"
 }

--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -16,7 +16,7 @@ resource "aws_db_instance" "db" {
   multi_az                    = true
   storage_encrypted           = "${var.db-encrypt-at-rest}"
   db_subnet_group_name        = "wifi-${var.Env-Name}-subnets"
-  vpc_security_group_ids      = ["${var.db-sg-list}"]
+  vpc_security_group_ids      = ["${aws_security_group.be-db-in.id}"]
   depends_on                  = ["aws_iam_role.rds-monitoring-role"]
   monitoring_role_arn         = "${aws_iam_role.rds-monitoring-role.arn}"
   monitoring_interval         = "${var.db-monitoring-interval}"
@@ -50,7 +50,7 @@ resource "aws_db_instance" "read_replica" {
   backup_retention_period     = 0
   multi_az                    = false
   storage_encrypted           = "${var.db-encrypt-at-rest}"
-  vpc_security_group_ids      = ["${var.db-sg-list}"]
+  vpc_security_group_ids      = ["${aws_security_group.be-db-in.id}"]
   depends_on                  = ["aws_iam_role.rds-monitoring-role"]
   monitoring_role_arn         = "${aws_iam_role.rds-monitoring-role.arn}"
   monitoring_interval         = "${var.db-monitoring-interval}"

--- a/govwifi-backend/db-users.tf
+++ b/govwifi-backend/db-users.tf
@@ -16,7 +16,7 @@ resource "aws_db_instance" "users_db" {
   multi_az                    = true
   storage_encrypted           = "${var.db-encrypt-at-rest}"
   db_subnet_group_name        = "wifi-${var.Env-Name}-subnets"
-  vpc_security_group_ids      = ["${var.db-sg-list}"]
+  vpc_security_group_ids      = ["${aws_security_group.be-db-in.id}"]
   depends_on                  = ["aws_iam_role.rds-monitoring-role"]
   monitoring_role_arn         = "${aws_iam_role.rds-monitoring-role.arn}"
   monitoring_interval         = "${var.db-monitoring-interval}"
@@ -49,7 +49,7 @@ resource "aws_db_instance" "users_read_replica" {
   password                    = "${var.user-db-password}"
   backup_retention_period     = 0
   multi_az                    = true
-  vpc_security_group_ids      = ["${var.db-sg-list}"]
+  vpc_security_group_ids      = ["${aws_security_group.be-db-in.id}"]
   depends_on                  = ["aws_iam_role.rds-monitoring-role"]
   monitoring_role_arn         = "${aws_iam_role.rds-monitoring-role.arn}"
   monitoring_interval         = "${var.db-monitoring-interval}"

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -5,7 +5,11 @@ resource "aws_instance" "management" {
   instance_type          = "${var.bastion-instance-type}"
   key_name               = "${var.bastion-ssh-key-name}"
   subnet_id              = "${aws_subnet.wifi-backend-subnet.0.id}"
-  vpc_security_group_ids = ["${var.mgt-sg-list}"]
+  vpc_security_group_ids = [
+    "${aws_security_group.be-vpn-in.id}",
+    "${aws_security_group.be-vpn-out.id}",
+    "${aws_security_group.be-ecs-out.id}",
+  ]
   iam_instance_profile   = "${aws_iam_instance_profile.bastion-instance-profile.id}"
   monitoring             = "${var.enable-bastion-monitoring}"
 

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -1,17 +1,19 @@
 # Using custom ubuntu AMI id, as the micro size is only supported for paravirtual images.
 resource "aws_instance" "management" {
-  count                  = "${var.enable-bastion}"
-  ami                    = "${var.bastion-ami}"
-  instance_type          = "${var.bastion-instance-type}"
-  key_name               = "${var.bastion-ssh-key-name}"
-  subnet_id              = "${aws_subnet.wifi-backend-subnet.0.id}"
+  count         = "${var.enable-bastion}"
+  ami           = "${var.bastion-ami}"
+  instance_type = "${var.bastion-instance-type}"
+  key_name      = "${var.bastion-ssh-key-name}"
+  subnet_id     = "${aws_subnet.wifi-backend-subnet.0.id}"
+
   vpc_security_group_ids = [
     "${aws_security_group.be-vpn-in.id}",
     "${aws_security_group.be-vpn-out.id}",
     "${aws_security_group.be-ecs-out.id}",
   ]
-  iam_instance_profile   = "${aws_iam_instance_profile.bastion-instance-profile.id}"
-  monitoring             = "${var.enable-bastion-monitoring}"
+
+  iam_instance_profile = "${aws_iam_instance_profile.bastion-instance-profile.id}"
+  monitoring           = "${var.enable-bastion-monitoring}"
 
   depends_on = [
     "aws_iam_instance_profile.bastion-instance-profile",

--- a/govwifi-backend/outputs.tf
+++ b/govwifi-backend/outputs.tf
@@ -17,3 +17,7 @@ output "ecs-service-role" {
 output "rds-monitoring-role" {
   value = "${aws_iam_role.rds-monitoring-role.arn}"
 }
+
+output "be-admin-in" {
+  value = "${aws_security_group.be-admin-in.*.id}"
+}

--- a/govwifi-backend/outputs.tf
+++ b/govwifi-backend/outputs.tf
@@ -19,5 +19,5 @@ output "rds-monitoring-role" {
 }
 
 output "be-admin-in" {
-  value = "${aws_security_group.be-admin-in.*.id}"
+  value = "${aws_security_group.be-admin-in.id}"
 }

--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -1,0 +1,214 @@
+resource "aws_security_group" "be-ecs-out" {
+  name        = "be-ecs-out"
+  description = "Allow the ECS agent to talk to the ECS endpoints"
+  vpc_id      = "${aws_vpc.wifi-backend.id}"
+
+  tags {
+    Name = "${title(var.Env-Name)} Backend ECS out"
+  }
+
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 123
+    to_port     = 123
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
+  }
+
+  egress {
+    from_port   = 11211
+    to_port     = 11211
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
+  }
+}
+
+resource "aws_security_group" "be-db-in" {
+  name        = "be-db-in"
+  description = "Allow connections to the DB"
+  vpc_id      = "${aws_vpc.wifi-backend.id}"
+
+  tags {
+    Name = "${title(var.Env-Name)} Backend DB in"
+  }
+
+  ingress {
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
+  }
+}
+
+resource "aws_security_group" "be-admin-in" {
+  name        = "be-admin-in"
+  description = "Allow inbound SSH from administrators"
+  vpc_id      = "${aws_vpc.wifi-backend.id}"
+
+  tags {
+    Name = "${title(var.Env-Name)} Backend Admin in"
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.bastion-server-IP)}", "${split(",", var.backend-subnet-IPs)}"]
+  }
+}
+
+resource "aws_security_group" "be-vpn-in" {
+  name        = "be-vpn-in"
+  description = "Allow inbound SSH from VPN IPs to the bastion only"
+  vpc_id      = "${aws_vpc.wifi-backend.id}"
+
+  tags {
+    Name = "${title(var.Env-Name)} Backend VPN in"
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.administrator-IPs)}"]
+  }
+}
+
+resource "aws_security_group" "be-vpn-out" {
+  name        = "be-vpn-out"
+  description = "Allow outbound SSH from bastion"
+  vpc_id      = "${aws_vpc.wifi-backend.id}"
+
+  tags {
+    Name = "${title(var.Env-Name)} Backend VPN out"
+  }
+
+  egress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+
+    cidr_blocks = [
+      "${split(",", var.backend-subnet-IPs)}",
+      "${split(",", var.frontend-subnet-IPs)}",
+      "${split(",", var.frontend-radius-IPs)}",
+    ]
+  }
+}
+
+resource "aws_security_group" "be-radius-api-in" {
+  name        = "be-radius-api-in"
+  description = "Allow inbound API calls from the RADIUS servers"
+  vpc_id      = "${aws_vpc.wifi-backend.id}"
+
+  tags {
+    Name = "${title(var.Env-Name)} Backend RADIUS API in"
+  }
+
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",",var.frontend-radius-IPs)}"]
+  }
+
+  ingress {
+    from_port   = 8443
+    to_port     = 8443
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",",var.frontend-radius-IPs)}"]
+  }
+}
+
+resource "aws_security_group" "be-sns-in" {
+  count       = "${var.sns-count}"
+  name        = "be-sns-in"
+  description = "Allow inbound calls from SNS"
+  vpc_id      = "${aws_vpc.wifi-backend.id}"
+
+  tags {
+    Name = "${title(var.Env-Name)} Backend SNS in"
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.amazon-sns-IPs)}"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.amazon-sns-IPs)}", "${split(",", var.bastion-server-IP)}"]
+  }
+}
+
+resource "aws_security_group" "be-elb-out" {
+  name        = "be-elb-out"
+  description = "Allow outbound calls from the backend"
+  vpc_id      = "${aws_vpc.wifi-backend.id}"
+
+  tags {
+    Name = "${title(var.Env-Name)} Backend ELB out"
+  }
+
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
+  }
+
+  egress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
+  }
+}
+
+resource "aws_security_group" "be-backend-in" {
+  name        = "be-backend-in"
+  description = "Allow inbound traffic from ELB"
+  vpc_id      = "${aws_vpc.wifi-backend.id}"
+
+  tags {
+    Name = "${title(var.Env-Name)} Backend Servers in"
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
+  }
+
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
+  }
+}

--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -110,7 +110,6 @@ resource "aws_security_group" "be-vpn-out" {
 
     cidr_blocks = [
       "${split(",", var.backend-subnet-IPs)}",
-      "${split(",", var.frontend-subnet-IPs)}",
       "${split(",", var.frontend-radius-IPs)}",
     ]
   }
@@ -137,78 +136,5 @@ resource "aws_security_group" "be-radius-api-in" {
     to_port     = 8443
     protocol    = "tcp"
     cidr_blocks = ["${split(",",var.frontend-radius-IPs)}"]
-  }
-}
-
-resource "aws_security_group" "be-sns-in" {
-  count       = "${var.sns-count}"
-  name        = "be-sns-in"
-  description = "Allow inbound calls from SNS"
-  vpc_id      = "${aws_vpc.wifi-backend.id}"
-
-  tags {
-    Name = "${title(var.Env-Name)} Backend SNS in"
-  }
-
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["${split(",", var.amazon-sns-IPs)}"]
-  }
-
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["${split(",", var.amazon-sns-IPs)}", "${split(",", var.bastion-server-IP)}"]
-  }
-}
-
-resource "aws_security_group" "be-elb-out" {
-  name        = "be-elb-out"
-  description = "Allow outbound calls from the backend"
-  vpc_id      = "${aws_vpc.wifi-backend.id}"
-
-  tags {
-    Name = "${title(var.Env-Name)} Backend ELB out"
-  }
-
-  egress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
-  }
-
-  egress {
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
-  }
-}
-
-resource "aws_security_group" "be-backend-in" {
-  name        = "be-backend-in"
-  description = "Allow inbound traffic from ELB"
-  vpc_id      = "${aws_vpc.wifi-backend.id}"
-
-  tags {
-    Name = "${title(var.Env-Name)} Backend Servers in"
-  }
-
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
-  }
-
-  ingress {
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    cidr_blocks = ["${split(",", var.backend-subnet-IPs)}"]
   }
 }

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -17,7 +17,6 @@ variable "aws-region-name" {}
 variable "backend-subnet-IPs" {}
 variable "administrator-IPs" {}
 variable "bastion-server-IP" {}
-variable "amazon-sns-IPs" {}
 variable "frontend-radius-IPs" {}
 
 variable "zone-count" {}
@@ -119,12 +118,4 @@ variable "rds-kms-key-id" {
 variable "user-replica-source-db" {
   type    = "string"
   default = ""
-}
-
-variable "sns-count" {
-  default = 1
-}
-
-variable "admin-count" {
-  default = 1
 }

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -18,7 +18,6 @@ variable "backend-subnet-IPs" {}
 variable "administrator-IPs" {}
 variable "bastion-server-IP" {}
 variable "amazon-sns-IPs" {}
-variable "frontend-subnet-IPs" {}
 variable "frontend-radius-IPs" {}
 
 variable "zone-count" {}

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -14,6 +14,13 @@ variable "aws-region" {}
 
 variable "aws-region-name" {}
 
+variable "backend-subnet-IPs" {}
+variable "administrator-IPs" {}
+variable "bastion-server-IP" {}
+variable "amazon-sns-IPs" {}
+variable "frontend-subnet-IPs" {}
+variable "frontend-radius-IPs" {}
+
 variable "zone-count" {}
 
 variable "zone-names" {
@@ -86,14 +93,6 @@ variable "user-rr-storage-gb" {
   default = 20
 }
 
-variable "mgt-sg-list" {
-  type = "list"
-}
-
-variable "db-sg-list" {
-  type = "list"
-}
-
 variable "critical-notifications-arn" {}
 
 variable "capacity-notifications-arn" {}
@@ -121,4 +120,12 @@ variable "rds-kms-key-id" {
 variable "user-replica-source-db" {
   type    = "string"
   default = ""
+}
+
+variable "sns-count" {
+  default = 1
+}
+
+variable "admin-count" {
+  default = 1
 }


### PR DESCRIPTION
There was a lot of duplication with the security groups being defined
next to the main files.  By moving this closer to where it is being
used, we only need to define it once.