### PR TITLE
Call the publish_(daily|weekly|monthly)_metrics rake tasks

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -102,3 +102,27 @@ resource "aws_cloudwatch_event_rule" "retrieve_notifications_event" {
   schedule_expression = "cron(0 6 * * ? *)"
   is_enabled          = true
 }
+
+resource "aws_cloudwatch_event_rule" "daily_metrics_user_signup_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-daily-metrics-frequency-user-signup"
+  description         = "Triggers daily 04:45 am UTC"
+  schedule_expression = "cron(45 4 * * ? *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "weekly_metrics_user_signup_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-weekly-metrics-frequency-user-signup"
+  description         = "Triggers every SUN 05:45 am UTC"
+  schedule_expression = "cron(45 5 ? * 7 *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "monthly_metrics_user_signup_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-monthly-metrics-frequency-user-signup"
+  description         = "Triggers on the first of each month at 06:30 am UTC"
+  schedule_expression = "cron(30 6 1 * ? *)"
+  is_enabled          = true
+}

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -198,6 +198,117 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-monthly-statistics" 
 EOF
 }
 
+resource "aws_cloudwatch_event_target" "user-signup-publish-daily-metrics" {
+  count     = "${var.user-signup-enabled}"
+  target_id = "${var.Env-Name}-user-signup-daily-metrics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.daily_metrics_user_signup_event.name}"
+  role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
+
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "user-signup",
+      "command": ["bundle", "exec", "rake", "publish_daily_metrics"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "user-signup-publish-weekly-metrics" {
+  count     = "${var.user-signup-enabled}"
+  target_id = "${var.Env-Name}-user-signup-weekly-metrics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.weekly_metrics_user_signup_event.name}"
+  role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
+
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "user-signup",
+      "command": ["bundle", "exec", "rake", "publish_weekly_metrics"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "user-signup-publish-monthly-metrics" {
+  count     = "${var.user-signup-enabled}"
+  target_id = "${var.Env-Name}-user-signup-monthly-metrics"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.monthly_metrics_user_signup_event.name}"
+  role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
+
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "user-signup",
+      "command": ["bundle", "exec", "rake", "publish_monthly_metrics"]
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
   count     = "${var.user-signup-enabled}"
   target_id = "${var.Env-Name}-user-signup-daily-user-deletion"


### PR DESCRIPTION
These supersede the publish_*_statistics tasks and send metrics
data points to S3 instead of the the soon-to-be-retired Performance
Platform