### PR TITLE
Instrument all SLIs on CloudWatch dashboard

### DIFF
--- a/govwifi-api/authorisation-metrics.tf
+++ b/govwifi-api/authorisation-metrics.tf
@@ -1,0 +1,14 @@
+resource "aws_cloudwatch_log_metric_filter" "response-status-ok" {
+  count = "${aws_cloudwatch_log_group.authorisation-api-log-group.count}"
+  name  = "${var.Env-Name}-response-status-ok"
+
+  pattern        = "\"status=200\" -\"user/HEALTH\""
+  log_group_name = "${aws_cloudwatch_log_group.authorisation-api-log-group.name}"
+
+  metric_transformation {
+    name          = "${var.Env-Name}-response-status-ok-count"
+    namespace     = "${local.authorisation_api_namespace}"
+    value         = "1"
+    default_value = "0"
+  }
+}

--- a/govwifi-api/locals.tf
+++ b/govwifi-api/locals.tf
@@ -1,4 +1,5 @@
 locals {
   logging_api_namespace       = "${var.Env-Name}-logging-api"
   authorisation_api_namespace = "${var.Env-Name}-authorisation-api"
+  signup_api_namespace        = "${var.Env-Name}-user-signup-api"
 }

--- a/govwifi-api/locals.tf
+++ b/govwifi-api/locals.tf
@@ -1,3 +1,4 @@
 locals {
-  logging_api_namespace = "${var.Env-Name}-logging-api"
+  logging_api_namespace       = "${var.Env-Name}-logging-api"
+  authorisation_api_namespace = "${var.Env-Name}-authorisation-api"
 }

--- a/govwifi-api/logging-metrics.tf
+++ b/govwifi-api/logging-metrics.tf
@@ -27,3 +27,18 @@ resource "aws_cloudwatch_log_metric_filter" "radius-access-accept" {
     default_value = "0"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "response-status-no-content" {
+  count = "${aws_cloudwatch_log_group.logging-api-log-group.count}"
+  name  = "${var.Env-Name}-response-status-no-content"
+
+  pattern        = "\"status=204\" -\"\\\"username\\\": \\\"HEALTH\\\"\""
+  log_group_name = "${aws_cloudwatch_log_group.logging-api-log-group.name}"
+
+  metric_transformation {
+    name          = "${var.Env-Name}-response-status-no-content-count"
+    namespace     = "${local.logging_api_namespace}"
+    value         = "1"
+    default_value = "0"
+  }
+}

--- a/govwifi-api/sli-graphs.tf
+++ b/govwifi-api/sli-graphs.tf
@@ -89,6 +89,46 @@ resource "aws_cloudwatch_dashboard" "SLIs" {
                 "title": "Successful SMS Responses",
                 "period": 300
             }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 6,
+            "width": 18,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "wifi-user-signup-api", "wifi-notify-email-success-count", { "id": "m1", "period": 300, "stat": "Sum", "label": "email-success-count" } ],
+                    [ ".", "wifi-notify-email-failed-count", { "id": "m2", "period": 300, "stat": "Sum", "label": "email-failed-count" } ]
+                ],
+                "view": "timeSeries",
+                "region": "eu-west-2",
+                "stacked": false,
+                "title": "Successful email Responses Details",
+                "period": 300,
+                "legend": {
+                    "position": "right"
+                }
+            }
+        },
+        {
+            "type": "metric",
+            "x": 18,
+            "y": 6,
+            "width": 6,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(METRICS())", "label": "total", "id": "e1", "visible": false } ],
+                    [ { "expression": "m1 / e1 * 100", "label": "percentile", "id": "e2" } ],
+                    [ "wifi-user-signup-api", "wifi-notify-email-success-count", { "id": "m1", "visible": false, "period": 604800, "stat": "Sum", "label": "email-success-count" } ],
+                    [ ".", "wifi-notify-email-failed-count", { "id": "m2", "visible": false, "period": 604800, "stat": "Sum", "label": "email-failed-count" } ]
+                ],
+                "view": "singleValue",
+                "region": "eu-west-2",
+                "title": "Successful email Responses",
+                "period": 300
+            }
         }
     ]
 }

