### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains instructions on how to build GovWifi end-to-end - the s
 ## Overview
 Our public-facing websites are:
 - A [product page](https://github.com/alphagov/govwifi-product-page) explaining the benefits of GovWifi
-- An [admin platform](https://github.com/alphagov/govwifi-admin) for organiations to self-serve changes to their GovWifi installation
+- An [admin platform](https://github.com/alphagov/govwifi-admin) for organisations to self-serve changes to their GovWifi installation
 - [Technical documentation](https://github.com/alphagov/govwifi-tech-docs), explaining GovWifi in more detail
 - A [redirection service](https://github.com/alphagov/govwifi-redirect) to handle "www" requests to these sites
 
@@ -187,54 +187,3 @@ certificate, and apply terraform
 
 Once you have applied terraform, you should clean up the unused certificates in
 the console
-
-## Performance Testing
-
-In order to understand the capabilities of our new infrastructure and applications we performance test it first.
-
-### Infrastructure
-
-The Terraform provisioning scripts for this are contained in the `performance-testing` module.
-Call this module, passing in all the required arguments in your `main.tf` file.
-You can find an example of this in `performance-london/main.tf`
-
-### Testing
-
-In order to generate realistic traffic, you will need list of fake user details.
-These will be used to generate UDP requests to radius servers, one per user.
-
-The scripts for running performance tests are contained in `scripts/performance`
-
-Copy the `scripts/performance` onto the performance testing instance that you created.
-This can be run locally too if you have eapol_test installed, but it is recommended to run it from an AWS instance to minimise potential throttling.
-#### Caveat
-These scripts do not gradually increase traffic, which is the recommended way by AWS.  This is to allow the Loadbalancer to scale and not start throttling requests.
-Our initial performance testing was a work in progress, so these scripts will improve over time.
-
-#### Testing scripts
-
-##### config_template.conf
-
-This dynamic template is used for each request by substituting the username and password with username and password found in `users.csv`.
-Copy this file unmodified onto the performance testing server.
-
-##### runperftest.sh
-
-This script is used to call `stress.rb` with different parameters.
-You can control how many threads you want to run the tests on and also how many requests.
-
-##### stress.rb
-
-This file iterates over `users.csv` and creates a request to all the frontend servers specified.
-Populate the `radius_server_ips` with the radius server IPs that you would like to send traffic to.
-Ensure that the shared secret being sent across is updated to one that the radius servers will accept (ie one that exists in the database for a specific organisation, currently we are using the HeatlCheck user organisation).
-
-##### users.csv
-
-Populate this file with test users from the staging database, exporting only usernames and passwords as a CSV.
-Some example values exist for guidance.
-
-#### Running the tests
-
-Run `sh runperftest.sh`
-You should see this generating traffic and exercising the full stack.


### PR DESCRIPTION
Correct spelling mistake and remove section about performance testing.
We've removed the performance environment so the scripts mentioned here don't
exist. Also don't think we should be too prescriptive about how this is done.

Looking at how the acceptance tests do this should give enough info on how to
achieve this.