### PR TITLE
Set up the new terraform configs to run from their new locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ terraform.tfstate.*.backup
 terraform/*/*.zip
 
 secrets.auto.tfvars
+variables.auto.tfvars
+govwifi/wordlist-short

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -16,7 +16,7 @@ module "tfstate" {
     "aws" = "aws.AWS-main"
   }
 
-  source             = "../modules/terraform-state"
+  source             = "../../terraform-state"
   product-name       = "${var.product-name}"
   Env-Name           = "${var.Env-Name}"
   aws-account-id     = "${var.aws-account-id}"
@@ -47,7 +47,7 @@ module "govwifi-keys" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/govwifi-keys"
+  source = "../../govwifi-keys"
 }
 
 # London Backend ==================================================================
@@ -56,7 +56,7 @@ module "backend" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-backend"
+  source        = "../../govwifi-backend"
   env           = "staging"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
@@ -124,7 +124,7 @@ module "frontend" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-frontend"
+  source        = "../../govwifi-frontend"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
 
@@ -192,7 +192,7 @@ module "govwifi-admin" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-admin"
+  source        = "../../govwifi-admin"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
 
@@ -264,7 +264,7 @@ module "api" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-api"
+  source        = "../../govwifi-api"
   env           = "staging"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
@@ -343,7 +343,7 @@ module "notifications" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-staging"
@@ -355,7 +355,7 @@ module "route53-notifications" {
     "aws" = "aws.route53-alarms"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-staging-london"

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -118,9 +118,18 @@ variable "user-rr-hostname" {
   default     = "users-rr.london.staging.wifi.service.gov.uk"
 }
 
+variable "admin-db-username" {
+  type        = "string"
+  description = "Database main username for govwifi-admin"
+}
 variable "admin-db-password" {
   type        = "string"
   description = "Database main password for govwifi-admin"
+}
+
+variable "zendesk-api-user" {
+  type        = "string"
+  description = "Username for authenticating with Zendesk API"
 }
 
 variable "zendesk-api-token" {

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -16,7 +16,7 @@ module "tfstate" {
     "aws" = "aws.AWS-main"
   }
 
-  source             = "../modules/terraform-state"
+  source             = "../../terraform-state"
   product-name       = "${var.product-name}"
   Env-Name           = "${var.Env-Name}"
   aws-account-id     = "${var.aws-account-id}"
@@ -48,7 +48,7 @@ module "backend" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-backend"
+  source        = "../../govwifi-backend"
   env           = "staging"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
@@ -126,7 +126,7 @@ module "emails" {
     "aws" = "aws.AWS-main"
   }
 
-  source                   = "../modules/govwifi-emails"
+  source                   = "../../govwifi-emails"
   product-name             = "${var.product-name}"
   Env-Name                 = "${var.Env-Name}"
   Env-Subdomain            = "${var.Env-Subdomain}"
@@ -147,7 +147,7 @@ module "govwifi-keys" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/govwifi-keys"
+  source = "../../govwifi-keys"
 }
 
 # Frontend ====================================================================
@@ -156,7 +156,7 @@ module "frontend" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-frontend"
+  source        = "../../govwifi-frontend"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
 
@@ -219,7 +219,7 @@ module "api" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-api"
+  source        = "../../govwifi-api"
   env           = "staging"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
@@ -296,7 +296,7 @@ module "notifications" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-staging"
@@ -308,7 +308,7 @@ module "route53-notifications" {
     "aws" = "aws.route53-alarms"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-staging"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -16,7 +16,7 @@ module "tfstate" {
     "aws" = "aws.AWS-main"
   }
 
-  source             = "../modules/terraform-state"
+  source             = "../../terraform-state"
   product-name       = "${var.product-name}"
   Env-Name           = "${var.Env-Name}"
   aws-account-id     = "${var.aws-account-id}"
@@ -47,7 +47,7 @@ module "govwifi-keys" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/govwifi-keys"
+  source = "../../govwifi-keys"
 }
 
 module "backend" {
@@ -55,7 +55,7 @@ module "backend" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-backend"
+  source        = "../../govwifi-backend"
   env           = "production"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
@@ -124,7 +124,7 @@ module "frontend" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-frontend"
+  source        = "../../govwifi-frontend"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
 
@@ -190,7 +190,7 @@ module "govwifi-admin" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-admin"
+  source        = "../../govwifi-admin"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
 
@@ -262,7 +262,7 @@ module "api" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-api"
+  source        = "../../govwifi-api"
   env           = "production"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
@@ -335,7 +335,7 @@ module "critical-notifications" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-wifi-critical"
@@ -347,7 +347,7 @@ module "capacity-notifications" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-wifi-capacity"
@@ -359,7 +359,7 @@ module "devops-notifications" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-wifi-devops"
@@ -371,7 +371,7 @@ module "route53-critical-notifications" {
     "aws" = "aws.route53-alarms"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-wifi-critical-london"

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -116,9 +116,18 @@ variable "user-rr-hostname" {
   default     = "users-rr.london.production.wifi.service.gov.uk"
 }
 
+variable "admin-db-username" {
+  type        = "string"
+  description = "Database main username for govwifi-admin"
+}
+
 variable "admin-db-password" {
   type        = "string"
   description = "Database main password for govwifi-admin"
+}
+variable "zendesk-api-user" {
+  type        = "string"
+  description = "User for authenticating with Zendesk API"
 }
 
 variable "zendesk-api-token" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -16,7 +16,7 @@ module "tfstate" {
     "aws" = "aws.AWS-main"
   }
 
-  source             = "../modules/terraform-state"
+  source             = "../../terraform-state"
   product-name       = "${var.product-name}"
   Env-Name           = "${var.Env-Name}"
   aws-account-id     = "${var.aws-account-id}"
@@ -47,7 +47,7 @@ module "govwifi-keys" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/govwifi-keys"
+  source = "../../govwifi-keys"
 }
 
 # Backend =====================================================================
@@ -56,7 +56,7 @@ module "backend" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-backend"
+  source        = "../../govwifi-backend"
   env           = "production"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
@@ -129,7 +129,7 @@ module "emails" {
     "aws" = "aws.AWS-main"
   }
 
-  source                   = "../modules/govwifi-emails"
+  source                   = "../../govwifi-emails"
   product-name             = "${var.product-name}"
   Env-Name                 = "${var.Env-Name}"
   Env-Subdomain            = "${var.Env-Subdomain}"
@@ -151,7 +151,7 @@ module "dns" {
     "aws" = "aws.AWS-main"
   }
 
-  source             = "../modules/global-dns"
+  source             = "../../global-dns"
   Env-Name           = "${var.Env-Name}"
   Env-Subdomain      = "${var.Env-Subdomain}"
   route53-zone-id    = "${var.route53-zone-id}"
@@ -164,7 +164,7 @@ module "frontend" {
     "aws" = "aws.AWS-main"
   }
 
-  source        = "../modules/govwifi-frontend"
+  source        = "../../govwifi-frontend"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
 
@@ -229,7 +229,7 @@ module "api" {
   }
 
   env           = "production"
-  source        = "../modules/govwifi-api"
+  source        = "../../govwifi-api"
   Env-Name      = "${var.Env-Name}"
   Env-Subdomain = "${var.Env-Subdomain}"
 
@@ -296,7 +296,7 @@ module "critical-notifications" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-wifi-critical"
@@ -308,7 +308,7 @@ module "capacity-notifications" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-wifi-capacity"
@@ -320,7 +320,7 @@ module "devops-notifications" {
     "aws" = "aws.AWS-main"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-wifi-devops"
@@ -332,7 +332,7 @@ module "route53-critical-notifications" {
     "aws" = "aws.route53-alarms"
   }
 
-  source = "../modules/sns-notification"
+  source = "../../sns-notification"
 
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-wifi-critical"

--- a/scripts/run-terraform.sh
+++ b/scripts/run-terraform.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-TERRAFORM_DIR="${SCRIPT_DIR}/../terraform/${DEPLOY_ENV}"
+TERRAFORM_DIR="${SCRIPT_DIR}/../govwifi/${DEPLOY_ENV}"
 export TF_CLI_ARGS_init="-backend=true -backend-config=${TERRAFORM_DIR}/backend.config"
 
 cd "${TERRAFORM_DIR}"

--- a/scripts/unencrypt-secrets.sh
+++ b/scripts/unencrypt-secrets.sh
@@ -14,3 +14,14 @@ for FILE in $files; do
   fi
 done
 
+if [[ -d .private/non-encrypted/secrets-to-copy ]]; then
+  files="$(find .private/non-encrypted/secrets-to-copy -type f)"
+  for FILE in $files; do
+    target_file="${FILE#.private/non-encrypted/secrets-to-copy/}"
+    if [ "$command" == "unencrypt" ]; then
+      cp "${FILE}" "${target_file}"
+    elif [ "$command" == "delete" ]; then
+      rm "${target_file}"
+    fi
+  done
+fi


### PR DESCRIPTION
- moves the module sourcing
- adds some missing variables that were stripped out
- copies over the unencrypted sensitive variables

State changes:
- staging: None
- staging-london: None
- wifi: currently the same plan as when run the old way
- wifi-london: currently the same plan as when run the old way

Update the .private submodule after https://github.com/alphagov/govwifi-build/pull/351 is merged