### PR TITLE
Revert "fix: add a new metrics task to log daily GovWifi users"

### DIFF
--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -50,43 +50,6 @@ resource "aws_iam_role_policy" "logging-scheduled-task-policy" {
 DOC
 }
 
-resource "aws_cloudwatch_event_target" "logging-publish-daily-statistics" {
-  count     = "${var.logging-enabled}"
-  target_id = "${var.Env-Name}-logging-daily-statistics"
-  arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.daily_statistics_logging_event.name}"
-  role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
-
-  ecs_target = {
-    task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.logging-api-scheduled-task.arn}"
-    launch_type         = "FARGATE"
-
-    network_configuration = {
-      subnets = ["${var.subnet-ids}"]
-
-      security_groups = [
-        "${var.backend-sg-list}",
-        "${aws_security_group.api-in.id}",
-        "${aws_security_group.api-out.id}",
-      ]
-
-      assign_public_ip = true
-    }
-  }
-
-  input = <<EOF
-{
-  "containerOverrides": [
-    {
-      "name": "logging",
-      "command": ["bundle", "exec", "rake", "publish_daily_statistics"]
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_cloudwatch_event_target" "logging-publish-weekly-statistics" {
   count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-weekly-statistics"


### PR DESCRIPTION
Reverts alphagov/govwifi-terraform#295

# Description
We don't want the `publish_[daily/weekly/monthly]_statistics` to run anymore, as these output to the PerformancePlatform and the PerformancePlatform is deprecated. What we do want is to have the [new `publish_[daily/weekly/monthly]_metrics` tasks](https://github.com/alphagov/govwifi-logging-api/pull/297) running (notice it's **metrics** instead of statistics), as these will upload to S3 where we want out metrics to move eventually.

In the meantime there is no need to generate more noise, and the reverted PR's changes haven't been deployed yet so we might as well revert while we can.