### PR TITLE
Add Security Audit module from CyberSecurity

### DIFF
--- a/govwifi-account/csw.tf
+++ b/govwifi-account/csw.tf
@@ -1,0 +1,7 @@
+variable "account-id" {}
+
+module "cyber-security-audit-role" {
+  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=c363ba60ca1ab491560bcd5a74f1ec0b62e1f0e4"
+
+  chain_account_id = "${var.account-id}"
+}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -145,7 +145,16 @@ module "emails" {
   user-signup-notifications-endpoint = "https://user-signup-api.${var.Env-Subdomain}.service.gov.uk:8443/user-signup/email-notification"
 }
 
-# Frontend ====================================================================
+# Global ====================================================================
+module "account" {
+  providers = {
+    "aws" = "aws.AWS-main"
+  }
+
+  source     = "../../govwifi-account"
+  account-id = "${var.aws-parent-account-id}"
+}
+
 module "dns" {
   providers = {
     "aws" = "aws.AWS-main"

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -99,6 +99,11 @@ variable "aws-account-id" {
   description = "The ID of the AWS tenancy."
 }
 
+variable "aws-parent-account-id" {
+  type        = "string"
+  description = "The ID of the AWS parent account."
+}
+
 variable "docker-image-path" {
   type        = "string"
   description = "ARN used to identify the common path element used for the docker image repositories."


### PR DESCRIPTION
## What

TechOps CyberSecurity team, would like to run some security auditing on
AWS accounts across the board.

This is accomplished, by us creating an Assumable Role that will be used
by Cyber to gather some information and alert when things are going
wrong.

The Policy at the time looks fairly sane. It has a lot of `Describe` and
`List` access; and doesn't include anything gathering potential
sensitive information.

The default [AWS Provided SecurityAudit][1] policy is used along with
some [additional permissions][2] added by the Cyber Security team.

[1]: https://console.aws.amazon.com/iam/home?#/policies/arn:aws:iam::aws:policy/SecurityAudit
[2]: https://github.com/alphagov/tech-ops/pull/26

## How to review

- Sanity check
- See if secret is fed in correctly
  - You will need to do: `cd .private && git checkout add-csw-module && cd ..` unless secrets are merged
- Attempt to run `make wifi plan`
