### PR TITLE
Export OTP_SECRET_ENCRYPTION_KEY to govwifi-admin cluster

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -140,6 +140,9 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "GOOGLE_MAPS_PUBLIC_API_KEY",
           "value": "${var.public-google-api-key}"
+        },{
+          "name": "OTP_SECRET_ENCRYPTION_KEY",
+          "value": "${var.otp-secret-encryption-key}"
         }
       ],
       "image": "${var.admin-docker-image}",

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -255,6 +255,8 @@ module "govwifi-admin" {
   logging-api-search-url     = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
   public-google-api-key      = "${var.public-google-api-key}"
 
+  otp-secret-encryption-key  = "${var.otp-secret-encryption-key}"
+
   zendesk-api-endpoint = "https://govuk.zendesk.com/api/v2/"
   zendesk-api-user     = "${var.zendesk-api-user}"
   zendesk-api-token    = "${var.zendesk-api-token}"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -251,6 +251,8 @@ module "govwifi-admin" {
   sentry-dsn                 = "${var.admin-sentry-dsn}"
   public-google-api-key      = "${var.public-google-api-key}"
 
+  otp-secret-encryption-key  = "${var.otp-secret-encryption-key}"
+
   logging-api-search-url = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
 
   zendesk-api-endpoint = "https://govuk.zendesk.com/api/v2/"


### PR DESCRIPTION
https://trello.com/c/s3l4mIVJ/30-enable-2fa-for-govwifi-admin-login-at-least-for-super-admins

Missed in https://github.com/alphagov/govwifi-terraform/pull/269 this PR ensures the env var
`OTP_SECRET_ENCRYPTION_KEY` is exported in the govwifi-admin cluster.