### PR TITLE
Fix frontend task definition

### DIFF
--- a/govwifi-admin/outputs.tf
+++ b/govwifi-admin/outputs.tf
@@ -1,7 +1,3 @@
 output "db-hostname" {
   value = "${aws_db_instance.admin_db.address}"
 }
-
-output "admin-bucket-name" {
-  value = "${aws_s3_bucket.admin-bucket.bucket}"
-}

--- a/govwifi-frontend/certs.tf
+++ b/govwifi-frontend/certs.tf
@@ -21,36 +21,3 @@ resource "aws_s3_bucket" "frontend-cert-bucket" {
     enabled = true
   }
 }
-
-data "aws_iam_policy_document" "frontend-cert-bucket-policy-document" {
-  statement {
-    actions = [
-      "s3:GetObject",
-    ]
-
-    resources = [
-      "${aws_s3_bucket.frontend-cert-bucket.arn}/*",
-    ]
-
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-
-    principals {
-      type        = "AWS"
-      identifiers = ["${aws_iam_role.ecs-service-role.arn}"]
-    }
-
-    condition {
-      test     = "IpAddress"
-      variable = "aws:SourceIp"
-      values   = ["${aws_eip_association.eip_assoc.*.public_ip}"]
-    }
-  }
-}
-
-resource "aws_s3_bucket_policy" "frontend-cert-bucket-policy" {
-  bucket = "${aws_s3_bucket.frontend-cert-bucket.id}"
-  policy = "${data.aws_iam_policy_document.frontend-cert-bucket-policy-document.json}"
-}

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -113,7 +113,7 @@ resource "aws_ecs_task_definition" "radius-task" {
     ]
   },
   {
-    "essential": true,
+    "essential": false,
     "mountPoints": [
       {
         "sourceVolume": "raddb-certs",
@@ -139,6 +139,7 @@ resource "aws_ecs_task_definition" "radius-task" {
         "awslogs-stream-prefix": "${var.Env-Name}-docker-logs"
       }
     },
+    "memory": 1500,
     "cpu": 1000,
     "expanded": true
   }

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -21,7 +21,8 @@ resource "aws_ecr_repository" "govwifi-raddb-ecr" {
 }
 
 resource "aws_ecs_task_definition" "radius-task" {
-  family = "radius-task-${var.Env-Name}"
+  family        = "radius-task-${var.Env-Name}"
+  task_role_arn = "${aws_iam_role.ecs-task-role.arn}"
 
   volume {
     name = "raddb-certs"
@@ -94,7 +95,7 @@ resource "aws_ecs_task_definition" "radius-task" {
         "value": "${var.rack-env}"
       }
     ],
-    "image": "${var.docker-image}",
+    "image": "${var.frontend-docker-image}",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
@@ -108,7 +109,7 @@ resource "aws_ecs_task_definition" "radius-task" {
     "dependsOn": [
       {
         "containerName": "populate-radius-certs",
-        "condition": "COMPLETE"
+        "condition": "SUCCESS"
       }
     ]
   },
@@ -124,13 +125,13 @@ resource "aws_ecs_task_definition" "radius-task" {
     "environment": [
       {
         "name": "WHITELIST_BUCKET",
-        "value": "https://s3.eu-west-2.amazonaws.com/govwifi-${var.rack-env}-admin"
+        "value": "s3://${var.admin-bucket-name}"
       },{
         "name": "CERT_STORE_BUCKET",
-        "value": "https://${aws_s3_bucket.frontend-cert-bucket.bucket_domain_name}"
+        "value": "s3://${aws_s3_bucket.frontend-cert-bucket.bucket}"
       }
     ],
-    "image": "${var.docker-image}",
+    "image": "${var.raddb-docker-image}",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -26,7 +26,9 @@ variable "radius-instance-sg-ids" {
   type = "list"
 }
 
-variable "docker-image" {}
+variable "frontend-docker-image" {}
+
+variable "raddb-docker-image" {}
 
 variable "ami" {
   description = "AMI id to launch, must be in the region specified by the region variable"
@@ -54,7 +56,7 @@ variable "elastic-ip-list" {
 variable "enable-detailed-monitoring" {}
 
 variable "radiusd-params" {
-  default = ""
+  default = "-f"
 }
 
 variable "users" {
@@ -81,5 +83,13 @@ variable "route53-critical-notifications-arn" {
 }
 
 variable "devops-notifications-arn" {
+  type = "string"
+}
+
+variable "admin-bucket-name" {
+  type = "string"
+}
+
+variable "admin-bucket-arn" {
   type = "string"
 }

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -150,19 +150,21 @@ module "frontend" {
   radius-instance-count      = 3
   enable-detailed-monitoring = false
 
-  # "-X" debug mode, "" normal mode (preventing insta-shutdown with pipeing to cat)
-  radiusd-params = ""
-
   # eg. dns recods are generated for radius(N).x.service.gov.uk
   # where N = this base + 1 + server#
   dns-numbering-base = 3
 
-  elastic-ip-list = ["${split(",", var.frontend-region-IPs)}"]
-  ami             = "${var.ami}"
-  ssh-key-name    = "${var.ssh-key-name}"
-  users           = "${var.users}"
-  docker-image    = "${format("%s/frontend:staging", var.docker-image-path)}"
-  create-ecr      = true
+  elastic-ip-list       = ["${split(",", var.frontend-region-IPs)}"]
+  ami                   = "${var.ami}"
+  ssh-key-name          = "${var.ssh-key-name}"
+  users                 = "${var.users}"
+  frontend-docker-image = "${format("%s/frontend:staging", var.docker-image-path)}"
+  raddb-docker-image    = "${format("%s/raddb:staging", var.docker-image-path)}"
+  create-ecr            = true
+
+  # admin bucket
+  admin-bucket-arn = "arn:aws:s3:::govwifi-staging-admin"
+  admin-bucket-name = "govwifi-staging-admin"
 
   logging-api-base-url = "${var.london-api-base-url}"
   auth-api-base-url    = "${var.london-api-base-url}"
@@ -335,7 +337,7 @@ module "api" {
   ecs-instance-profile-id            = "${module.backend.ecs-instance-profile-id}"
   ecs-service-role                   = "${module.backend.ecs-service-role}"
   user-signup-api-base-url           = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443"
-  admin-bucket-name                  = "${module.govwifi-admin.admin-bucket-name}"
+  admin-bucket-name                  = "govwifi-staging-admin"
   govnotify-bearer-token             = "${var.govnotify-bearer-token}"
   user-signup-api-is-public          = true
 

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -180,18 +180,20 @@ module "frontend" {
   radius-instance-count      = 3
   enable-detailed-monitoring = false
 
-  # "-X" debug mode, "" normal mode (preventing insta-shutdown with pipeing to cat)
-  radiusd-params = ""
-
   # eg. dns recods are generated for radius(N).x.service.gov.uk
   # where N = this base + 1 + server#
   dns-numbering-base = 0
 
-  elastic-ip-list = ["${split(",", var.frontend-region-IPs)}"]
-  ami             = "${var.ami}"
-  ssh-key-name    = "${var.ssh-key-name}"
-  users           = "${var.users}"
-  docker-image    = "${format("%s/frontend:staging", var.docker-image-path)}"
+  elastic-ip-list       = ["${split(",", var.frontend-region-IPs)}"]
+  ami                   = "${var.ami}"
+  ssh-key-name          = "${var.ssh-key-name}"
+  users                 = "${var.users}"
+  frontend-docker-image = "${format("%s/frontend:staging", var.docker-image-path)}"
+  raddb-docker-image    = "${format("%s/raddb:staging", var.docker-image-path)}"
+
+  # admin bucket
+  admin-bucket-arn = "arn:aws:s3:::govwifi-staging-admin"
+  admin-bucket-name = "govwifi-staging-admin"
 
   logging-api-base-url = "${var.london-api-base-url}"
   auth-api-base-url    = "${var.dublin-api-base-url}"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -150,19 +150,21 @@ module "frontend" {
   radius-instance-count      = 3
   enable-detailed-monitoring = true
 
-  # "-X" debug mode, "" normal mode (preventing insta-shutdown with pipeing to cat)
-  radiusd-params = ""
-
   # eg. dns recods are generated for radius(N).x.service.gov.uk
   # where N = this base + 1 + server#
   dns-numbering-base = 3
 
-  elastic-ip-list = ["${split(",", var.frontend-region-IPs)}"]
-  ami             = "${var.ami}"
-  ssh-key-name    = "${var.ssh-key-name}"
-  users           = "${var.users}"
-  docker-image    = "${format("%s/frontend:latest", var.docker-image-path)}"
-  shared-key      = "${var.shared-key}"
+  elastic-ip-list       = ["${split(",", var.frontend-region-IPs)}"]
+  ami                   = "${var.ami}"
+  ssh-key-name          = "${var.ssh-key-name}"
+  users                 = "${var.users}"
+  frontend-docker-image = "${format("%s/frontend:latest", var.docker-image-path)}"
+  raddb-docker-image    = "${format("%s/raddb:latest", var.docker-image-path)}"
+  shared-key            = "${var.shared-key}"
+
+  # admin bucket
+  admin-bucket-arn = "arn:aws:s3:::govwifi-production-admin"
+  admin-bucket-name = "govwifi-production-admin"
 
   logging-api-base-url = "${var.london-api-base-url}"
   auth-api-base-url    = "${var.london-api-base-url}"
@@ -326,7 +328,7 @@ module "api" {
   user-db-hostname                   = "${var.user-db-hostname}"
   user-db-password                   = "${var.user-db-password}"
   user-rr-hostname                   = "${var.user-rr-hostname}"
-  admin-bucket-name                  = "${module.govwifi-admin.admin-bucket-name}"
+  admin-bucket-name                  = "govwifi-production-admin"
   background-jobs-enabled            = 1
   govnotify-bearer-token             = "${var.govnotify-bearer-token}"
   user-signup-api-is-public          = true

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -197,20 +197,22 @@ module "frontend" {
   radius-instance-count      = 3
   enable-detailed-monitoring = true
 
-  # "-X" debug mode, "" normal mode (preventing insta-shutdown with pipeing to cat)
-  radiusd-params = ""
-
   # eg. dns recods are generated for radius(N).x.service.gov.uk
   # where N = this base + 1 + server#
   dns-numbering-base = 0
 
-  elastic-ip-list = ["${split(",", var.frontend-region-IPs)}"]
-  ami             = "${var.ami}"
-  ssh-key-name    = "${var.ssh-key-name}"
-  users           = "${var.users}"
-  docker-image    = "${format("%s/frontend:latest", var.docker-image-path)}"
+  elastic-ip-list       = ["${split(",", var.frontend-region-IPs)}"]
+  ami                   = "${var.ami}"
+  ssh-key-name          = "${var.ssh-key-name}"
+  users                 = "${var.users}"
+  frontend-docker-image = "${format("%s/frontend:latest", var.docker-image-path)}"
+  raddb-docker-image    = "${format("%s/raddb:latest", var.docker-image-path)}"
 
   shared-key = "${var.shared-key}"
+
+  # admin bucket
+  admin-bucket-arn = "arn:aws:s3:::govwifi-production-admin"
+  admin-bucket-name = "govwifi-production-admin"
 
   logging-api-base-url = "${var.london-api-base-url}"
   auth-api-base-url    = "${var.dublin-api-base-url}"


### PR DESCRIPTION
The populate-radius-certs container can't be essential since it could
fail.

There was a memory parameter missing from the container definition.