### PR TITLE
change the replica lag threshold to 30 seconds

### DIFF
--- a/govwifi-backend/db-alarms.tf
+++ b/govwifi-backend/db-alarms.tf
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_laggingalarm" {
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Minimum"
-  threshold           = "600"
+  threshold           = "30"
 
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.read_replica.identifier}"


### PR DESCRIPTION
10 minutes is far too high, and by that point we've already lost.