### PR TITLE
Update Terraform configs to be inline with Terraform 11 syntax

### DIFF
--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -23,7 +23,7 @@ resource "aws_db_parameter_group" "db-parameters" {
     value = "FILE"
   }
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} DB parameter group for govwifi-admin"
   }
 }
@@ -39,7 +39,7 @@ resource "aws_db_option_group" "mariadb-audit" {
     option_name = "MARIADB_AUDIT_PLUGIN"
   }
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} DB Audit configuration for govwifi-admin"
   }
 }
@@ -72,7 +72,7 @@ resource "aws_db_instance" "admin_db" {
   option_group_name               = "${aws_db_option_group.mariadb-audit.name}"
   parameter_group_name            = "${aws_db_parameter_group.db-parameters.name}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} DB for govwifi-admin"
   }
 }

--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "db_cpualarm" {
   threshold           = "80"
   depends_on          = ["aws_db_instance.admin_db"]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.admin_db.identifier}"
   }
 
@@ -108,7 +108,7 @@ resource "aws_cloudwatch_metric_alarm" "db_memoryalarm" {
   threshold           = "524288000"
   depends_on          = ["aws_db_instance.admin_db"]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.admin_db.identifier}"
   }
 
@@ -128,7 +128,7 @@ resource "aws_cloudwatch_metric_alarm" "db_storagealarm" {
   threshold           = "21474836480"
   depends_on          = ["aws_db_instance.admin_db"]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.admin_db.identifier}"
   }
 
@@ -148,7 +148,7 @@ resource "aws_cloudwatch_metric_alarm" "db_burstbalancealarm" {
   threshold           = "45"
   depends_on          = ["aws_db_instance.admin_db"]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.admin_db.identifier}"
   }
 

