### PR TITLE
  Add roaming users environment variable

### DIFF
--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -225,6 +225,9 @@ resource "aws_ecs_task_definition" "logging-api-scheduled-task" {
           "name": "PERFORMANCE_BEARER_UNIQUE_USERS",
           "value": "${var.performance-bearer-unique-users}"
         },{
+          "name": "PERFORMANCE_BEARER_ROAMING_USERS",
+          "value": "${var.performance-bearer-roaming-users}"
+        },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_BUCKET",
           "value": "govwifi-${var.rack-env}-admin"
         },{

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -98,6 +98,10 @@ variable "performance-bearer-active-users" {
   default = ""
 }
 
+variable "performance-bearer-roaming-users" {
+  default = ""
+}
+
 variable "performance-bearer-unique-users" {
   default = ""
 }


### PR DESCRIPTION
  This is the bearer token used for sending roaming statistics to the performance
  platform