### PR TITLE
Add Prometheus server to production

### DIFF
--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -96,5 +96,5 @@ resource "aws_eip_association" "prometheus_eip_assoc" {
   count       = "${var.create_prometheus_server}"
   depends_on  = ["aws_instance.prometheus_instance"]
   instance_id = "${aws_instance.prometheus_instance.id}"
-  public_ip   = "${var.prometheus_eip}"
+  public_ip   = "${var.prometheus-IPs}"
 }

--- a/govwifi-prometheus/variables.tf
+++ b/govwifi-prometheus/variables.tf
@@ -16,9 +16,7 @@ variable "prometheus_volume_size" {
   default = "40"
 }
 
-variable "prometheus_eip" {
-  default = "18.135.11.32"
-}
+variable "prometheus-IPs" {}
 
 variable "frontend-vpc-id" {}
 
@@ -42,7 +40,7 @@ variable "radius-ip-addresses" {
 }
 
 # Feature toggle to create (1) or not create (0) Prometheus server
-# Default value is 0, we only want Prometheus enabled in Staging.
+# Default value is 0, we only want Prometheus enabled in Staging and Production (London only).
 # To enable Prometheus, set the value to 1 in the relevant <environment>/main.tf
 variable "create_prometheus_server" {
   default = 0

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -116,7 +116,7 @@ module "backend" {
   # Whether or not to save Performance Platform backup data
   save-pp-data   = 1
   pp-domain-name = "www.performance.service.gov.uk"
-  prometheus-IPs = "${var.prometheus-IPs}"
+  prometheus-IPs = "${var.staging-prometheus-IPs}/32"
 }
 
 # London Frontend ==================================================================
@@ -189,7 +189,7 @@ module "frontend" {
     "${split(",", var.backend-subnet-IPs)}",
   ]
 
-  prometheus-IPs = "${var.prometheus-IPs}"
+  prometheus-IPs = "${var.staging-prometheus-IPs}/32"
 
   radius-CIDR-blocks = [
     "${split(",", var.frontend-radius-IPs)}",
@@ -418,4 +418,6 @@ module "govwifi-prometheus" {
   # Feature toggle creating Prometheus server.
   # Value defaults to 0 and is only enabled (i.e., value = 1) in staging-london
   create_prometheus_server = 1
+
+  prometheus-IPs = "${var.staging-prometheus-IPs}"
 }

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -261,4 +261,4 @@ variable "govnotify-bearer-token" {
 
 variable "notification-email" {}
 
-variable "prometheus-IPs" {}
+variable "staging-prometheus-IPs" {}

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -118,7 +118,7 @@ module "backend" {
   user-db-hostname      = ""
   user-db-instance-type = ""
   user-db-storage-gb    = 0
-  prometheus-IPs        = "${var.prometheus-IPs}"
+  prometheus-IPs        = "${var.staging-prometheus-IPs}/32"
 }
 
 # Emails ======================================================================
@@ -216,7 +216,7 @@ module "frontend" {
     "${var.bastion-server-IP}",
   ]
 
-  prometheus-IPs = "${var.prometheus-IPs}"
+  prometheus-IPs = "${var.staging-prometheus-IPs}/32"
 
   radius-CIDR-blocks = [
     "${split(",", var.frontend-radius-IPs)}",

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -144,4 +144,4 @@ variable "auth-sentry-dsn" {
 
 variable "notification-email" {}
 
-variable "prometheus-IPs" {}
+variable "staging-prometheus-IPs" {}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -116,7 +116,7 @@ module "backend" {
   # Whether or not to save Performance Platform backup data
   save-pp-data   = 1
   pp-domain-name = "www.performance.service.gov.uk"
-  prometheus-IPs = "${var.prometheus-IPs}"
+  prometheus-IPs = "${var.production-prometheus-IP}/32"
 }
 
 # London Frontend ======DIFFERENT AWS REGION===================================
@@ -187,7 +187,7 @@ module "frontend" {
     "${split(",", var.backend-subnet-IPs)}",
   ]
 
-  prometheus-IPs = "${var.prometheus-IPs}"
+  prometheus-IPs = "${var.production-prometheus-IP}/32"
 
   radius-CIDR-blocks = [
     "${split(",", var.frontend-radius-IPs)}",
@@ -432,6 +432,8 @@ module "govwifi-prometheus" {
   dublin-radius-ip-addresses = "${var.dublin-radius-ip-addresses}"
 
   # Feature toggle creating Prometheus server.
-  # Value defaults to 0 and should only be enabled (i.e., value = 1) in staging-london
-  # create_prometheus_server = 1
+  # Value defaults to 0 and should only be enabled (i.e., value = 1) in staging-london and wifi-london
+  create_prometheus_server = 1
+
+  prometheus-IPs = "${var.production-prometheus-IP}"
 }

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -259,4 +259,4 @@ variable "devops-notification-email" {
   type = "string"
 }
 
-variable "prometheus-IPs" {}
+variable "production-prometheus-IP" {}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -121,7 +121,7 @@ module "backend" {
   user-db-hostname      = "${var.user-db-hostname}"
   user-db-storage-gb    = 20
   user-rr-hostname      = "${var.user-rr-hostname}"
-  prometheus-IPs        = "${var.prometheus-IPs}"
+  prometheus-IPs        = "${var.production-prometheus-IPs}/32"
 }
 
 # Emails ======================================================================
@@ -234,7 +234,7 @@ module "frontend" {
     "${split(",", var.backend-subnet-IPs)}",
   ]
 
-  prometheus-IPs = "${var.prometheus-IPs}"
+  prometheus-IPs = "${var.production-prometheus-IPs}/32"
 
   radius-CIDR-blocks = [
     "${split(",", var.frontend-radius-IPs)}",

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -218,4 +218,4 @@ variable "devops-notification-email" {
   type = "string"
 }
 
-variable "prometheus-IPs" {}
+variable "production-prometheus-IPs" {}


### PR DESCRIPTION
* Enable feature toggle to add EC2 instance with running Prometheus to production (London only).
* Ensure networks are configured correctly and pull in the elastic IP from govwifi-build.
* Remove the default EIP and interpolate the value for staging and production from govwifi-build.
* For govwifi-frontend and govwifi-backend ensure Prometheus EIP is in CIDR format for security groups.

**Successfully planned and applied in wifi-london**.

We checked the Prometheus server is running successfully by tunnelling into the instance and forwarding to localhost:9090 on our laptops.

Log exporter is not yet enabled in production.

paired: @camdesgov & @sarahseewhy