### PR TITLE
Align ACM certification and Route 53 configuration with AWS

### DIFF
--- a/govwifi-api/certs.tf
+++ b/govwifi-api/certs.tf
@@ -13,3 +13,19 @@ resource "aws_acm_certificate_validation" "api-elb-global" {
   certificate_arn         = "${aws_acm_certificate.api-elb-global.arn}"
   validation_record_fqdns = ["${aws_route53_record.elb_global_cert_validation.fqdn}"]
 }
+
+resource "aws_acm_certificate" "api-elb-regional" {
+  count             = "${aws_lb.api-alb.count}"
+  domain_name       = "${aws_route53_record.elb.fqdn}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "api-elb-regional" {
+  count           = "${aws_acm_certificate.api-elb-regional.count}"
+  certificate_arn = "${aws_acm_certificate.api-elb-regional.arn}"
+  validation_record_fqdns = ["${aws_route53_record.elb_regional_cert_validation.fqdn}"]
+}

--- a/govwifi-api/certs.tf
+++ b/govwifi-api/certs.tf
@@ -25,7 +25,7 @@ resource "aws_acm_certificate" "api-elb-regional" {
 }
 
 resource "aws_acm_certificate_validation" "api-elb-regional" {
-  count           = "${aws_acm_certificate.api-elb-regional.count}"
-  certificate_arn = "${aws_acm_certificate.api-elb-regional.arn}"
+  count                   = "${aws_acm_certificate.api-elb-regional.count}"
+  certificate_arn         = "${aws_acm_certificate.api-elb-regional.arn}"
   validation_record_fqdns = ["${aws_route53_record.elb_regional_cert_validation.fqdn}"]
 }

