### PR TITLE
RED-134: Run safe restarter daily at 1am

### DIFF
--- a/govwifi-api/safe-restart-scheduled-task.tf
+++ b/govwifi-api/safe-restart-scheduled-task.tf
@@ -1,8 +1,8 @@
 resource "aws_cloudwatch_event_rule" "daily_safe_restart" {
   count               = "${var.safe-restart-enabled}"
   name                = "${var.Env-Name}-daily-safe-restart"
-  description         = "Triggers at midnight Daily"
-  schedule_expression = "cron(0 0 * * ? *)"
+  description         = "Triggers at 1am Daily"
+  schedule_expression = "cron(0 1 * * ? *)"
   is_enabled          = true
 }
 


### PR DESCRIPTION
Running at 00:00 collides with automatic security updates and subsequent service restart causing the task to be stopped prematurely.