### PR TITLE
Expose freeradius prometheus log exporter endpoint

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -52,6 +52,11 @@ resource "aws_ecs_task_definition" "radius-task" {
         "hostPort": 1813,
         "containerPort": 1813,
         "protocol": "udp"
+      },
+      {
+        "hostPort": 9812,
+        "containerPort": 9812,
+        "protocol": "tcp"
       }
     ],
     "essential": true,


### PR DESCRIPTION
Expose port `9812` on the FreeRadius containers. 

We need to expose port 9812 in the terraform to make the `metrics` path available. This allows the Prometheus server to connect to the FreeRadius log exporter.

The FreeRadius log exporter is a custom built Prometheus agent for FreeRadius. 

When the two are able to connect, the Prometheus server will query the `/metrics` path on port 9812 on the Prometheus agent (aka the FreeRadius log exporter), scrape the data, and display it in a Promtheus web UI.