### PR TITLE
Add user db connection details to admin app

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -117,6 +117,18 @@ resource "aws_ecs_task_definition" "admin-task" {
           "name": "RR_DB_NAME",
           "value": "${var.rr-db-name}"
         },{
+          "name": "USER_DB_USER",
+          "value": "${var.user-db-user}"
+        },{
+          "name": "USER_DB_PASS",
+          "value": "${var.user-db-password}"
+        },{
+          "name": "USER_DB_HOST",
+          "value": "${var.user-db-host}"
+        },{
+          "name": "USER_DB_NAME",
+          "value": "${var.user-db-name}"
+        },{
           "name": "ZENDESK_API_ENDPOINT",
           "value": "${var.zendesk-api-endpoint}"
         },{

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -132,6 +132,14 @@ variable "rr-db-host" {}
 
 variable "rr-db-name" {}
 
+variable "user-db-user" {}
+
+variable "user-db-password" {}
+
+variable "user-db-host" {}
+
+variable "user-db-name" {}
+
 variable "zendesk-api-endpoint" {}
 
 variable "zendesk-api-user" {}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -235,6 +235,11 @@ module "govwifi-admin" {
   rr-db-host     = "db.london.staging.wifi.service.gov.uk"
   rr-db-name     = "govwifi_staging"
 
+  user-db-user     = "${var.user-db-username}"
+  user-db-password = "${var.user-db-password}"
+  user-db-host     = "${var.user-db-hostname}"
+  user-db-name     = "govwifi_staging_users"
+
   db-sg-list = []
 
   critical-notifications-arn = "${module.notifications.topic-arn}"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -234,6 +234,11 @@ module "govwifi-admin" {
   rr-db-host     = "rr.london.wifi.service.gov.uk"
   rr-db-name     = "govwifi_wifi"
 
+  user-db-user     = "${var.user-db-username}"
+  user-db-password = "${var.user-db-password}"
+  user-db-host     = "${var.user-rr-hostname}"
+  user-db-name     = "govwifi_production_users"
+
   critical-notifications-arn = "${module.critical-notifications.topic-arn}"
   capacity-notifications-arn = "${module.capacity-notifications.topic-arn}"
 


### PR DESCRIPTION
https://trello.com/c/ydPR0kkx/33-l-allow-gds-super-admin-to-find-user-details-of-a-username-and-vice-versa-7

Expose user db connection vars to the govwifi-admin application.