### PR TITLE
feat: add and schedule tasks to publish active users metrics

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -69,3 +69,28 @@ resource "aws_cloudwatch_event_rule" "daily_gdpr_set_user_last_login" {
   schedule_expression = "cron(0 2 * * ? *)"
   is_enabled          = true
 }
+
+# new daily, weekly and monthly active users metrics published to S3
+resource "aws_cloudwatch_event_rule" "daily_active_users_metrics_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-daily-active-users-metrics-logging"
+  description         = "Triggers daily 02:00 am UTC"
+  schedule_expression = "cron(0 2 * * ? *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "weekly_active_users_metrics_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-weekly-active-users-metrics-logging"
+  description         = "Triggers every SUN 05:45 am UTC"
+  schedule_expression = "cron(45 5 ? * 1 *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "monthly_active_users_metrics_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-monthly-active-users-metrics-logging"
+  description         = "Triggers on the first of each month at 06:00 am UTC"
+  schedule_expression = "cron(0 6 1 * ? *)"
+  is_enabled          = true
+}

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -198,6 +198,118 @@ resource "aws_cloudwatch_event_target" "gdpr-set-user-last-login" {
 EOF
 }
 
+# new metrics
+resource "aws_cloudwatch_event_target" "logging-publish-monthly-active-users-metrics" {
+  count     = "${var.logging-enabled}"
+  target_id = "${var.Env-Name}-logging-monthly-metrics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.monthly_active_users_metrics_event.name}"
+  role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.logging-api-scheduled-task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
+
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "logging",
+      "command": ["bundle", "exec", "rake", "publish_monthly_metrics"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "logging-publish-active-users-weekly-metrics" {
+  count     = "${var.logging-enabled}"
+  target_id = "${var.Env-Name}-logging-weekly-metrics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.weekly_active_users_metrics_event.name}"
+  role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.logging-api-scheduled-task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
+
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "logging",
+      "command": ["bundle", "exec", "rake", "publish_weekly_metrics"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "logging-publish-active-users-daily-metrics" {
+  count     = "${var.logging-enabled}"
+  target_id = "${var.Env-Name}-logging-daily-metrics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.daily_active_users_metrics_event.name}"
+  role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.logging-api-scheduled-task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
+
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "logging",
+      "command": ["bundle", "exec", "rake", "publish_daily_metrics"]
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_ecs_task_definition" "logging-api-scheduled-task" {
   count                    = "${var.logging-enabled}"
   family                   = "logging-api-scheduled-task-${var.Env-Name}"


### PR DESCRIPTION
The new active users metrics are almost identical to the metrics sent
to the PerformancePlatform (i.e `publish_daily_statistics`) except
they're called `publish_daily_metrics`.

Re-use most of the previous code but use `metrics` in identifier and
schedule:

* the daily metrics generation at 2AM;
* the weekly metrics generation on Sundays at 5:45AM;
* the monthly metrics generation every 1st of the month at 6AM.