### PR TITLE
Expose freeradius prometheus exporter endpoint

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -52,6 +52,11 @@ resource "aws_ecs_task_definition" "radius-task" {
         "hostPort": 1813,
         "containerPort": 1813,
         "protocol": "udp"
+      },
+      {
+        "hostPort": 9812,
+        "containerPort": 9812,
+        "protocol": "tcp"
       }
     ],
     "essential": true,


### PR DESCRIPTION
This exposes the freeradius prometheus exporter endpoint in preparation
for metrics scraping.

Pair: @sarahseewhy & @smford