--- a/govwifi-admin/loadbalancer.tf
+++ b/govwifi-admin/loadbalancer.tf
@@ -10,7 +10,7 @@ resource "aws_lb" "admin-alb" {
 
   load_balancer_type = "application"
 
-  tags {
+  tags = {
     Name = "admin-alb-${var.Env-Name}"
   }
 }

--- a/govwifi-admin/s3.tf
+++ b/govwifi-admin/s3.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket" "admin-bucket" {
   force_destroy = true
   acl           = "private"
 
-  tags {
+  tags = {
     Name        = "${title(var.Env-Name)} Admin data"
     Region      = "${title(var.aws-region-name)}"
     Environment = "${title(var.rack-env)}"
@@ -21,7 +21,7 @@ resource "aws_s3_bucket" "product-page-data-bucket" {
   force_destroy = true
   acl           = "public-read"
 
-  tags {
+  tags = {
     Name        = "${title(var.rack-env)} Product page data"
     Region      = "${title(var.aws-region-name)}"
     Environment = "${title(var.rack-env)}"
@@ -38,7 +38,7 @@ resource "aws_s3_bucket" "admin-mou-bucket" {
   force_destroy = true
   acl           = "private"
 
-  tags {
+  tags = {
     Name        = "${title(var.Env-Name)} MOU documents from Admin"
     Region      = "${title(var.aws-region-name)}"
     Environment = "${title(var.rack-env)}"

--- a/govwifi-admin/security_groups.tf
+++ b/govwifi-admin/security_groups.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "admin-alb-in" {
   description = "Allow Inbound Traffic to the admin platform ALB"
   vpc_id      = "${var.vpc-id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Admin ALB Traffic In"
   }
 
@@ -20,7 +20,7 @@ resource "aws_security_group" "admin-alb-out" {
   description = "Allow Outbound Traffic from the admin platform ALB"
   vpc_id      = "${var.vpc-id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Admin ALB Traffic Out"
   }
 
@@ -37,7 +37,7 @@ resource "aws_security_group" "admin-ec2-in" {
   description = "Allow Inbound Traffic To Admin from the ALB"
   vpc_id      = "${var.vpc-id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Admin EC2 Traffic In"
   }
 
@@ -61,7 +61,7 @@ resource "aws_security_group" "admin-ec2-out" {
   description = "Allow Outbound Traffic From the Admin EC2 container"
   vpc_id      = "${var.vpc-id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Admin EC2 Traffic Out"
   }
 
@@ -78,7 +78,7 @@ resource "aws_security_group" "admin-db-in" {
   description = "Allow connections to the DB"
   vpc_id      = "${var.vpc-id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Admin DB in"
   }
 

--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
   statistic           = "Average"
   threshold           = "50"
 
-  dimensions {
+  dimensions = {
     ClusterName = "${aws_ecs_cluster.api-cluster.name}"
     ServiceName = "${aws_ecs_service.logging-api-service.name}"
   }
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
   statistic           = "Average"
   threshold           = "10"
 
-  dimensions {
+  dimensions = {
     ClusterName = "${aws_ecs_cluster.api-cluster.name}"
     ServiceName = "${aws_ecs_service.logging-api-service.name}"
   }

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-low" {
   statistic           = "Average"
   threshold           = "1"
 
-  dimensions {
+  dimensions = {
     AutoScalingGroupName = "${aws_autoscaling_group.api-asg.name}"
   }
 
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "ec2-api-cpu-alarm-high" {
   statistic           = "Average"
   threshold           = "60"
 
-  dimensions {
+  dimensions = {
     AutoScalingGroupName = "${aws_autoscaling_group.api-asg.name}"
   }
 
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-high" {
   statistic           = "Average"
   threshold           = "50"
 
-  dimensions {
+  dimensions = {
     ClusterName = "${aws_ecs_cluster.api-cluster.name}"
     ServiceName = "${aws_ecs_service.authorisation-api-service.name}"
   }
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
   statistic           = "Average"
   threshold           = "10"
 
-  dimensions {
+  dimensions = {
     ClusterName = "${aws_ecs_cluster.api-cluster.name}"
     ServiceName = "${aws_ecs_service.authorisation-api-service.name}"
   }
@@ -109,7 +109,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-high" {
   statistic           = "Average"
   threshold           = "75"
 
-  dimensions {
+  dimensions = {
     ClusterName = "${aws_ecs_cluster.api-cluster.name}"
   }
 
@@ -133,7 +133,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs-api-memory-reservation-low" {
   statistic           = "Average"
   threshold           = "40"
 
-  dimensions {
+  dimensions = {
     ClusterName = "${aws_ecs_cluster.api-cluster.name}"
   }
 

--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -130,7 +130,7 @@ resource "aws_alb_target_group" "alb_target_group" {
   vpc_id      = "${var.vpc-id}"
   target_type = "ip"
 
-  tags {
+  tags = {
     Name = "api-alb-tg-${var.Env-Name}"
   }
 

--- a/govwifi-api/elb.tf
+++ b/govwifi-api/elb.tf
@@ -11,7 +11,7 @@ resource "aws_lb" "api-alb" {
 
   load_balancer_type = "application"
 
-  tags {
+  tags = {
     Name = "api-alb-${var.Env-Name}"
   }
 }
@@ -44,7 +44,7 @@ resource "aws_security_group" "api-alb-in" {
   description = "Allow Inbound Traffic To The ALB"
   vpc_id      = "${var.vpc-id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} ALB Traffic In"
   }
 
@@ -61,7 +61,7 @@ resource "aws_security_group" "api-alb-out" {
   description = "Allow Outbound Traffic To The ALB"
   vpc_id      = "${var.vpc-id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} ALB Traffic Out"
   }
 

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -154,7 +154,7 @@ resource "aws_alb_target_group" "logging-api-tg" {
   vpc_id      = "${var.vpc-id}"
   target_type = "ip"
 
-  tags {
+  tags = {
     Name = "logging-api-tg-${var.Env-Name}"
   }
 

--- a/govwifi-api/security-groups.tf
+++ b/govwifi-api/security-groups.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "api-in" {
   description = "Allow Inbound Traffic To API"
   vpc_id      = "${var.vpc-id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} API Traffic In"
   }
 
@@ -20,7 +20,7 @@ resource "aws_security_group" "api-out" {
   description = "Allow Outbound Traffic From the API"
   vpc_id      = "${var.vpc-id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} API Traffic Out"
   }
 

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -205,7 +205,7 @@ resource "aws_alb_target_group" "user-signup-api-tg" {
   vpc_id      = "${var.vpc-id}"
   target_type = "ip"
 
-  tags {
+  tags = {
     Name = "user-signup-api-tg-${var.Env-Name}"
   }
 

--- a/govwifi-api/user-signup-api-lb.tf
+++ b/govwifi-api/user-signup-api-lb.tf
@@ -12,7 +12,7 @@ resource "aws_lb" "user-signup-api" {
 
   load_balancer_type = "application"
 
-  tags {
+  tags = {
     Name = "user-signup-api-${var.Env-Name}"
   }
 }

--- a/govwifi-api/wordlist.tf
+++ b/govwifi-api/wordlist.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "wordlist" {
   count  = "${var.wordlist-bucket-count}"
   acl    = "private"
 
-  tags {
+  tags = {
     Name = "wordlist-bucket"
   }
 

--- a/govwifi-backend/backend.tf
+++ b/govwifi-backend/backend.tf
@@ -7,7 +7,7 @@ resource "aws_vpc" "wifi-backend" {
   # Hostnames required by the CIS hardened image.
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "GovWifi Backend - ${var.Env-Name}"
   }
 }
@@ -17,7 +17,7 @@ resource "aws_vpc" "wifi-backend" {
 resource "aws_internet_gateway" "wifi-backend" {
   vpc_id = "${aws_vpc.wifi-backend.id}"
 
-  tags {
+  tags = {
     Name = "Backend Internet GW - ${var.Env-Name}"
   }
 }
@@ -37,7 +37,7 @@ resource "aws_subnet" "wifi-backend-subnet" {
   cidr_block              = "${lookup(var.zone-subnets, format("zone%d", count.index))}"
   map_public_ip_on_launch = true
 
-  tags {
+  tags = {
     Name = "${var.Env-Name} Backend - AZ: ${lookup(var.zone-names, format("zone%d", count.index))} - GovWifi subnet"
   }
 }

--- a/govwifi-backend/db-alarms.tf
+++ b/govwifi-backend/db-alarms.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "db_cpualarm" {
   statistic           = "Maximum"
   threshold           = "80"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.db.identifier}"
   }
 
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "db_memoryalarm" {
   statistic           = "Minimum"
   threshold           = "524288000"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.db.identifier}"
   }
 
@@ -49,7 +49,7 @@ resource "aws_cloudwatch_metric_alarm" "db_storagealarm" {
   statistic           = "Minimum"
   threshold           = "21474836480"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.db.identifier}"
   }
 
@@ -69,7 +69,7 @@ resource "aws_cloudwatch_metric_alarm" "db_burstbalancealarm" {
   statistic           = "Minimum"
   threshold           = "45"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.db.identifier}"
   }
 
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_burstbalancealarm" {
   statistic           = "Minimum"
   threshold           = "45"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.read_replica.identifier}"
   }
 
@@ -109,7 +109,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_laggingalarm" {
   statistic           = "Minimum"
   threshold           = "30"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.read_replica.identifier}"
   }
 
@@ -129,7 +129,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_cpualarm" {
   statistic           = "Maximum"
   threshold           = "80"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.read_replica.identifier}"
   }
 
@@ -149,7 +149,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_memoryalarm" {
   statistic           = "Minimum"
   threshold           = "524288000"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.read_replica.identifier}"
   }
 
@@ -169,7 +169,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_storagealarm" {
   statistic           = "Minimum"
   threshold           = "21474836480"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.read_replica.identifier}"
   }
 

--- a/govwifi-backend/db-parameters.tf
+++ b/govwifi-backend/db-parameters.tf
@@ -3,7 +3,7 @@ resource "aws_db_subnet_group" "db-subnets" {
   description = "GovWifi ${var.Env-Name} backend subnets"
   subnet_ids  = ["${aws_subnet.wifi-backend-subnet.*.id}"]
 
-  tags {
+  tags = {
     Name = "wifi-${var.Env-Name}-subnets"
   }
 }
@@ -34,7 +34,7 @@ resource "aws_db_parameter_group" "db-parameters" {
     value = "FILE"
   }
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} DB parameter group"
   }
 }
@@ -65,7 +65,7 @@ resource "aws_db_parameter_group" "user-db-parameters" {
     value = "FILE"
   }
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} User DB parameter group"
   }
 }
@@ -96,7 +96,7 @@ resource "aws_db_parameter_group" "rr-parameters" {
     value = "FILE"
   }
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} DB read replica parameter group"
   }
 }
@@ -128,7 +128,7 @@ resource "aws_db_parameter_group" "user-rr-parameters" {
     value = "FILE"
   }
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} User DB read replica parameter group"
   }
 }
@@ -146,7 +146,7 @@ resource "aws_db_option_group" "mariadb-audit" {
     option_name = "MARIADB_AUDIT_PLUGIN"
   }
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} DB Audit configuration"
   }
 }
@@ -159,7 +159,7 @@ resource "aws_db_option_group" "user-mariadb-audit" {
   engine_name              = "mysql"
   major_engine_version     = "8.0"
 
-  tags {
+  tags = {
     Name = "${title(var.env)} User DB Audit configuration"
   }
 }

--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -28,7 +28,7 @@ resource "aws_db_instance" "db" {
   option_group_name               = "${aws_db_option_group.mariadb-audit.name}"
   parameter_group_name            = "${aws_db_parameter_group.db-parameters.name}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} DB"
   }
 }
@@ -60,7 +60,7 @@ resource "aws_db_instance" "read_replica" {
   option_group_name           = "${aws_db_option_group.mariadb-audit.name}"
   parameter_group_name        = "${aws_db_parameter_group.rr-parameters.name}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} DB Read Replica"
   }
 }

--- a/govwifi-backend/db-users.tf
+++ b/govwifi-backend/db-users.tf
@@ -50,7 +50,6 @@ resource "aws_db_instance" "users_read_replica" {
   backup_retention_period     = 0
   multi_az                    = true
   vpc_security_group_ids      = ["${aws_security_group.be-db-in.id}"]
-  depends_on                  = ["aws_iam_role.rds-monitoring-role"]
   monitoring_role_arn         = "${aws_iam_role.rds-monitoring-role.arn}"
   monitoring_interval         = "${var.db-monitoring-interval}"
   maintenance_window          = "${var.db-maintenance-window}"

--- a/govwifi-backend/db-users.tf
+++ b/govwifi-backend/db-users.tf
@@ -28,7 +28,7 @@ resource "aws_db_instance" "users_db" {
   option_group_name               = "${aws_db_option_group.user-mariadb-audit.name}"
   parameter_group_name            = "${aws_db_parameter_group.user-db-parameters.name}"
 
-  tags {
+  tags = {
     Name = "${title(var.env)} Users DB"
   }
 }
@@ -61,7 +61,7 @@ resource "aws_db_instance" "users_read_replica" {
 
   depends_on = ["aws_db_instance.users_db"]
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} DB Read Replica"
   }
 }

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -302,7 +302,7 @@ resource "aws_cloudwatch_metric_alarm" "bastion_statusalarm" {
   unit                = "Count"
   threshold           = "1"
 
-  dimensions {
+  dimensions = {
     InstanceId = "${aws_instance.management.id}"
   }
 

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -189,7 +189,7 @@ sudo python3 ./awslogs-agent-setup.py -n -r ${var.aws-region} -c ./initial-awslo
 --==BOUNDARY==--
 DATA
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Bastion - backend (${aws_vpc.wifi-backend.id})"
     Env  = "${title(var.Env-Name)}"
   }

--- a/govwifi-backend/s3.tf
+++ b/govwifi-backend/s3.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "pp-data-bucket" {
   force_destroy = true
   acl           = "private"
 
-  tags {
+  tags = {
     Name   = "${title(var.Env-Name)} Performance Platform data backup"
     Region = "${title(var.aws-region-name)}"
 

--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "be-ecs-out" {
   description = "Allow the ECS agent to talk to the ECS endpoints"
   vpc_id      = "${aws_vpc.wifi-backend.id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Backend ECS out"
   }
 
@@ -48,7 +48,7 @@ resource "aws_security_group" "be-db-in" {
   description = "Allow connections to the DB"
   vpc_id      = "${aws_vpc.wifi-backend.id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Backend DB in"
   }
 
@@ -65,7 +65,7 @@ resource "aws_security_group" "be-admin-in" {
   description = "Allow inbound SSH from administrators"
   vpc_id      = "${aws_vpc.wifi-backend.id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Backend Admin in"
   }
 
@@ -82,7 +82,7 @@ resource "aws_security_group" "be-vpn-in" {
   description = "Allow inbound SSH from VPN IPs to the bastion only"
   vpc_id      = "${aws_vpc.wifi-backend.id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Backend VPN in"
   }
 
@@ -99,7 +99,7 @@ resource "aws_security_group" "be-vpn-out" {
   description = "Allow outbound SSH from bastion"
   vpc_id      = "${aws_vpc.wifi-backend.id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Backend VPN out"
   }
 
@@ -120,7 +120,7 @@ resource "aws_security_group" "be-radius-api-in" {
   description = "Allow inbound API calls from the RADIUS servers"
   vpc_id      = "${aws_vpc.wifi-backend.id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Backend RADIUS API in"
   }
 

--- a/govwifi-backend/user-db-alarms.tf
+++ b/govwifi-backend/user-db-alarms.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "user_db_cpualarm" {
   statistic           = "Maximum"
   threshold           = "80"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.users_db.identifier}"
   }
 
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "user_db_memoryalarm" {
   statistic           = "Minimum"
   threshold           = "524288000"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.users_db.identifier}"
   }
 
@@ -49,7 +49,7 @@ resource "aws_cloudwatch_metric_alarm" "user_db_storagealarm" {
   statistic           = "Minimum"
   threshold           = "21474836480"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.users_db.identifier}"
   }
 
@@ -69,7 +69,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_burstbalancealarm" {
   statistic           = "Minimum"
   threshold           = "45"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.users_read_replica.identifier}"
   }
 
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_laggingalarm" {
   statistic           = "Minimum"
   threshold           = "600"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.users_read_replica.identifier}"
   }
 