--- a/govwifi-api/sli-graphs.tf
+++ b/govwifi-api/sli-graphs.tf
@@ -1,0 +1,56 @@
+resource "aws_cloudwatch_dashboard" "SLIs" {
+  dashboard_name = "SLIs"
+
+  dashboard_body = <<EOF
+{
+    "widgets": [
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 0,
+            "width": 18,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "wifi-logging-api", "wifi-radius-access-accept-count", { "period": 300, "stat": "Sum", "label": "accept-count" } ],
+                    [ ".", "wifi-radius-access-reject-count", { "period": 300, "stat": "Sum", "label": "reject-count" } ],
+                    [ "wifi-authorisation-api", "wifi-response-status-ok-count", { "period": 300, "stat": "Sum", "label": "ok-count" } ],
+                    [ "wifi-logging-api", "wifi-response-status-no-content-count", { "period": 300, "stat": "Sum", "label": "no-content-count" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "eu-west-2",
+                "title": "Authentication Journey Details",
+                "legend": {
+                    "position": "right"
+                },
+                "period": 300
+            }
+        },
+        {
+            "type": "metric",
+            "x": 18,
+            "y": 0,
+            "width": 6,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM([m1,m2])", "label": "access-count", "id": "e1", "visible": false } ],
+                    [ { "expression": "e1 / m3 * 100", "label": "access-ok", "id": "e2", "visible": false } ],
+                    [ { "expression": "e1 / m4 * 100", "label": "access-no-content", "id": "e3", "visible": false } ],
+                    [ { "expression": "AVG([(e1 / m3), (e1 / m4)]) * 100", "label": "percentile", "id": "e4" } ],
+                    [ "wifi-logging-api", "wifi-radius-access-accept-count", { "period": 604800, "stat": "Sum", "id": "m1", "label": "accept-count", "visible": false } ],
+                    [ ".", "wifi-radius-access-reject-count", { "period": 604800, "stat": "Sum", "id": "m2", "label": "reject-count", "visible": false } ],
+                    [ "wifi-authorisation-api", "wifi-response-status-ok-count", { "period": 604800, "stat": "Sum", "id": "m3", "label": "ok-count", "visible": false } ],
+                    [ "wifi-logging-api", "wifi-response-status-no-content-count", { "period": 604800, "stat": "Sum", "id": "m4", "label": "no-content-count", "visible": false } ]
+                ],
+                "view": "singleValue",
+                "region": "eu-west-2",
+                "title": "Authentication Journey",
+                "period": 300
+            }
+        }
+    ]
+}
+ EOF
+}

--- a/govwifi-api/sli-graphs.tf
+++ b/govwifi-api/sli-graphs.tf
@@ -49,6 +49,46 @@ resource "aws_cloudwatch_dashboard" "SLIs" {
                 "title": "Authentication Journey",
                 "period": 300
             }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 3,
+            "width": 18,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "wifi-user-signup-api", "wifi-notify-sms-success-count", { "id": "m1", "period": 300, "stat": "Sum", "label": "sms-success-count" } ],
+                    [ ".", "wifi-notify-sms-failed-count", { "id": "m2", "period": 300, "stat": "Sum", "label": "sms-failed-count" } ]
+                ],
+                "view": "timeSeries",
+                "region": "eu-west-2",
+                "stacked": false,
+                "title": "Successful SMS Responses Details",
+                "period": 300,
+                "legend": {
+                    "position": "right"
+                }
+            }
+        },
+        {
+            "type": "metric",
+            "x": 18,
+            "y": 3,
+            "width": 6,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(METRICS())", "label": "total", "id": "e1", "visible": false } ],
+                    [ { "expression": "m1 / e1 * 100", "label": "percentile", "id": "e2" } ],
+                    [ "wifi-user-signup-api", "wifi-notify-sms-success-count", { "id": "m1", "visible": false, "period": 604800, "stat": "Sum", "label": "sms-success-count" } ],
+                    [ ".", "wifi-notify-sms-failed-count", { "id": "m2", "visible": false, "period": 604800, "stat": "Sum", "label": "sms-failed-count" } ]
+                ],
+                "view": "singleValue",
+                "region": "eu-west-2",
+                "title": "Successful SMS Responses",
+                "period": 300
+            }
         }
     ]
 }

