### PR TITLE
Move the retrieve notifications event from logging to signup-api

### DIFF
--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -57,43 +57,6 @@ resource "aws_iam_role_policy" "logging-scheduled-task-policy" {
 DOC
 }
 
-resource "aws_cloudwatch_event_target" "retrieve-notifications" {
-  count     = "${var.logging-enabled}"
-  target_id = "${var.Env-Name}-retrieve-notifications"
-  arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.retrieve_notifications_event.name}"
-  role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
-
-  ecs_target = {
-    task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.logging-api-scheduled-task.arn}"
-    launch_type         = "FARGATE"
-
-    network_configuration = {
-      subnets = ["${var.subnet-ids}"]
-
-      security_groups = [
-        "${var.backend-sg-list}",
-        "${aws_security_group.api-in.id}",
-        "${aws_security_group.api-out.id}",
-      ]
-
-      assign_public_ip = true
-    }
-  }
-
-  input = <<EOF
-{
-  "containerOverrides": [
-    {
-      "name": "logging",
-      "command": ["bundle", "exec", "rake", "retrieve_notifications"]
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_cloudwatch_event_target" "logging-publish-weekly-statistics" {
   count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-weekly-statistics"

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -1,3 +1,40 @@
+resource "aws_cloudwatch_event_target" "retrieve-notifications" {
+  count     = "${var.user-signup-enabled}"
+  target_id = "${var.Env-Name}-retrieve-notifications"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.retrieve_notifications_event.name}"
+  role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
+
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "user-signup",
+      "command": ["bundle", "exec", "rake", "retrieve_notifications"]
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role" "user-signup-scheduled-task-role" {
   count = "${var.user-signup-enabled}"
   name  = "${var.Env-Name}-user-signup-scheduled-task-role"


### PR DESCRIPTION
Because the rake task is defined in the govwifi-signup-api repo