### PR TITLE
fix: make the rencrypt-passwords command use an absolute path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ run-terraform-init: check-env
 	scripts/run-terraform.sh init
 init-backend: check-env unencrypt-secrets run-terraform-init delete-secrets ## Initalize the terraform backend. Use this when first working on the project to download the required state file. Must run in form make <env> init-backend
 rencrypt-passwords: .private ## Rencrypt passwords after adding a new gpg id to the password store
-	PASSWORD_STORE_DIR=.private/passwords pass init $$(cat .private/passwords/.gpg-id)
+	PASSWORD_STORE_DIR=$$(pwd)/.private/passwords pass init $$(cat .private/passwords/.gpg-id)
 unencrypt-secrets: .private
 	scripts/unencrypt-secrets.sh unencrypt
 delete-secrets: .private


### PR DESCRIPTION
TL;DR: we want an absolute path to give to `pass init` otherwise it ends up
confusing the underlying git command.

----

Once upon a a time, we had a command in our Makefile to re-encrypt
secrets that went like this:

```
PASSWORD_STORE_DIR=.private/passwords pass init $$(cat .private/passwords/.gpg-id)
```

The re-encoding of the pass store happens by encrypting and git-adding
every file according to the keys supplied as arguments.

Now this is how it goes in the `pass` utility:

1. `cmd_init()` is invoked[1];
2. `$gpg_id` is formed based on the `PREFIX + .gpg-id` (`$id_path` is
empty)[2]. In our case that means (looking at the Makefile cmd):
`.private/passwords//.gpg-id`;
3. `git_add_file` is invoked with this `$gpg_id`[3];
4. it tries to run `git -C PREFIX add ARG`[4], and with our invokation
of it this ends up being:

`git -C .private/passwords .private/passwords//.gpg.id`.

What's wrong with that? Well, the `-C` argument of git:

> Run as if git was started in <path> instead of the current working
> directory.

Effectively, git changes directory to our password store, then tries
to add `.private/passwords//.gpg.id` which isn't relevant anymore
because we've already changed (-C) into the folder.

This bug is illustrated with the earlier `git_add` invokation but
recurrs past the `.gpg-id` file when other secrets need to be added.

Setting the password path as absolute means that our git command knows
where to stand and doesn't get confused anymore.

\[1\]: https://github.com/zx2c4/password-store/blob/master/src/password-store.sh#L319
\[2\]: https://github.com/zx2c4/password-store/blob/master/src/password-store.sh#L333
\[3\]: https://github.com/zx2c4/password-store/blob/master/src/password-store.sh#L349
\[4\]: https://github.com/zx2c4/password-store/blob/master/src/password-store.sh#L39