### PR TITLE
Remove patch version from RDS engine_versions

### DIFF
--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -48,7 +48,7 @@ resource "aws_db_instance" "admin_db" {
   allocated_storage           = "${var.db-storage-gb}"
   storage_type                = "gp2"
   engine                      = "mysql"
-  engine_version              = "5.7.23"
+  engine_version              = "5.7"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true

--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -3,7 +3,7 @@ resource "aws_db_instance" "db" {
   allocated_storage           = "${var.session-db-storage-gb}"
   storage_type                = "gp2"
   engine                      = "mysql"
-  engine_version              = "5.7.23"
+  engine_version              = "5.7"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true
@@ -40,7 +40,7 @@ resource "aws_db_instance" "read_replica" {
   replicate_source_db         = "${aws_db_instance.db.identifier}"
   storage_type                = "gp2"
   engine                      = "mysql"
-  engine_version              = "5.7.23"
+  engine_version              = "5.7"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true

--- a/govwifi-backend/db-users.tf
+++ b/govwifi-backend/db-users.tf
@@ -3,7 +3,7 @@ resource "aws_db_instance" "users_db" {
   allocated_storage           = "${var.user-db-storage-gb}"
   storage_type                = "gp2"
   engine                      = "mysql"
-  engine_version              = "8.0.11"
+  engine_version              = "8.0"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true
@@ -40,7 +40,7 @@ resource "aws_db_instance" "users_read_replica" {
   kms_key_id                  = "${var.rds-kms-key-id}"
   storage_encrypted           = "${var.db-encrypt-at-rest}"
   storage_type                = "gp2"
-  engine_version              = "8.0.11"
+  engine_version              = "8.0"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true


### PR DESCRIPTION
Since all our DBs have auto_minor_version_upgrade enabled, we should remove
the patch version from the engine_version to stop Terraform trying to
downgrade the DBs all the time.