### PR TITLE
Fix/allow logging api to write metrics

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -221,7 +221,15 @@ resource "aws_iam_role_policy" "logging-api-task-policy" {
         "s3:GetObject"
       ],
       "Resource": "arn:aws:s3:::govwifi-${var.rack-env}-admin/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::${var.metrics-bucket-name}/*"
     }
+
   ]
 }
 EOF

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -94,6 +94,10 @@ resource "aws_ecs_task_definition" "logging-api-task" {
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
+        },
+        {
+          "name": "S3_METRICS_BUCKET",
+          "value": "${var.metrics-bucket-name}"
         }
       ],
       "links": null,

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -213,6 +213,6 @@ variable "user-signup-api-is-public" {
 }
 
 variable "metrics-bucket-name" {
-  type = "string"
+  type        = "string"
   description = "Name of the S3 bucket to write metrics into"
 }

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -211,3 +211,8 @@ variable "govnotify-bearer-token" {
 variable "user-signup-api-is-public" {
   default = false
 }
+
+variable "metrics-bucket-name" {
+  type = "string"
+  description = "Name of the S3 bucket to write metrics into"
+}

--- a/govwifi-dashboard/outputs.tf
+++ b/govwifi-dashboard/outputs.tf
@@ -1,4 +1,4 @@
-output "metrics_bucket_arn" {
-  description = "the ARN for the metrics bucket"
-  value       = "${aws_s3_bucket.metrics-bucket.arn}"
+output "metrics-bucket-name" {
+  description = "the name for the metrics bucket"
+  value       = "${aws_s3_bucket.metrics-bucket.id}"
 }

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -345,6 +345,8 @@ module "api" {
   backend-sg-list = [
     "${module.backend.be-admin-in}",
   ]
+
+  metrics-bucket-name = "${module.govwifi-dashboard.metrics-bucket-name}"
 }
 
 module "notifications" {


### PR DESCRIPTION
# Description
The logging API is the first app we're going to collect metrics from (metrics that don't go into the Performance Platform, that is) and for this purpose it needs access to the S3 metrics bucket. This just does that.

