### PR TITLE
Temporarily add ITHC IPs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ apply_task: check-env
 apply: check-env unencrypt-secrets apply_task delete-secrets ## Run terraform apply after decrypting secrets. Must run in form make <env> apply
 .PHONY: terraform
 terraform_task: check-env
-terraform: check-env unencrypt-secrets delete-secrets
+terraform: check-env unencrypt-secrets
 	scripts/run-terraform.sh ${terraform_cmd}
 destroy_task: check-env
 	scripts/run-terraform.sh destroy

--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -87,9 +87,10 @@ resource "aws_security_group" "be-vpn-in" {
   }
 
   ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+
     # Temporarily add ITHC IPs. Remove when ITHC complete.
     cidr_blocks = ["${split(",", var.administrator-IPs)}", "3.10.4.0/24", "90.155.48.192/26"]
   }

--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -90,7 +90,8 @@ resource "aws_security_group" "be-vpn-in" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["${split(",", var.administrator-IPs)}"]
+    # Temporarily add ITHC IPs. Remove when ITHC complete.
+    cidr_blocks = ["${split(",", var.administrator-IPs)}", "3.10.4.0/24", "90.155.48.192/26"]
   }
 }
 


### PR DESCRIPTION
* Allows us to plan/apply without having to use terraform target which slows down our work.
* This makes the local state match the remote state where we configured the IPs manually.
* Remove after ITHC is complete.

paired: @camdesgov