### PR TITLE
Fix typo in prometheus IPs variable

### DIFF
--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -116,7 +116,7 @@ module "backend" {
   # Whether or not to save Performance Platform backup data
   save-pp-data   = 1
   pp-domain-name = "www.performance.service.gov.uk"
-  prometheus-IPs = "${var.production-prometheus-IP}/32"
+  prometheus-IPs = "${var.production-prometheus-IPs}/32"
 }
 
 # London Frontend ======DIFFERENT AWS REGION===================================
@@ -187,7 +187,7 @@ module "frontend" {
     "${split(",", var.backend-subnet-IPs)}",
   ]
 
-  prometheus-IPs = "${var.production-prometheus-IP}/32"
+  prometheus-IPs = "${var.production-prometheus-IPs}/32"
 
   radius-CIDR-blocks = [
     "${split(",", var.frontend-radius-IPs)}",
@@ -435,5 +435,5 @@ module "govwifi-prometheus" {
   # Value defaults to 0 and should only be enabled (i.e., value = 1) in staging-london and wifi-london
   create_prometheus_server = 1
 
-  prometheus-IPs = "${var.production-prometheus-IP}"
+  prometheus-IPs = "${var.production-prometheus-IPs}"
 }

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -259,4 +259,4 @@ variable "devops-notification-email" {
   type = "string"
 }
 
-variable "production-prometheus-IP" {}
+variable "production-prometheus-IPs" {}


### PR DESCRIPTION
This is typo because the password store has it with a leading 's'.