### PR TITLE
fix: add a new metrics task to log daily GovWifi users

### DIFF
--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -50,6 +50,43 @@ resource "aws_iam_role_policy" "logging-scheduled-task-policy" {
 DOC
 }
 
+resource "aws_cloudwatch_event_target" "logging-publish-daily-statistics" {
+  count     = "${var.logging-enabled}"
+  target_id = "${var.Env-Name}-logging-daily-statistics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.daily_statistics_logging_event.name}"
+  role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.logging-api-scheduled-task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
+
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "logging",
+      "command": ["bundle", "exec", "rake", "publish_daily_statistics"]
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_cloudwatch_event_target" "logging-publish-weekly-statistics" {
   count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-weekly-statistics"


### PR DESCRIPTION
The relevant task was implemented in
https://github.com/alphagov/govwifi-logging-api/pull/243 but was never
actually triggered by the environment.