### PR TITLE
fix: use correct list permissions for metrics bucket

### DIFF
--- a/govwifi-dashboard/iam.tf
+++ b/govwifi-dashboard/iam.tf
@@ -15,7 +15,7 @@ resource "aws_iam_user_policy" "dashboard-read-only-policy" {
     },
     {
       "Action": [
-        "s3:ListObjectsV2"
+        "s3:ListBucket"
       ],
       "Effect": "Allow",
       "Resource": "arn:aws:s3:::${aws_s3_bucket.metrics-bucket.bucket}"


### PR DESCRIPTION
`ListObjectsV2` is something else. `ListBucket` does what we want (successfully tested by manually amending the string in AWS console).