### PR TITLE
BAU: Add secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,99 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-11-17T11:11:39Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "docs/creating-new-govwifi-using-terraform.md": [
+      {
+        "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
+        "is_verified": false,
+        "line_number": 137,
+        "type": "Secret Keyword"
+      }
+    ],
+    "docs/rebuilding-after-performing-secret-rotation.md": [
+      {
+        "hashed_secret": "5bab61eb53176449e25c2c82f172b82cb13ffb9d",
+        "is_verified": false,
+        "line_number": 77,
+        "type": "Secret Keyword"
+      }
+    ],
+    "govwifi/staging-london/variables.tf": [
+      {
+        "hashed_secret": "812ed97e289034abdfaddb6699cb13fd993fb7c8",
+        "is_verified": false,
+        "line_number": 73,
+        "type": "Base64 High Entropy String"
+      }
+    ],
+    "govwifi/wifi-london/variables.tf": [
+      {
+        "hashed_secret": "812ed97e289034abdfaddb6699cb13fd993fb7c8",
+        "is_verified": false,
+        "line_number": 73,
+        "type": "Base64 High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
https://github.com/alphagov/gds-pre-commit

The one thing that looks like an actual secret is the `public-google-api-key`; I'm assuming from the name though, it's fine for this to be stored in plaintext?