### PR TITLE
fix: use the correct value for the StatusPage DNS entry

### DIFF
--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -164,7 +164,7 @@ module "dns" {
   Env-Name           = "${var.Env-Name}"
   Env-Subdomain      = "${var.Env-Subdomain}"
   route53-zone-id    = "${var.route53-zone-id}"
-  status-page-domain = "govwifi2.statuspage.io"
+  status-page-domain = "bl6klm1cjshh.stspg-customer.com"
 }
 
 # Frontend ====================================================================


### PR DESCRIPTION
StatusPage enforces a specific value for us to set in our DNS record if we want to have it on our canonical URL. See the [configuration page](https://manage.statuspage.io/pages/bl6klm1cjshh/dns).

