### PR TITLE
Rename publishing events to make naming more consistent.

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -70,28 +70,52 @@ resource "aws_cloudwatch_event_rule" "daily_gdpr_set_user_last_login" {
   is_enabled          = true
 }
 
-# new daily, weekly and monthly active users metrics published to S3
-resource "aws_cloudwatch_event_rule" "daily_active_users_metrics_event" {
+# new daily, weekly and monthly metrics published to S3
+resource "aws_cloudwatch_event_rule" "daily_metrics_logging_event" {
   count               = "${var.event-rule-count}"
-  name                = "${var.Env-Name}-daily-active-users-metrics-logging"
+  name                = "${var.Env-Name}-daily-metrics-logging"
   description         = "Triggers daily 02:00 am UTC"
   schedule_expression = "cron(0 2 * * ? *)"
   is_enabled          = true
 }
 
-resource "aws_cloudwatch_event_rule" "weekly_active_users_metrics_event" {
+resource "aws_cloudwatch_event_rule" "weekly_metrics_logging_event" {
   count               = "${var.event-rule-count}"
-  name                = "${var.Env-Name}-weekly-active-users-metrics-logging"
+  name                = "${var.Env-Name}-weekly-metrics-logging"
   description         = "Triggers every SUN 05:45 am UTC"
   schedule_expression = "cron(45 5 ? * 1 *)"
   is_enabled          = true
 }
 
-resource "aws_cloudwatch_event_rule" "monthly_active_users_metrics_event" {
+resource "aws_cloudwatch_event_rule" "monthly_metrics_logging_event" {
   count               = "${var.event-rule-count}"
-  name                = "${var.Env-Name}-monthly-active-users-metrics-logging"
+  name                = "${var.Env-Name}-monthly-metrics-logging"
   description         = "Triggers on the first of each month at 06:00 am UTC"
   schedule_expression = "cron(0 6 1 * ? *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "daily_metrics_user_signup_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-daily-metrics-user-signup"
+  description         = "Triggers daily 04:45 am UTC"
+  schedule_expression = "cron(45 4 * * ? *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "weekly_metrics_user_signup_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-weekly-metrics-user-signup"
+  description         = "Triggers every SUN 05:45 am UTC"
+  schedule_expression = "cron(45 5 ? * 7 *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_rule" "monthly_metrics_user_signup_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-monthly-metrics-user-signup"
+  description         = "Triggers on the first of each month at 06:30 am UTC"
+  schedule_expression = "cron(30 6 1 * ? *)"
   is_enabled          = true
 }
 
@@ -100,29 +124,5 @@ resource "aws_cloudwatch_event_rule" "retrieve_notifications_event" {
   name                = "${var.Env-Name}-retrieve-notifications"
   description         = "Triggers daily 06:00 am UTC"
   schedule_expression = "cron(0 6 * * ? *)"
-  is_enabled          = true
-}
-
-resource "aws_cloudwatch_event_rule" "daily_metrics_user_signup_event" {
-  count               = "${var.event-rule-count}"
-  name                = "${var.Env-Name}-daily-metrics-frequency-user-signup"
-  description         = "Triggers daily 04:45 am UTC"
-  schedule_expression = "cron(45 4 * * ? *)"
-  is_enabled          = true
-}
-
-resource "aws_cloudwatch_event_rule" "weekly_metrics_user_signup_event" {
-  count               = "${var.event-rule-count}"
-  name                = "${var.Env-Name}-weekly-metrics-frequency-user-signup"
-  description         = "Triggers every SUN 05:45 am UTC"
-  schedule_expression = "cron(45 5 ? * 7 *)"
-  is_enabled          = true
-}
-
-resource "aws_cloudwatch_event_rule" "monthly_metrics_user_signup_event" {
-  count               = "${var.event-rule-count}"
-  name                = "${var.Env-Name}-monthly-metrics-frequency-user-signup"
-  description         = "Triggers on the first of each month at 06:30 am UTC"
-  schedule_expression = "cron(30 6 1 * ? *)"
   is_enabled          = true
 }

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -199,11 +199,11 @@ EOF
 }
 
 # new metrics
-resource "aws_cloudwatch_event_target" "logging-publish-monthly-active-users-metrics" {
+resource "aws_cloudwatch_event_target" "publish-monthly-metrics-logging" {
   count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-monthly-metrics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.monthly_active_users_metrics_event.name}"
+  rule      = "${aws_cloudwatch_event_rule.monthly_metrics_logging_event.name}"
   role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
 
   ecs_target = {
@@ -236,11 +236,11 @@ resource "aws_cloudwatch_event_target" "logging-publish-monthly-active-users-met
 EOF
 }
 
-resource "aws_cloudwatch_event_target" "logging-publish-active-users-weekly-metrics" {
+resource "aws_cloudwatch_event_target" "publish-weekly-metrics-logging" {
   count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-weekly-metrics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.weekly_active_users_metrics_event.name}"
+  rule      = "${aws_cloudwatch_event_rule.weekly_metrics_logging_event.name}"
   role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
 
   ecs_target = {
@@ -273,11 +273,11 @@ resource "aws_cloudwatch_event_target" "logging-publish-active-users-weekly-metr
 EOF
 }
 
-resource "aws_cloudwatch_event_target" "logging-publish-active-users-daily-metrics" {
+resource "aws_cloudwatch_event_target" "publish-daily-metrics-logging" {
   count     = "${var.logging-enabled}"
   target_id = "${var.Env-Name}-logging-daily-metrics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.daily_active_users_metrics_event.name}"
+  rule      = "${aws_cloudwatch_event_rule.daily_metrics_logging_event.name}"
   role_arn  = "${aws_iam_role.logging-scheduled-task-role.arn}"
 
   ecs_target = {

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -198,7 +198,7 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-monthly-statistics" 
 EOF
 }
 
-resource "aws_cloudwatch_event_target" "user-signup-publish-daily-metrics" {
+resource "aws_cloudwatch_event_target" "publish-daily-metrics-user-signup" {
   count     = "${var.user-signup-enabled}"
   target_id = "${var.Env-Name}-user-signup-daily-metrics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
@@ -235,7 +235,7 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-daily-metrics" {
 EOF
 }
 
-resource "aws_cloudwatch_event_target" "user-signup-publish-weekly-metrics" {
+resource "aws_cloudwatch_event_target" "publish-weekly-metrics-user-signup" {
   count     = "${var.user-signup-enabled}"
   target_id = "${var.Env-Name}-user-signup-weekly-metrics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"
@@ -272,7 +272,7 @@ resource "aws_cloudwatch_event_target" "user-signup-publish-weekly-metrics" {
 EOF
 }
 
-resource "aws_cloudwatch_event_target" "user-signup-publish-monthly-metrics" {
+resource "aws_cloudwatch_event_target" "publish-monthly-metrics-user-signup" {
   count     = "${var.user-signup-enabled}"
   target_id = "${var.Env-Name}-user-signup-monthly-metrics"
   arn       = "${aws_ecs_cluster.api-cluster.arn}"


### PR DESCRIPTION
The naming of various events and handlers has become a bit ad-hoc.

This PR makes the relevant names more consistent