### PR TITLE
Refactor aws_appautoscaling_policy to use interpolation

### DIFF
--- a/govwifi-api/logging-scaling-policy.tf
+++ b/govwifi-api/logging-scaling-policy.tf
@@ -10,10 +10,10 @@ resource "aws_appautoscaling_target" "logging-ecs-target" {
 resource "aws_appautoscaling_policy" "ecs-policy-up-logging" {
   count              = "${var.logging-enabled}"
   name               = "ECS Scale Up Logging"
-  service_namespace  = "ecs"
+  service_namespace  = "${aws_appautoscaling_target.logging-ecs-target.service_namespace}"
   policy_type        = "StepScaling"
-  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.logging-api-service.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
+  resource_id        = "${aws_appautoscaling_target.logging-ecs-target.resource_id}"
+  scalable_dimension = "${aws_appautoscaling_target.logging-ecs-target.scalable_dimension}"
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
@@ -31,10 +31,10 @@ resource "aws_appautoscaling_policy" "ecs-policy-up-logging" {
 resource "aws_appautoscaling_policy" "ecs-policy-down-logging" {
   count              = "${var.logging-enabled}"
   name               = "ECS Scale Down"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.logging-api-service.name}"
+  service_namespace  = "${aws_appautoscaling_target.logging-ecs-target.service_namespace}"
+  resource_id        = "${aws_appautoscaling_target.logging-ecs-target.resource_id}"
   policy_type        = "StepScaling"
-  scalable_dimension = "ecs:service:DesiredCount"
+  scalable_dimension = "${aws_appautoscaling_target.logging-ecs-target.scalable_dimension}"
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"


### PR DESCRIPTION
Use interpolation to set values on `aws_appautoscaling_policy` instead of hard-coding. This will make it easier if we need to refactor.

Aligns better with Terraform documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy

When I ran `terraform plan` there were no changes (both staging and production).