### PR TITLE
REP-461: Use all AZs in London

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ wifi:
 	$(eval export AWS_REGION=eu-west-1)
 
 plan_task: check-env
-	scripts/run-terraform.sh plan
+	scripts/run-terraform.sh plan ${terraform_flags}
 plan: check-env unencrypt-secrets plan_task delete-secrets ## Run terraform plan after decrypting secrets. Must run in form make <env> plan
 apply_task: check-env
 	scripts/run-terraform.sh apply ${terraform_flags}

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -38,7 +38,7 @@ variable "backup-region-name" {
 
 variable "zone-count" {
   type    = "string"
-  default = "2"
+  default = "3"
 }
 
 # Zone names and subnets MUST be static, can not be constructed from vars.
@@ -47,9 +47,8 @@ variable "zone-names" {
 
   default = {
     zone0 = "eu-west-2a"
-    zone1 = "eu-west-2b" #,
-
-    #zone2 = "eu-west-2c"
+    zone1 = "eu-west-2b"
+    zone2 = "eu-west-2c"
   }
 }
 

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -38,7 +38,7 @@ variable "backup-region-name" {
 
 variable "zone-count" {
   type    = "string"
-  default = "2"
+  default = "3"
 }
 
 # Zone names and subnets MUST be static, can not be constructed from vars.
@@ -48,6 +48,7 @@ variable "zone-names" {
   default = {
     zone0 = "eu-west-2a"
     zone1 = "eu-west-2b"
+    zone2 = "eu-west-2c"
   }
 }
 


### PR DESCRIPTION
eu-west-2 now has three availability zones, so let's use them. The
changes in this commit need to be applied in two stages. First, apply
the backend module changes:

    make terraform_flags="-target=module.backend" <env> init-backend apply

Then you can go ahead with:

    make <env> apply

You might have to run this a couple of times so that the Route53
healthchecks get sorted out.