### PR TITLE
fix: add a new task declaration and its daily trigger

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -126,3 +126,11 @@ resource "aws_cloudwatch_event_rule" "retrieve_notifications_event" {
   schedule_expression = "cron(0 6 * * ? *)"
   is_enabled          = true
 }
+
+resource "aws_cloudwatch_event_rule" "user_active_signup_survey_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-active_signup_survey"
+  description         = "Triggers daily at 1:00PM UTC"
+  schedule_expression = "cron(0 13 * * ? *)"
+  is_enabled          = true
+}

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -448,3 +448,40 @@ resource "aws_ecs_task_definition" "user-signup-api-scheduled-task" {
 ]
 EOF
 }
+
+resource "aws_cloudwatch_event_target" "user-active-signup-user-surveys" {
+  count     = "${var.user-signup-enabled}"
+  target_id = "${var.Env-Name}-user-signup-user-surveys"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.user_active_signup_survey_event.name}"
+  role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
+
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "user-signup",
+      "command": ["bundle", "exec", "rake", "send_active_users_signup_survey"]
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
We want to send our active user signup surveys every day at 1PM.