### PR TITLE
Run all remaining Scheduled tasks on Fargate

### DIFF
--- a/govwifi-api/locals.tf
+++ b/govwifi-api/locals.tf
@@ -2,16 +2,4 @@ locals {
   logging_api_namespace       = "${var.Env-Name}-logging-api"
   authorisation_api_namespace = "${var.Env-Name}-authorisation-api"
   signup_api_namespace        = "${var.Env-Name}-user-signup-api"
-
-  scheduled_task_network_configuration = {
-    subnets = ["${var.subnet-ids}"]
-
-    security_groups = [
-      "${var.backend-sg-list}",
-      "${aws_security_group.api-in.id}",
-      "${aws_security_group.api-out.id}",
-    ]
-
-    assign_public_ip = true
-  }
 }

--- a/govwifi-api/locals.tf
+++ b/govwifi-api/locals.tf
@@ -2,4 +2,16 @@ locals {
   logging_api_namespace       = "${var.Env-Name}-logging-api"
   authorisation_api_namespace = "${var.Env-Name}-authorisation-api"
   signup_api_namespace        = "${var.Env-Name}-user-signup-api"
+
+  scheduled_task_network_configuration = {
+    subnets = ["${var.subnet-ids}"]
+
+    security_groups = [
+      "${var.backend-sg-list}",
+      "${aws_security_group.api-in.id}",
+      "${aws_security_group.api-out.id}",
+    ]
+
+    assign_public_ip = true
+  }
 }

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -58,12 +58,21 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-daily-statistics" {
   role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
 
   ecs_target = {
-    task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
-    launch_type         = "FARGATE"
-  }
+    task_count            = 1
+    task_definition_arn   = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
+    launch_type           = "FARGATE"
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
 
-  network_configuration = "${local.scheduled_task_network_configuration}"
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
 
   input = <<EOF
 {
@@ -85,12 +94,21 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-weekly-statistics" {
   role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
 
   ecs_target = {
-    task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
-    launch_type         = "FARGATE"
-  }
+    task_count            = 1
+    task_definition_arn   = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
+    launch_type           = "FARGATE"
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
 
-  network_configuration = "${local.scheduled_task_network_configuration}"
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
 
   input = <<EOF
 {
@@ -112,12 +130,21 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-monthly-statistics" 
   role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
 
   ecs_target = {
-    task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
-    launch_type         = "FARGATE"
-  }
+    task_count            = 1
+    task_definition_arn   = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
+    launch_type           = "FARGATE"
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
 
-  network_configuration = "${local.scheduled_task_network_configuration}"
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
 
   input = <<EOF
 {
@@ -139,12 +166,21 @@ resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
   role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
 
   ecs_target = {
-    task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
-    launch_type         = "FARGATE"
-  }
+    task_count            = 1
+    task_definition_arn   = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
+    launch_type           = "FARGATE"
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
 
-  network_configuration = "${local.scheduled_task_network_configuration}"
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
 
   input = <<EOF
 {

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -60,8 +60,10 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-daily-statistics" {
   ecs_target = {
     task_count          = 1
     task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
-    launch_type         = "EC2"
+    launch_type         = "FARGATE"
   }
+
+  network_configuration = "${local.scheduled_task_network_configuration}"
 
   input = <<EOF
 {
@@ -85,8 +87,10 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-weekly-statistics" {
   ecs_target = {
     task_count          = 1
     task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
-    launch_type         = "EC2"
+    launch_type         = "FARGATE"
   }
+
+  network_configuration = "${local.scheduled_task_network_configuration}"
 
   input = <<EOF
 {
@@ -110,8 +114,10 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-monthly-statistics" 
   ecs_target = {
     task_count          = 1
     task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
-    launch_type         = "EC2"
+    launch_type         = "FARGATE"
   }
+
+  network_configuration = "${local.scheduled_task_network_configuration}"
 
   input = <<EOF
 {
@@ -135,8 +141,10 @@ resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
   ecs_target = {
     task_count          = 1
     task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
-    launch_type         = "EC2"
+    launch_type         = "FARGATE"
   }
+
+  network_configuration = "${local.scheduled_task_network_configuration}"
 
   input = <<EOF
 {
@@ -151,15 +159,20 @@ EOF
 }
 
 resource "aws_ecs_task_definition" "user-signup-api-scheduled-task" {
-  count         = "${var.user-signup-enabled}"
-  family        = "user-signup-api-scheduled-task-${var.Env-Name}"
-  task_role_arn = "${aws_iam_role.user-signup-api-task-role.arn}"
+  count                    = "${var.user-signup-enabled}"
+  family                   = "user-signup-api-scheduled-task-${var.Env-Name}"
+  task_role_arn            = "${aws_iam_role.user-signup-api-task-role.arn}"
+  execution_role_arn       = "${aws_iam_role.ecsTaskExecutionRole.arn}"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 512
+  memory                   = 1024
+  network_mode             = "awsvpc"
 
   container_definitions = <<EOF
 [
     {
       "volumesFrom": [],
-      "memory": 512,
+      "memory": 1024,
       "extraHosts": null,
       "dnsServers": null,
       "disableNetworking": null,


### PR DESCRIPTION
ECS scheduled tasks may now be run on the Fargate launch type in the eu-west-2 (London) region. These tasks currently run on ECS using an EC2 instance launch type. EC2 instances in the api cluster may be removed.