### PR TITLE
Create Prometheus Server In Ireland Production

### DIFF
--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -113,7 +113,8 @@ resource "aws_security_group" "be-vpn-out" {
     cidr_blocks = [
       "${split(",", var.backend-subnet-IPs)}",
       "${split(",", var.frontend-radius-IPs)}",
-      "${var.prometheus-IPs}",
+      "${var.prometheus-IP-ireland}",
+      "${var.prometheus-IP-london}",
     ]
   }
 }

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -120,4 +120,6 @@ variable "user-replica-source-db" {
   default = ""
 }
 
-variable "prometheus-IPs" {}
+variable "prometheus-IP-london" {}
+
+variable "prometheus-IP-ireland" {}

--- a/govwifi-frontend/security_groups.tf
+++ b/govwifi-frontend/security_groups.tf
@@ -63,9 +63,10 @@ resource "aws_security_group" "fe-prometheus-in" {
   }
 
   ingress {
-    from_port   = 9812
-    to_port     = 9812
-    protocol    = "tcp"
+    from_port = 9812
+    to_port   = 9812
+    protocol  = "tcp"
+
     cidr_blocks = [
       "${var.prometheus-IP-ireland}",
       "${var.prometheus-IP-london}",

--- a/govwifi-frontend/security_groups.tf
+++ b/govwifi-frontend/security_groups.tf
@@ -66,7 +66,10 @@ resource "aws_security_group" "fe-prometheus-in" {
     from_port   = 9812
     to_port     = 9812
     protocol    = "tcp"
-    cidr_blocks = ["${var.prometheus-IPs}"]
+    cidr_blocks = [
+      "${var.prometheus-IP-ireland}",
+      "${var.prometheus-IP-london}",
+    ]
   }
 }
 

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -98,3 +98,7 @@ variable "radius-CIDR-blocks" {
   description = "IP addresses for the London and Ireland Radius instances in CIDR block format"
   type        = "list"
 }
+
+variable "prometheus-IP-london" {}
+
+variable "prometheus-IP-ireland" {}

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -77,7 +77,7 @@ resource "aws_ebs_volume" "prometheus_ebs" {
   count             = "${var.create_prometheus_server}"
   size              = 40
   encrypted         = true
-  availability_zone = "${var.aws-region}"
+  availability_zone = "${var.aws-region}a"
 
   tags = {
     Name = "Prometheus volume"

--- a/govwifi-prometheus/variables.tf
+++ b/govwifi-prometheus/variables.tf
@@ -1,8 +1,6 @@
 variable "Env-Name" {}
 
-variable "aws-region" {
-  default = "eu-west-2a"
-}
+variable "aws-region" {}
 
 variable "zone-subnets" {
   default = {

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -389,19 +389,21 @@ module "govwifi-dashboard" {
 }
 
 /*
-We are only configuring a Prometheus server in London for now.
+We are only configuring a Prometheus server in Staging London for now, although
+in production the instance is available in both regions.
 The server will scrape metrics from the agents configured in both regions.
-The module `govwifi-prometheus` only needs to exist in
-govwifi/staging-london/main.tf and govwifi/wifi-london/main.tf.
+There are some problems with the Staging Bastion instance that is preventing
+us from mirroring the setup in Production in Staging. This will be rectified
+when we create a separate staging environment.
 */
 module "govwifi-prometheus" {
   providers = {
     "aws" = "aws.AWS-main"
   }
 
-  source   = "../../govwifi-prometheus"
-  Env-Name = "${var.Env-Name}"
-  aws-region   = "${var.aws-region}"
+  source     = "../../govwifi-prometheus"
+  Env-Name   = "${var.Env-Name}"
+  aws-region = "${var.aws-region}"
 
   ssh-key-name = "${var.ssh-key-name}"
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -401,6 +401,7 @@ module "govwifi-prometheus" {
 
   source   = "../../govwifi-prometheus"
   Env-Name = "${var.Env-Name}"
+  aws-region   = "${var.aws-region}"
 
   ssh-key-name = "${var.ssh-key-name}"
 

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -328,8 +328,9 @@ module "govwifi-prometheus" {
     "aws" = "aws.AWS-main"
   }
 
-  source   = "../../govwifi-prometheus"
-  Env-Name = "${var.Env-Name}"
+  source       = "../../govwifi-prometheus"
+  Env-Name     = "${var.Env-Name}"
+  aws-region   = "${var.aws-region}"
 
   ssh-key-name = "${var.ssh-key-name}"
 
@@ -346,7 +347,7 @@ module "govwifi-prometheus" {
 
   # Feature toggle creating Prometheus server.
   # Value defaults to 0 and should only be enabled (i.e., value = 1)
-  create_prometheus_server = 1
+  create_prometheus_server = 0
 
   prometheus-IPs = "${var.staging-prometheus-IPs}"
 }

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -328,9 +328,9 @@ module "govwifi-prometheus" {
     "aws" = "aws.AWS-main"
   }
 
-  source       = "../../govwifi-prometheus"
-  Env-Name     = "${var.Env-Name}"
-  aws-region   = "${var.aws-region}"
+  source     = "../../govwifi-prometheus"
+  Env-Name   = "${var.Env-Name}"
+  aws-region = "${var.aws-region}"
 
   ssh-key-name = "${var.ssh-key-name}"
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -114,8 +114,8 @@ module "backend" {
   user-db-storage-gb    = 1000
   user-db-replica-count = 1
   # Whether or not to save Performance Platform backup data
-  save-pp-data   = 1
-  pp-domain-name = "www.performance.service.gov.uk"
+  save-pp-data          = 1
+  pp-domain-name        = "www.performance.service.gov.uk"
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -116,7 +116,8 @@ module "backend" {
   # Whether or not to save Performance Platform backup data
   save-pp-data   = 1
   pp-domain-name = "www.performance.service.gov.uk"
-  prometheus-IPs = "${var.production-prometheus-IPs}/32"
+  prometheus-IP-london  = "${var.prometheus-IP-london}/32"
+  prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 }
 
 # London Frontend ======DIFFERENT AWS REGION===================================

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -260,3 +260,7 @@ variable "devops-notification-email" {
 }
 
 variable "production-prometheus-IPs" {}
+
+variable "prometheus-IP-london" {}
+
+variable "prometheus-IP-ireland" {}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -364,9 +364,9 @@ module "govwifi-prometheus" {
     "aws" = "aws.AWS-main"
   }
 
-  source   = "../../govwifi-prometheus"
-  Env-Name = "${var.Env-Name}"
-  aws-region   = "${var.aws-region}"
+  source     = "../../govwifi-prometheus"
+  Env-Name   = "${var.Env-Name}"
+  aws-region = "${var.aws-region}"
 
   ssh-key-name = "${var.ssh-key-name}"
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -382,7 +382,6 @@ module "govwifi-prometheus" {
   dublin-radius-ip-addresses = "${var.dublin-radius-ip-addresses}"
 
   # Feature toggle creating Prometheus server.
-  # Value defaults to 0 and should only be enabled (i.e., value = 1) in staging-london and wifi-london
   create_prometheus_server = 1
 
   prometheus-IPs = "${var.production-prometheus-IPs}"

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -121,7 +121,8 @@ module "backend" {
   user-db-hostname      = "${var.user-db-hostname}"
   user-db-storage-gb    = 20
   user-rr-hostname      = "${var.user-rr-hostname}"
-  prometheus-IPs        = "${var.production-prometheus-IPs}/32"
+  prometheus-IP-london  = "${var.prometheus-IP-london}/32"
+  prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 }
 
 # Emails ======================================================================
@@ -234,7 +235,9 @@ module "frontend" {
     "${split(",", var.backend-subnet-IPs)}",
   ]
 
-  prometheus-IPs = "${var.production-prometheus-IPs}/32"
+  prometheus-IPs        = "${var.production-prometheus-IPs}/32"
+  prometheus-IP-london  = "${var.prometheus-IP-london}/32"
+  prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 
   radius-CIDR-blocks = [
     "${split(",", var.frontend-radius-IPs)}",
@@ -354,4 +357,33 @@ module "route53-critical-notifications" {
   env-name   = "${var.Env-Name}"
   topic-name = "govwifi-wifi-critical"
   emails     = ["${var.critical-notification-email}"]
+}
+
+module "govwifi-prometheus" {
+  providers = {
+    "aws" = "aws.AWS-main"
+  }
+
+  source   = "../../govwifi-prometheus"
+  Env-Name = "${var.Env-Name}"
+  aws-region   = "${var.aws-region}"
+
+  ssh-key-name = "${var.ssh-key-name}"
+
+  frontend-vpc-id = "${module.frontend.frontend-vpc-id}"
+
+  fe-admin-in   = "${module.frontend.fe-admin-in}"
+  fe-ecs-out    = "${module.frontend.fe-ecs-out}"
+  fe-radius-in  = "${module.frontend.fe-radius-in}"
+  fe-radius-out = "${module.frontend.fe-radius-out}"
+
+  wifi-frontend-subnet       = "${module.frontend.wifi-frontend-subnet}"
+  london-radius-ip-addresses = "${var.london-radius-ip-addresses}"
+  dublin-radius-ip-addresses = "${var.dublin-radius-ip-addresses}"
+
+  # Feature toggle creating Prometheus server.
+  # Value defaults to 0 and should only be enabled (i.e., value = 1) in staging-london and wifi-london
+  create_prometheus_server = 1
+
+  prometheus-IPs = "${var.production-prometheus-IPs}"
 }

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -155,6 +155,16 @@ variable "performance-bearer-unique-users" {
   description = "Bearer token for `unique-users` Performance platform statistics"
 }
 
+variable "london-radius-ip-addresses" {
+  type        = "list"
+  description = "Frontend RADIUS server IP addresses - London"
+}
+
+variable "dublin-radius-ip-addresses" {
+  type        = "list"
+  description = "Frontend RADIUS server IP addresses - Dublin"
+}
+
 variable "auth-sentry-dsn" {
   type = "string"
 }
@@ -219,3 +229,7 @@ variable "devops-notification-email" {
 }
 
 variable "production-prometheus-IPs" {}
+
+variable "prometheus-IP-london" {}
+
+variable "prometheus-IP-ireland" {}


### PR DESCRIPTION
Add supporting variables to ensure security groups still
function correctly.

Remove Staging Ireland Prometheus Instance. This has been
put on hold until we have a bastion instance in Ireland as
well as London. Deploying the Staging Ireland instance and
configuring it to use the London Bastion instance for ssh
connection is causing problems.