### PR TITLE
fix: let the scheduled metrics task write into the S3 bucket

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -221,6 +221,13 @@ resource "aws_iam_role_policy" "logging-api-task-policy" {
         "s3:GetObject"
       ],
       "Resource": "arn:aws:s3:::govwifi-${var.rack-env}-admin/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::${var.metrics-bucket-name}/*"
     }
   ]
 }

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -44,13 +44,6 @@ resource "aws_iam_role_policy" "logging-scheduled-task-policy" {
               "iam:PassedToService": "ecs-tasks.amazonaws.com"
             }
           }
-        },
-        {
-          "Effect": "Allow",
-          "Action": [
-            "s3:PutObject"
-          ],
-          "Resource": "arn:aws:s3:::${var.metrics-bucket-name}/*"
         }
     ]
 }


### PR DESCRIPTION
TLDR: provision the S3 write access in the actual `logging-api-task`, but keep the environment variable in the `logging-api-scheduled-task` environment.

Please see the [commit message](https://github.com/alphagov/govwifi-terraform/pull/311/commits/ef2ed32d70d74358c858d90ccb055a8eeafff35a) for the full description.