### PR TITLE
Update policy to delete S3 objects after 30 days.

### DIFF
--- a/govwifi-emails/s3sns.tf
+++ b/govwifi-emails/s3sns.tf
@@ -64,6 +64,10 @@ EOF
     expiration {
       days = 30
     }
+
+    noncurrent_version_expiration {
+      days = 1
+    }
   }
 }
 


### PR DESCRIPTION
We have a lifecycle policy to expire objects in the `wifi-emailbucket` after 30 days, but we need second policy to delete expired objects.

paired: @sarahseewhy & @camdesgov