### PR TITLE
Adjust alarm period for radius to api alarm

### DIFF
--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -78,7 +78,7 @@ resource "aws_cloudwatch_metric_alarm" "radius-cannot-connect-to-api" {
   comparison_operator = "GreaterThanThreshold"
   threshold           = 0
   evaluation_periods  = 1
-  period              = "${60 * 60 * 24}"
+  period              = "300"
   statistic           = "Sum"
   treat_missing_data  = "breaching"
   metric_name         = "${aws_cloudwatch_log_metric_filter.radius-cannot-connect-to-api.metric_transformation.0.name}"


### PR DESCRIPTION
Alarm alert period was set for 1 day, which is too large, this
reduces it to 5min.