@@ -109,7 +109,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_cpualarm" {
   statistic           = "Maximum"
   threshold           = "80"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.users_read_replica.identifier}"
   }
 
@@ -129,7 +129,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_memoryalarm" {
   statistic           = "Minimum"
   threshold           = "524288000"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.users_read_replica.identifier}"
   }
 
@@ -149,7 +149,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_storagealarm" {
   statistic           = "Minimum"
   threshold           = "21474836480"
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${aws_db_instance.users_read_replica.identifier}"
   }
 

--- a/govwifi-emails/s3sns.tf
+++ b/govwifi-emails/s3sns.tf
@@ -40,7 +40,7 @@ resource "aws_s3_bucket" "emailbucket" {
 }
 EOF
 
-  tags {
+  tags = {
     Name   = "${title(var.Env-Name)} Email Bucket"
     Region = "${title(var.aws-region-name)}"
 
@@ -110,7 +110,7 @@ resource "aws_s3_bucket" "admin-emailbucket" {
 }
 EOF
 
-  tags {
+  tags = {
     Name   = "${title(var.Env-Name)} Admin Email Bucket"
     Region = "${title(var.aws-region-name)}"
 

--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "radius-hc" {
   threshold           = "1"
   treat_missing_data  = "breaching"
 
-  dimensions {
+  dimensions = {
     HealthCheckId = "${element(aws_route53_health_check.radius.*.id, count.index)}"
   }
 
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "radius-latency" {
   statistic           = "Average"
   threshold           = "1000"
 
-  dimensions {
+  dimensions = {
     HealthCheckId = "${element(aws_route53_health_check.radius.*.id, count.index)}"
   }
 

--- a/govwifi-frontend/certs.tf
+++ b/govwifi-frontend/certs.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "frontend-cert-bucket" {
   bucket = "govwifi-${var.rack-env}-${lower(var.aws-region-name)}-frontend-cert"
   acl    = "private"
 
-  tags {
+  tags = {
     Name        = "${title(var.Env-Name)} Frontend certs"
     Region      = "${title(var.aws-region-name)}"
     Environment = "${title(var.rack-env)}"

--- a/govwifi-frontend/frontend.tf
+++ b/govwifi-frontend/frontend.tf
@@ -5,7 +5,7 @@ resource "aws_vpc" "wifi-frontend" {
   cidr_block           = "${var.vpc-cidr-block}"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "GovWifi Frontend - ${var.Env-Name}"
   }
 }
@@ -15,7 +15,7 @@ resource "aws_vpc" "wifi-frontend" {
 resource "aws_internet_gateway" "wifi-frontend" {
   vpc_id = "${aws_vpc.wifi-frontend.id}"
 
-  tags {
+  tags = {
     Name = "Frontend Internet GW - ${var.Env-Name}"
   }
 }
@@ -35,7 +35,7 @@ resource "aws_subnet" "wifi-frontend-subnet" {
   cidr_block              = "${lookup(var.zone-subnets, format("zone%d", count.index))}"
   map_public_ip_on_launch = true
 
-  tags {
+  tags = {
     Name = "${var.Env-Name} Frontend - AZ: ${lookup(var.zone-names, format("zone%d", count.index))} - GovWifi subnet"
   }
 }

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -205,7 +205,7 @@ end script
 
 DATA
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Frontend Radius-${var.dns-numbering-base + count.index + 1}"
     Env  = "${title(var.Env-Name)}"
   }

--- a/govwifi-frontend/main.tf
+++ b/govwifi-frontend/main.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  alias = "route53-alarms"
+}

--- a/govwifi-frontend/route53.tf
+++ b/govwifi-frontend/route53.tf
@@ -19,7 +19,7 @@ resource "aws_route53_health_check" "radius" {
   failure_threshold = "3"
   measure_latency   = true
 
-  tags {
+  tags = {
     Name = "${format("${var.Env-Name}-${var.aws-region-name}-%d", count.index + 1)}"
   }
 }

--- a/govwifi-frontend/security_groups.tf
+++ b/govwifi-frontend/security_groups.tf
@@ -5,7 +5,7 @@ resource "aws_security_group" "fe-ecs-out" {
   description = "Allow the ECS agent to talk to the ECS endpoints"
   vpc_id      = "${aws_vpc.wifi-frontend.id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Frontend ECS out"
   }
 
@@ -39,7 +39,7 @@ resource "aws_security_group" "fe-admin-in" {
   description = "Allow inbound traffic from administrators"
   vpc_id      = "${aws_vpc.wifi-frontend.id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Frontend Admin in"
   }
 
@@ -58,7 +58,7 @@ resource "aws_security_group" "fe-radius-out" {
   description = "Allow outbound API calls from the RADIUS servers"
   vpc_id      = "${aws_vpc.wifi-frontend.id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Frontend RADIUS out"
   }
 
@@ -94,7 +94,7 @@ resource "aws_security_group" "fe-radius-in" {
   description = "Allow inbound API calls to the RADIUS servers"
   vpc_id      = "${aws_vpc.wifi-frontend.id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Frontend RADIUS in"
   }
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -122,6 +122,7 @@ module "backend" {
 module "frontend" {
   providers = {
     "aws" = "aws.AWS-main"
+    "aws.route53-alarms" = "aws.route53-alarms"
   }
 
   source        = "../../govwifi-frontend"

--- a/govwifi/staging-london/security-groups-performance-testing.tf
+++ b/govwifi/staging-london/security-groups-performance-testing.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "be-perf-out" {
   description = "Allow outbound RADIUS traffic from the performance testing instance"
   vpc_id      = "${module.backend.backend-vpc-id}"
 
-  tags {
+  tags = {
     Name = "${title(var.Env-Name)} Backend performance out"
   }
 

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -154,6 +154,7 @@ module "govwifi-keys" {
 module "frontend" {
   providers = {
     "aws" = "aws.AWS-main"
+    "aws.route53-alarms" = "aws.route53-alarms"
   }
 
   source        = "../../govwifi-frontend"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -122,6 +122,7 @@ module "backend" {
 module "frontend" {
   providers = {
     "aws" = "aws.AWS-main"
+    "aws.route53-alarms" = "aws.route53-alarms"
   }
 
   source        = "../../govwifi-frontend"

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -171,6 +171,7 @@ module "dns" {
 module "frontend" {
   providers = {
     "aws" = "aws.AWS-main"
+    "aws.route53-alarms" = "aws.route53-alarms"
   }
 
   source        = "../../govwifi-frontend"

--- a/terraform-state/accesslogs.tf
+++ b/terraform-state/accesslogs.tf
@@ -73,7 +73,7 @@ resource "aws_s3_bucket" "accesslogs-bucket" {
   region = "${var.aws-region}"
   acl    = "log-delivery-write"
 
-  tags {
+  tags = {
     Region      = "${title(var.aws-region-name)}"
     Product     = "${var.product-name}"
     Environment = "${title(var.Env-Name)}"

--- a/terraform-state/tfstate.tf
+++ b/terraform-state/tfstate.tf
@@ -70,7 +70,7 @@ resource "aws_kms_key" "tfstate-key" {
   deletion_window_in_days = 10
   is_enabled              = true
 
-  tags {
+  tags = {
     Region      = "${title(var.aws-region-name)}"
     Product     = "${var.product-name}"
     Environment = "${title(var.Env-Name)}"
@@ -106,7 +106,7 @@ resource "aws_s3_bucket" "state-bucket" {
 }
 EOF
 
-  tags {
+  tags = {
     Region      = "${title(var.aws-region-name)}"
     Product     = "${var.product-name}"
     Environment = "${title(var.Env-Name)}"


### PR DESCRIPTION
There were some cases of TF 0.9 and 0.10 syntax being used.

While this is fine for tf11, upgrading to tf12 will make these changes strictly required:

- attributes can no longer be declared as blocks
- providers must be explicit
- duplicate attributes no-longer allowed