### PR TITLE
feat(ecs-task-role): add ecs task role and policy

### DIFF
--- a/govwifi-frontend/iam-roles.tf
+++ b/govwifi-frontend/iam-roles.tf
@@ -117,3 +117,23 @@ resource "aws_iam_role" "ecs-service-role" {
 }
 EOF
 }
+
+resource "aws_iam_role_policy" "connect_to_cert_bucket" {
+  name = "${var.aws-region-name}-frontend-connect-to-cert-bucket-${var.Env-Name}"
+  role = "${aws_iam_role.ecs-service-role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": ["${aws_s3_bucket.frontend-cert-bucket.arn}/*"]
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
* Policy provides permission to read from the frontend `cert` S3 bucket.
* It uses the pre-existing but unused `ecs-service-role`.