--- a/govwifi-api/elb.tf
+++ b/govwifi-api/elb.tf
@@ -20,7 +20,7 @@ resource "aws_alb_listener" "alb_listener" {
   load_balancer_arn = "${aws_lb.api-alb.arn}"
   port              = "8443"
   protocol          = "HTTPS"
-  certificate_arn   = "${var.elb-ssl-cert-arn}"
+  certificate_arn   = "${aws_acm_certificate.api-elb-regional.arn}"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
 
   default_action {

--- a/govwifi-api/route53.tf
+++ b/govwifi-api/route53.tf
@@ -37,3 +37,12 @@ resource "aws_route53_record" "elb_global_cert_validation" {
   records = ["${aws_acm_certificate.api-elb-global.domain_validation_options.0.resource_record_value}"]
   ttl     = 60
 }
+
+resource "aws_route53_record" "elb_regional_cert_validation" {
+  count   = "${aws_acm_certificate.api-elb-regional.count}"
+  name    = "${aws_acm_certificate.api-elb-regional.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.api-elb-regional.domain_validation_options.0.resource_record_type}"
+  zone_id = "${var.route53-zone-id}"
+  records = ["${aws_acm_certificate.api-elb-regional.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -42,8 +42,6 @@ variable "backend-elb-count" {}
 
 variable "aws-account-id" {}
 
-variable "elb-ssl-cert-arn" {}
-
 variable "user-signup-enabled" {
   default = 1
 }

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -286,7 +286,6 @@ module "api" {
   backend-min-size       = 1
   backend-cpualarm-count = 1
   aws-account-id         = "${var.aws-account-id}"
-  elb-ssl-cert-arn       = "${var.govwifi-api-ssl-cert-arn}"
   aws-region-name        = "${var.aws-region-name}"
   aws-region             = "${var.aws-region}"
   route53-zone-id        = "${var.route53-zone-id}"

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -192,16 +192,6 @@ variable "route53-zone-id" {
   description = "Zone ID used by the Route53 DNS service."
 }
 
-variable "elb-ssl-cert-arn" {
-  type        = "string"
-  description = "ARN of the ACM SSL certificate to be attached to the ELB"
-}
-
-variable "govwifi-api-ssl-cert-arn" {
-  type        = "string"
-  description = "ARN of the ACM SSL certificate to be attached to the ELB for the API"
-}
-
 variable "performance-url" {
   type        = "string"
   description = "URL endpoint leading to Performance platform API, with a trailing slash at the end"

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -234,7 +234,6 @@ module "api" {
   backend-min-size       = 1
   backend-cpualarm-count = 1
   aws-account-id         = "${var.aws-account-id}"
-  elb-ssl-cert-arn       = "${var.govwifi-api-ssl-cert-arn}"
   aws-region-name        = "${var.aws-region-name}"
   aws-region             = "${var.aws-region}"
   route53-zone-id        = "${var.route53-zone-id}"

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -142,10 +142,4 @@ variable "auth-sentry-dsn" {
   type = "string"
 }
 
-variable "govwifi-api-ssl-cert-arn" {
-  type        = "string"
-  description = "ARN of the ACM SSL certificate to be attached to the ELB for the API"
-  default     = "arn:aws:acm:eu-west-1:788375279931:certificate/88b4e46f-69ac-4445-8c17-3066ba7a6ac4"
-}
-
 variable "notification-email" {}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -284,7 +284,6 @@ module "api" {
   backend-min-size       = 1
   backend-cpualarm-count = 1
   aws-account-id         = "${var.aws-account-id}"
-  elb-ssl-cert-arn       = "${var.govwifi-api-ssl-cert-arn}"
   aws-region-name        = "${var.aws-region-name}"
   aws-region             = "${var.aws-region}"
   route53-zone-id        = "${var.route53-zone-id}"

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -192,16 +192,6 @@ variable "route53-zone-id" {
   description = "Zone ID used by the Route53 DNS service."
 }
 
-variable "elb-ssl-cert-arn" {
-  type        = "string"
-  description = "ARN of the ACM SSL certificate to be attached to the ELB"
-}
-
-variable "govwifi-api-ssl-cert-arn" {
-  type        = "string"
-  description = "ARN of the ACM SSL certificate to be attached to the ELB for the API"
-}
-
 variable "performance-url" {
   type        = "string"
   description = "URL endpoint leading to Performance platform API, with a trailing slash at the end"

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -253,7 +253,6 @@ module "api" {
   backend-min-size        = 1
   backend-cpualarm-count  = 1
   aws-account-id          = "${var.aws-account-id}"
-  elb-ssl-cert-arn        = "${var.govwifi-api-ssl-cert-arn}"
   aws-region-name         = "${lower(var.aws-region-name)}"
   aws-region              = "${var.aws-region}"
   route53-zone-id         = "${var.route53-zone-id}"

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -114,11 +114,6 @@ variable "route53-zone-id" {
   description = "Zone ID used by the Route53 DNS service."
 }
 
-variable "elb-ssl-cert-arn" {
-  type        = "string"
-  description = "ARN of the ACM SSL certificate to be attached to the ELB"
-}
-
 variable "user-signup-sentry-dsn" {
   type    = "string"
   default = ""
@@ -158,11 +153,6 @@ variable "performance-bearer-unique-users" {
   default     = ""
   type        = "string"
   description = "Bearer token for `unique-users` Performance platform statistics"
-}
-
-variable "govwifi-api-ssl-cert-arn" {
-  type        = "string"
-  description = "ARN of the ACM SSL certificate to be attached to the ELB for the API"
 }
 
 variable "auth-sentry-dsn" {


### PR DESCRIPTION
* The project contained missing ACM certificate configuration which existed in AWS.
* We created resources for the `api-elb-regional` ACM certificate, certificate validation, and Route 53 validation record.
* We imported these resources and then applied the terraform in `staging` and `staging-london` thereby aligning Terraform code with AWS configuration.
* This solves an issue discovered in building the new staging environment where London and Ireland regions try to create the same unique Route 53 record for `api-elb-global` ACM certificate validation.
* We configured the alb_listener to compute the `api-elb-regional` ARN instead of hard coding the `elb-ssl-cert-arn` value.
* We removed the now unused `elb-ssl-cert-arn` variable from the codebase.

Paired: @smford & @sarahseewhy