### PR TITLE
Use production container tags in frontend task definition

### DIFF
--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -158,8 +158,8 @@ module "frontend" {
   ami                   = "${var.ami}"
   ssh-key-name          = "${var.ssh-key-name}"
   users                 = "${var.users}"
-  frontend-docker-image = "${format("%s/frontend:latest", var.docker-image-path)}"
-  raddb-docker-image    = "${format("%s/raddb:latest", var.docker-image-path)}"
+  frontend-docker-image = "${format("%s/frontend:production", var.docker-image-path)}"
+  raddb-docker-image    = "${format("%s/raddb:production", var.docker-image-path)}"
   shared-key            = "${var.shared-key}"
 
   # admin bucket

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -205,8 +205,8 @@ module "frontend" {
   ami                   = "${var.ami}"
   ssh-key-name          = "${var.ssh-key-name}"
   users                 = "${var.users}"
-  frontend-docker-image = "${format("%s/frontend:latest", var.docker-image-path)}"
-  raddb-docker-image    = "${format("%s/raddb:latest", var.docker-image-path)}"
+  frontend-docker-image = "${format("%s/frontend:production", var.docker-image-path)}"
+  raddb-docker-image    = "${format("%s/raddb:production", var.docker-image-path)}"
 
   shared-key = "${var.shared-key}"
 


### PR DESCRIPTION
Production task definition was incorrectly using "latest" tag.
Production container builds are tagged as "production".