### PR TITLE
Enable debug level logging on radius servers

### DIFF
--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -56,7 +56,7 @@ variable "elastic-ip-list" {
 variable "enable-detailed-monitoring" {}
 
 variable "radiusd-params" {
-  default = "-f"
+  default = "-X"
 }
 
 variable "users" {


### PR DESCRIPTION
This is a temporary change that is needed to allow debugging of radius server problems that a large user of GovWifi is experiencing, it will be reverted later today.