### PR TITLE
Adding Metric Filter and Alarm on Radius API Errors

### DIFF
--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -72,3 +72,19 @@ resource "aws_cloudwatch_metric_alarm" "outer-and-inner-identities-same" {
     "${var.devops-notifications-arn}",
   ]
 }
+
+resource "aws_cloudwatch_metric_alarm" "radius-cannot-connect-to-api" {
+  alarm_name          = "${var.Env-Name}-radius-cannot-connect-to-api"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 0
+  evaluation_periods  = 1
+  period              = "${60 * 60 * 24}"
+  statistic           = "Sum"
+  treat_missing_data  = "breaching"
+  metric_name         = "${aws_cloudwatch_log_metric_filter.radius-cannot-connect-to-api.metric_transformation.0.name}"
+  namespace           = "${aws_cloudwatch_log_metric_filter.radius-cannot-connect-to-api.metric_transformation.0.namespace}"
+
+  alarm_actions = [
+    "${var.devops-notifications-arn}",
+  ]
+}

--- a/govwifi-frontend/metrics.tf
+++ b/govwifi-frontend/metrics.tf
@@ -53,3 +53,17 @@ resource "aws_cloudwatch_log_metric_filter" "unknown-client" {
     default_value = "0"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "radius-cannot-connect-to-api" {
+  name = "${var.Env-Name}-radius-cannot-connect-to-api"
+
+  pattern        = "\"ERROR: Server returned no data\""
+  log_group_name = "${aws_cloudwatch_log_group.frontend-log-group.name}"
+
+  metric_transformation {
+    name          = "radius-cannot-connect-to-api"
+    namespace     = "${local.frontend_metrics_namespace}"
+    value         = "1"
+    default_value = "0"
+  }
+}


### PR DESCRIPTION
Measure and alert when errors are detected in Radius server
log indicating there are problems connecting to the
authorisation-api