### PR TITLE
Update Frontend security groups to allow Prometheus traffic

### DIFF
--- a/govwifi-frontend/security_groups.tf
+++ b/govwifi-frontend/security_groups.tf
@@ -162,9 +162,9 @@ resource "aws_security_group" "fe-radius-in" {
     from_port   = 9812
     to_port     = 9812
     protocol    = "tcp"
+
     cidr_blocks = [
-      "${split(",", var.london-radius-ip-addresses)}",
-      "${split(",", var.dublin-radius-ip-addresses)}",
+      "${var.radius-CIDR-blocks}",
     ]
   }
 }

--- a/govwifi-frontend/security_groups.tf
+++ b/govwifi-frontend/security_groups.tf
@@ -104,6 +104,14 @@ resource "aws_security_group" "fe-radius-out" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  egress {
+    from_port   = 9812
+    to_port     = 9812
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow outbound data to Prometheus server"
+  }
 }
 
 # RADIUS traffic to the RADIUS servers
@@ -147,6 +155,17 @@ resource "aws_security_group" "fe-radius-in" {
     to_port     = 3000
     protocol    = "tcp"
     cidr_blocks = ["${data.aws_ip_ranges.route53_healthcheck.cidr_blocks}"]
+  }
+
+  ingress {
+    description = "Allow FreeRadius Log Exporter in"
+    from_port   = 9812
+    to_port     = 9812
+    protocol    = "tcp"
+    cidr_blocks = [
+      "${split(",", var.london-radius-ip-addresses)}",
+      "${split(",", var.dublin-radius-ip-addresses)}",
+    ]
   }
 }
 

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -94,11 +94,7 @@ variable "prometheus-IPs" {
   type = "string"
 }
 
-variable "london-radius-ip-addresses" {
-  type    = "string"
-  default = ""
-}
-variable "dublin-radius-ip-addresses" {
-  type = "string"
-  default = ""
+variable "radius-CIDR-blocks" {
+  description = "IP addresses for the London and Ireland Radius instances in CIDR block format"
+  type        = "list"
 }

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -93,3 +93,12 @@ variable "admin-bucket-name" {
 variable "prometheus-IPs" {
   type = "string"
 }
+
+variable "london-radius-ip-addresses" {
+  type    = "string"
+  default = ""
+}
+variable "dublin-radius-ip-addresses" {
+  type = "string"
+  default = ""
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -190,6 +190,10 @@ module "frontend" {
   ]
 
   prometheus-IPs = "${var.prometheus-IPs}"
+
+  radius-CIDR-blocks = [
+    "${split(",", var.frontend-radius-IPs)}",
+  ]
 }
 
 module "govwifi-admin" {

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -217,6 +217,10 @@ module "frontend" {
   ]
 
   prometheus-IPs = "${var.prometheus-IPs}"
+
+  radius-CIDR-blocks = [
+    "${split(",", var.frontend-radius-IPs)}",
+  ]
 }
 
 module "api" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -188,6 +188,10 @@ module "frontend" {
   ]
 
   prometheus-IPs = "${var.prometheus-IPs}"
+
+  radius-CIDR-blocks = [
+    "${split(",", var.frontend-radius-IPs)}",
+  ]
 }
 
 module "govwifi-admin" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -235,6 +235,10 @@ module "frontend" {
   ]
 
   prometheus-IPs = "${var.prometheus-IPs}"
+
+  radius-CIDR-blocks = [
+    "${split(",", var.frontend-radius-IPs)}",
+  ]
 }
 
 module "api" {


### PR DESCRIPTION
Update the `fe-radius-in` security group, adding a rule to allow FreeRadius Log Exporter traffic in and traffic out.

The security group needs to be applied to both the prometheus instance and the radius instances. 

This is achieved by amending the `fe-radius-in` and `fe-radius-out` security groups to allow incoming/outgoing Prometheus traffic instead of creating and attaching a new security group.

We must apply the update to all environments because Terraform does not accept an empty list as a default and we don't have a separate staging environment account.

**These changes have been applied to staging and staging-london, they've not been applied to production.**