### PR TITLE
fix: setup wifi-london to have the logging api output metrics

### DIFF
--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -214,5 +214,6 @@ variable "user-signup-api-is-public" {
 
 variable "metrics-bucket-name" {
   type        = "string"
+  default     = ""
   description = "Name of the S3 bucket to write metrics into"
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -337,6 +337,8 @@ module "api" {
   backend-sg-list = [
     "${module.backend.be-admin-in}",
   ]
+
+  metrics-bucket-name = "${module.govwifi-dashboard.metrics-bucket-name}"
 }
 
 module "critical-notifications" {


### PR DESCRIPTION
Also default the variable to an empty string to avoid failing all
environments that don't build the dashboard module along the logging
API.