### PR TITLE
Adjust radius to auth api alerting threshold

### DIFF
--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -77,8 +77,8 @@ resource "aws_cloudwatch_metric_alarm" "radius-cannot-connect-to-api" {
   alarm_name          = "${var.Env-Name}-radius-cannot-connect-to-api"
   comparison_operator = "GreaterThanThreshold"
   threshold           = 0
-  evaluation_periods  = 1
-  period              = "300"
+  evaluation_periods  = 2
+  period              = "60"
   statistic           = "Sum"
   treat_missing_data  = "breaching"
   metric_name         = "${aws_cloudwatch_log_metric_filter.radius-cannot-connect-to-api.metric_transformation.0.name}"


### PR DESCRIPTION
From: 1 error message detected in the last 5 minutes
To: 1 error message detected in each of the last two minutes

An occassional error is fine (it seems to occur ~9:30am and just after lunch which suggests it is a load based), and it quickly heals upon a subsequent attempt to authenticate. We are more interested when there is a sustained period of errors indicating a real problem which is what this change to threshold allows.