### PR TITLE
Remove debug level logging on radius servers

### DIFF
--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -56,7 +56,7 @@ variable "elastic-ip-list" {
 variable "enable-detailed-monitoring" {}
 
 variable "radiusd-params" {
-  default = "-X"
+  default = "-f"
 }
 
 variable "users" {


### PR DESCRIPTION
debug level logging was only enabled for temporary diagnosis of a
problem.