### PR TITLE
fix: add an IAM user to access the dashboard bucket

### DIFF
--- a/govwifi-dashboard/iam.tf
+++ b/govwifi-dashboard/iam.tf
@@ -1,0 +1,30 @@
+resource "aws_iam_user_policy" "dashboard-read-only-policy" {
+  user = "${aws_iam_user.dashboard-read-only-user.name}"
+  name = "dashboard-${var.Env-Name}-read-only-policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.metrics-bucket.bucket}/*"
+    },
+    {
+      "Action": [
+        "s3:ListObjectsV2"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.metrics-bucket.bucket}"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user" "dashboard-read-only-user" {
+  name = "dashboard-${var.Env-Name}-read-only-user"
+}


### PR DESCRIPTION
Because our dashboard app is not terraformed with the rest of our
infrastructure (it lives on PaaS), use an intermediate IAM role whose
credentials we will generate through the AWS console, then store in
govwifi-build, then encrypt within the dashboard app.

This is directly inspired by the `govwifi-api/wordlist.tf` file and
its jenkins user which can be consulted for further reference.