### PR TITLE
Add OTP secret encryption key to admin env

### DIFF
--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -148,6 +148,10 @@ variable "zendesk-api-token" {}
 
 variable "public-google-api-key" {}
 
+variable "otp-secret-encryption-key" {
+  description = "Encryption key used to verify OTP authentication codes"
+}
+
 variable "bastion-ips" {
   description = "The list of allowed hosts to connect to the ec2 instances"
   type        = "list"

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -74,6 +74,11 @@ variable "public-google-api-key" {
   default = "AIzaSyCz1cPYKamsA_ZJCygL9EY0Zq6stkazTco"
 }
 
+variable "otp-secret-encryption-key" {
+  type        = "string"
+  description = "Encryption key used to verify OTP authentication codes"
+}
+
 variable "user-signup-sentry-dsn" {
   type    = "string"
 }

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -72,6 +72,11 @@ variable "public-google-api-key" {
   default = "AIzaSyCz1cPYKamsA_ZJCygL9EY0Zq6stkazTco"
 }
 
+variable "otp-secret-encryption-key" {
+  type        = "string"
+  description = "Encryption key used to verify OTP authentication codes"
+}
+
 variable "user-signup-sentry-dsn" {
   type    = "string"
 }


### PR DESCRIPTION
https://trello.com/c/s3l4mIVJ/30-enable-2fa-for-govwifi-admin-login-at-least-for-super-admins

GovWifi admin 2FA requires that a > 32 byte secret encryption key is present as the environment variable OTP_SECRET_ENCRYPTION_KEY

These keys are used to verify TOTP/2FA codes when authenticating with 2FA.

See https://github.com/alphagov/govwifi-build/pull/367 for corresponding secrets