### PR TITLE
feat(aws-provider): bump version to 2.17

### DIFF
--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -1,12 +1,12 @@
 provider "aws" {
   # Workaround for import issue, see https://github.com/hashicorp/terraform/issues/13018#issuecomment-291547317
-  version = "2.10.0"
+  version = "2.17.0"
   alias   = "AWS-main"
   region  = "${var.aws-region}"
 }
 
 provider "aws" {
-  version = "2.10.0"
+  version = "2.17.0"
   alias   = "route53-alarms"
   region  = "us-east-1"
 }
@@ -36,7 +36,6 @@ terraform {
     #key    = "${lower(var.aws-region-name)}-tfstate"
     #region = "${var.aws-region}"
     bucket = "govwifi-staging-london-tfstate"
-
     key    = "london-tfstate"
     region = "eu-west-2"
   }


### PR DESCRIPTION
* AWS provider version 2.17 enables support for UDP on `aws_lb_listener` and `aws_target_group`.
* See Terraform Providers Changelog: https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md
* When running 'terraform apply' it registers no changes.
* I have applied the change to `staging-london` and `staging`, **it needs to be applied to production once approved**.

Co-authored by: Sarah Young <sarah.young@digital.cabinet-office.gov.uk>