--- a/govwifi-api/user-signup-metrics.tf
+++ b/govwifi-api/user-signup-metrics.tf
@@ -1,0 +1,29 @@
+resource "aws_cloudwatch_log_metric_filter" "notify-sms-successful-response" {
+  count = "${aws_cloudwatch_log_group.user-signup-api-log-group.count}"
+  name  = "${var.Env-Name}-notify-sms-success"
+
+  pattern        = "\"user-signup/sms-notification\" \"status=200\" -\"Processing\""
+  log_group_name = "${aws_cloudwatch_log_group.user-signup-api-log-group.name}"
+
+  metric_transformation {
+    name          = "${var.Env-Name}-notify-sms-success-count"
+    namespace     = "${local.signup_api_namespace}"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "notify-sms-failed-response" {
+  count = "${aws_cloudwatch_log_group.user-signup-api-log-group.count}"
+  name  = "${var.Env-Name}-notify-sms-failed"
+
+  pattern        = "\"user-signup/sms-notification\" -\"status=200\" -\"Processing\""
+  log_group_name = "${aws_cloudwatch_log_group.user-signup-api-log-group.name}"
+
+  metric_transformation {
+    name          = "${var.Env-Name}-notify-sms-failed-count"
+    namespace     = "${local.signup_api_namespace}"
+    value         = "1"
+    default_value = "0"
+  }
+}

--- a/govwifi-api/user-signup-metrics.tf
+++ b/govwifi-api/user-signup-metrics.tf
@@ -27,3 +27,33 @@ resource "aws_cloudwatch_log_metric_filter" "notify-sms-failed-response" {
     default_value = "0"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "notify-email-successful-response" {
+  count = "${aws_cloudwatch_log_group.user-signup-api-log-group.count}"
+  name  = "${var.Env-Name}-notify-email-success"
+
+  pattern        = "\"user-signup/email-notification\" \"status=200\" -\"Processing\""
+  log_group_name = "${aws_cloudwatch_log_group.user-signup-api-log-group.name}"
+
+  metric_transformation {
+    name          = "${var.Env-Name}-notify-email-success-count"
+    namespace     = "${local.signup_api_namespace}"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "notify-email-failed-response" {
+  count = "${aws_cloudwatch_log_group.user-signup-api-log-group.count}"
+  name  = "${var.Env-Name}-notify-email-failed"
+
+  pattern        = "\"user-signup/email-notification\" -\"status=200\" -\"Processing\" -\"Sending performance\""
+  log_group_name = "${aws_cloudwatch_log_group.user-signup-api-log-group.name}"
+
+  metric_transformation {
+    name          = "${var.Env-Name}-notify-email-failed-count"
+    namespace     = "${local.signup_api_namespace}"
+    value         = "1"
+    default_value = "0"
+  }
+}


### PR DESCRIPTION
## What

We'd like to be monitoring three SLIs for GovWiFi. These are:
- Authentication journeys
- Successful responses on signup via SMS
- Successful responses on signup via email

We're composing custom metrics based on logs already stored in CloudWatch, in order to make our lives easier. It's overly complicated to simply mix logs and metrics.

## How to review

- Code sanity check
- See the thing running: AWS > London > CloudWatch > Dashboards > SLIs