### PR TITLE
Make Radius EIPS get provisioned via terraform

### DIFF
--- a/govwifi-frontend/eips.tf
+++ b/govwifi-frontend/eips.tf
@@ -1,0 +1,14 @@
+resource "aws_eip" "radius-eips" {
+  count = "${var.radius-instance-count}"
+  vpc   = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags {
+    Name   = "${title(var.Env-Name)} Frontend Radius-${var.dns-numbering-base + count.index + 1}"
+    Region = "${title(var.aws-region-name)}"
+    Env    = "${title(var.Env-Name)}"
+  }
+}


### PR DESCRIPTION
Currently the EIPs used for the radius servers are not managed by
terraform, this change allows them to be managed by terraform.

Mob: @sarahseewhy, @camdesgov & @smford