### PR TITLE
fix: redirect status.wifi.service.gov.uk to StatusPage.io

### DIFF
--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -164,7 +164,7 @@ module "dns" {
   Env-Name           = "${var.Env-Name}"
   Env-Subdomain      = "${var.Env-Subdomain}"
   route53-zone-id    = "${var.route53-zone-id}"
-  status-page-domain = "govwifi.hund.io"
+  status-page-domain = "govwifi2.statuspage.io"
 }
 
 # Frontend ====================================================================


### PR DESCRIPTION
Note: "govwifi2" because someone probably setup a test page some time
ago which is now inactive and has the canonical URL and we can't
access it. So "govwifi2" it is.