### PR TITLE
fix: correctly provision the Logging API's new scheduled tasks

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -94,10 +94,6 @@ resource "aws_ecs_task_definition" "logging-api-task" {
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
-        },
-        {
-          "name": "S3_METRICS_BUCKET",
-          "value": "${var.metrics-bucket-name}"
         }
       ],
       "links": null,
@@ -225,15 +221,7 @@ resource "aws_iam_role_policy" "logging-api-task-policy" {
         "s3:GetObject"
       ],
       "Resource": "arn:aws:s3:::govwifi-${var.rack-env}-admin/*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Resource": "arn:aws:s3:::${var.metrics-bucket-name}/*"
     }
-
   ]
 }
 EOF

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -44,6 +44,13 @@ resource "aws_iam_role_policy" "logging-scheduled-task-policy" {
               "iam:PassedToService": "ecs-tasks.amazonaws.com"
             }
           }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "s3:PutObject"
+          ],
+          "Resource": "arn:aws:s3:::${var.metrics-bucket-name}/*"
         }
     ]
 }
@@ -398,6 +405,10 @@ resource "aws_ecs_task_definition" "logging-api-scheduled-task" {
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
+        },
+        {
+          "name": "S3_METRICS_BUCKET",
+          "value": "${var.metrics-bucket-name}"
         }
       ],
       "links": null,


### PR DESCRIPTION
# Description
Quoting my commit message as markdown is badly interpreting it:

```
The tasks recently introduced[1] into the logging API require two things:

1. the name of a bucket to write the new metrics into;
2. write access to that bucket.

This was effectively provisioned[2] but in the wrong place: it's not
the `logging-api-task` and `logging-api-task-policy` that need the
information but their counterpart `logging-api-scheduled-task` and
`logging-scheduled-task-policy`.

Move the variables around to make sure the tasks run swiftly.

[1]: https://github.com/alphagov/govwifi-terraform/pull/303
[2]: https://github.com/alphagov/govwifi-terraform/pull/301/
```

This should fix the `key not found: "S3_METRICS_BUCKET"` errors on Sentry.