### PR TITLE
fix: schedule the inactive user signup survey task

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -134,3 +134,11 @@ resource "aws_cloudwatch_event_rule" "active_users_signup_survey_event" {
   schedule_expression = "cron(0 13 * * ? *)"
   is_enabled          = true
 }
+
+resource "aws_cloudwatch_event_rule" "inactive_users_signup_survey_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-inactive-users-signup-survey"
+  description         = "Triggers daily at 1:00PM UTC"
+  schedule_expression = "cron(0 13 * * ? *)"
+  is_enabled          = true
+}

--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -138,7 +138,7 @@ resource "aws_cloudwatch_event_rule" "active_users_signup_survey_event" {
 resource "aws_cloudwatch_event_rule" "inactive_users_signup_survey_event" {
   count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-inactive-users-signup-survey"
-  description         = "Triggers daily at 1:00PM UTC"
+  description         = "Triggers daily at 11:00AM UTC"
   schedule_expression = "cron(0 11 * * ? *)"
   is_enabled          = true
 }

--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -139,6 +139,6 @@ resource "aws_cloudwatch_event_rule" "inactive_users_signup_survey_event" {
   count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-inactive-users-signup-survey"
   description         = "Triggers daily at 1:00PM UTC"
-  schedule_expression = "cron(0 13 * * ? *)"
+  schedule_expression = "cron(0 11 * * ? *)"
   is_enabled          = true
 }


### PR DESCRIPTION
And amend the task name for the active task as well as we've regrouped
them under one namespace (`users_signup_survey:send_[in]active`).