### PR TITLE
Update latency alert period

### DIFF
--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "radius-latency" {
   evaluation_periods  = "1"
   metric_name         = "TimeToFirstByte"
   namespace           = "AWS/Route53"
-  period              = "60"
+  period              = "120"
   statistic           = "Average"
   threshold           = "1000"
 


### PR DESCRIPTION
* Increase the period to 120 seconds to reduce alert noise. This means we will be alerted when latency is greater than 1 second for two minutes.
* Ideally latency alerts should be turned into a graph so we can identify patterns.
* Something to consider for next time: this alert only captures a single health check ID (I think) which is dynamic. We lose visibility on past latency patterns when the ID changes.