### PR TITLE
Remove deprecated tasks

### DIFF
--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -50,31 +50,6 @@ resource "aws_iam_role_policy" "logging-scheduled-task-policy" {
 DOC
 }
 
-resource "aws_cloudwatch_event_target" "logging-publish-daily-statistics" {
-  count     = "${var.logging-enabled}"
-  target_id = "${var.Env-Name}-logging-daily-statistics"
-  arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.daily_statistics_logging_event.name}"
-  role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
-
-  ecs_target = {
-    task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.logging-api-scheduled-task.arn}"
-    launch_type         = "EC2"
-  }
-
-  input = <<EOF
-{
-  "containerOverrides": [
-    {
-      "name": "logging",
-      "command": ["bundle", "exec", "rake", "publish_daily_statistics"]
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_cloudwatch_event_target" "logging-publish-weekly-statistics" {
   count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-weekly-statistics"


### PR DESCRIPTION
## What

We just removed the `publish_daily_statistics` rake task from the
logging api as we don't need it any more. However, the ECS scheduled
task is still running, and can't find the rake task. We need to delete
this scheduled task from the infrastructure.

This is causing throwing a RuntimeError caught by Sentry and false
alarming our Slack channel.

## How to review

- Sanity check
- Make sure the tasks are in fact removed
- Tell me off as much as possible as this is my first PR and attempt at supporting GovWifi