### PR TITLE
Fix calling the publish_*_metrics rake tasks

### DIFF
--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -25,6 +25,13 @@ resource "aws_iam_role" "user-signup-api-task-role" {
       },
       "Effect": "Allow",
       "Sid": ""
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::${var.metrics-bucket-name}/*"
     }
   ]
 }

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -152,6 +152,10 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
         },{
           "name": "GOVNOTIFY_BEARER_TOKEN",
           "value": "${var.govnotify-bearer-token}"
+        },
+        {
+          "name": "S3_METRICS_BUCKET",
+          "value": "${var.metrics-bucket-name}"
         }
       ],
       "links": null,


### PR DESCRIPTION
- Add S3_METRICS_BUCKET environment variable to user_signup_api task
- Allow the User Signup Api cluster to access the Metrics S3 bucket