### PR TITLE
Fix acm certificate config

### DIFF
--- a/govwifi-api/certs.tf
+++ b/govwifi-api/certs.tf
@@ -13,3 +13,19 @@ resource "aws_acm_certificate_validation" "api-elb-global" {
   certificate_arn         = "${aws_acm_certificate.api-elb-global.arn}"
   validation_record_fqdns = ["${aws_route53_record.elb_global_cert_validation.fqdn}"]
 }
+
+resource "aws_acm_certificate" "api-elb" {
+  count             = "${aws_lb.api-alb.count}"
+  domain_name       = "${aws_route53_record.elb.fqdn}"
+  validation_method = "DNS"
+
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "api-elb" {
+  count                   = "${aws_acm_certificate.api-elb.count}"
+  certificate_arn         = "${aws_acm_certificate.api-elb.arn}"
+}

--- a/govwifi-api/certs.tf
+++ b/govwifi-api/certs.tf
@@ -11,7 +11,6 @@ resource "aws_acm_certificate" "api-elb-global" {
 resource "aws_acm_certificate_validation" "api-elb-global" {
   count                   = "${aws_acm_certificate.api-elb-global.count}"
   certificate_arn         = "${aws_acm_certificate.api-elb-global.arn}"
-  validation_record_fqdns = ["${aws_route53_record.elb_global_cert_validation.fqdn}"]
 }
 
 resource "aws_acm_certificate" "api-elb" {

--- a/govwifi-api/certs.tf
+++ b/govwifi-api/certs.tf
@@ -9,8 +9,8 @@ resource "aws_acm_certificate" "api-elb-global" {
 }
 
 resource "aws_acm_certificate_validation" "api-elb-global" {
-  count                   = "${aws_acm_certificate.api-elb-global.count}"
-  certificate_arn         = "${aws_acm_certificate.api-elb-global.arn}"
+  count           = "${aws_acm_certificate.api-elb-global.count}"
+  certificate_arn = "${aws_acm_certificate.api-elb-global.arn}"
 }
 
 resource "aws_acm_certificate" "api-elb" {
@@ -18,13 +18,12 @@ resource "aws_acm_certificate" "api-elb" {
   domain_name       = "${aws_route53_record.elb.fqdn}"
   validation_method = "DNS"
 
-
   lifecycle {
     create_before_destroy = true
   }
 }
 
 resource "aws_acm_certificate_validation" "api-elb" {
-  count                   = "${aws_acm_certificate.api-elb.count}"
-  certificate_arn         = "${aws_acm_certificate.api-elb.arn}"
+  count           = "${aws_acm_certificate.api-elb.count}"
+  certificate_arn = "${aws_acm_certificate.api-elb.arn}"
 }

--- a/govwifi-api/route53.tf
+++ b/govwifi-api/route53.tf
@@ -28,12 +28,3 @@ resource "aws_route53_record" "elb_global" {
     region = "${var.aws-region}"
   }
 }
-
-resource "aws_route53_record" "elb_global_cert_validation" {
-  count   = "${aws_acm_certificate.api-elb-global.count}"
-  name    = "${aws_acm_certificate.api-elb-global.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.api-elb-global.domain_validation_options.0.resource_record_type}"
-  zone_id = "${var.route53-zone-id}"
-  records = ["${aws_acm_certificate.api-elb-global.domain_validation_options.0.resource_record_value}"]
-  ttl     = 60
-}


### PR DESCRIPTION
Add ACM configuration for `api-elb` and remove stale terraform code.

* We need to add ACM certificate and validation for api-elb because terraform fails to apply when building a new environment.
* `elb_global_cert_validation` needs to be removed because AWS now manages this automatically. 