### PR TITLE
Allow listing objects in a bucket for the admin

### DIFF
--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -69,6 +69,12 @@ resource "aws_iam_role_policy" "ecs-admin-instance-policy" {
         "s3:DeleteObject"
       ],
       "Resource": ["${aws_s3_bucket.admin-mou-bucket.arn}/*"]
+    },{
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": ["${aws_s3_bucket.admin-mou-bucket.arn}"]
     }
   ]
 }


### PR DESCRIPTION
We are getting access denied when trying to upload an MOU template.
This is due to the way that ActiveStorage works with S3, it requires
s3:ListBucket permissions.

https://github.com/rails/rails/issues/32066