### PR TITLE
Cyber audit support permissions

### DIFF
--- a/govwifi-account/csw.tf
+++ b/govwifi-account/csw.tf
@@ -1,7 +1,7 @@
 variable "account-id" {}
 
 module "cyber-security-audit-role" {
-  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=c363ba60ca1ab491560bcd5a74f1ec0b62e1f0e4"
+  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=13f54e554b8f56f34f975447a1011a03321c92b6"
 
   chain_account_id = "${var.account-id}"
 }


### PR DESCRIPTION
Switch security audit role commit ref to apply support:* permissions for Support/Trusted Advisor.