### PR TITLE
Set Storage Time For Prometheus Data To 90 Days

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -62,6 +62,14 @@ resource "aws_cloudwatch_event_rule" "daily_user_deletion_event" {
   is_enabled          = true
 }
 
+resource "aws_cloudwatch_event_rule" "smoke_test_user_deletion_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-smoke-test-user-deletion"
+  description         = "Triggers daily 23:30 pm UTC"
+  schedule_expression = "cron(30 23 * * ? *)"
+  is_enabled          = true
+}
+
 resource "aws_cloudwatch_event_rule" "daily_gdpr_set_user_last_login" {
   count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-daily-gdpr-set-user-last-login"

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -346,6 +346,43 @@ resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
 EOF
 }
 
+resource "aws_cloudwatch_event_target" "smoke-test-user-deletion" {
+  count     = "${var.user-signup-enabled}"
+  target_id = "${var.Env-Name}-smoke-test-user-deletion"
+  arn       = "${aws_ecs_cluster.api-cluster.arn}"
+  rule      = "${aws_cloudwatch_event_rule.smoke_test_user_deletion_event.name}"
+  role_arn  = "${aws_iam_role.user-signup-scheduled-task-role.arn}"
+
+  ecs_target = {
+    task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.user-signup-api-scheduled-task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration = {
+      subnets = ["${var.subnet-ids}"]
+
+      security_groups = [
+        "${var.backend-sg-list}",
+        "${aws_security_group.api-in.id}",
+        "${aws_security_group.api-out.id}",
+      ]
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "user-signup",
+      "command": ["bundle", "exec", "rake", "delete_smoke_test_users"]
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_ecs_task_definition" "user-signup-api-scheduled-task" {
   count                    = "${var.user-signup-enabled}"
   family                   = "user-signup-api-scheduled-task-${var.Env-Name}"

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -90,10 +90,6 @@ variable "admin-bucket-name" {
   type = "string"
 }
 
-variable "prometheus-IPs" {
-  type = "string"
-}
-
 variable "radius-CIDR-blocks" {
   description = "IP addresses for the London and Ireland Radius instances in CIDR block format"
   type        = "list"

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -80,7 +80,7 @@ resource "aws_ebs_volume" "prometheus_ebs" {
   availability_zone = "${var.aws-region}a"
 
   tags = {
-    Name = "Prometheus volume"
+    Name = "${var.Env-Name} Prometheus volume"
   }
 }
 

--- a/govwifi-prometheus/prometheus-govwifi
+++ b/govwifi-prometheus/prometheus-govwifi
@@ -5,7 +5,9 @@ Documentation=https://github.com/alphagov/govwifi-terraform/blob/master/README.m
 [Service]
 Restart=always
 User=prometheus
-ExecStart=/usr/bin/prometheus --storage.tsdb.path=/srv/prometheus/metrics2
+ExecStart=/usr/bin/prometheus \
+  --storage.tsdb.path=/srv/prometheus/metrics2 \
+  --storage.tsdb.retention.time=90d
 TimeoutStopSec=30s
 
 [Install]

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -116,7 +116,8 @@ module "backend" {
   # Whether or not to save Performance Platform backup data
   save-pp-data   = 1
   pp-domain-name = "www.performance.service.gov.uk"
-  prometheus-IPs = "${var.staging-prometheus-IPs}/32"
+  prometheus-IP-london  = "${var.prometheus-IP-london}/32"
+  prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 }
 
 # London Frontend ==================================================================
@@ -189,7 +190,8 @@ module "frontend" {
     "${split(",", var.backend-subnet-IPs)}",
   ]
 
-  prometheus-IPs = "${var.staging-prometheus-IPs}/32"
+  prometheus-IP-london  = "${var.prometheus-IP-london}/32"
+  prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 
   radius-CIDR-blocks = [
     "${split(",", var.frontend-radius-IPs)}",
@@ -422,5 +424,5 @@ module "govwifi-prometheus" {
   # Value defaults to 0 and is only enabled (i.e., value = 1) in staging-london
   create_prometheus_server = 1
 
-  prometheus-IPs = "${var.staging-prometheus-IPs}"
+  prometheus-IPs = "${var.prometheus-IP-london}"
 }

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -114,8 +114,8 @@ module "backend" {
   user-db-instance-type = "db.t2.small"
   user-db-storage-gb    = 20
   # Whether or not to save Performance Platform backup data
-  save-pp-data   = 1
-  pp-domain-name = "www.performance.service.gov.uk"
+  save-pp-data          = 1
+  pp-domain-name        = "www.performance.service.gov.uk"
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 }

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -261,4 +261,6 @@ variable "govnotify-bearer-token" {
 
 variable "notification-email" {}
 
-variable "staging-prometheus-IPs" {}
+variable "prometheus-IP-london" {}
+
+variable "prometheus-IP-ireland" {}

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -118,7 +118,8 @@ module "backend" {
   user-db-hostname      = ""
   user-db-instance-type = ""
   user-db-storage-gb    = 0
-  prometheus-IPs        = "${var.staging-prometheus-IPs}/32"
+  prometheus-IP-london  = "${var.prometheus-IP-london}/32"
+  prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 }
 
 # Emails ======================================================================
@@ -216,7 +217,8 @@ module "frontend" {
     "${var.bastion-server-IP}",
   ]
 
-  prometheus-IPs = "${var.staging-prometheus-IPs}/32"
+  prometheus-IP-london  = "${var.prometheus-IP-london}/32"
+  prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 
   radius-CIDR-blocks = [
     "${split(",", var.frontend-radius-IPs)}",
@@ -349,5 +351,5 @@ module "govwifi-prometheus" {
   # Value defaults to 0 and should only be enabled (i.e., value = 1)
   create_prometheus_server = 0
 
-  prometheus-IPs = "${var.staging-prometheus-IPs}"
+  prometheus-IPs = "${var.prometheus-IP-ireland}"
 }

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -144,8 +144,6 @@ variable "auth-sentry-dsn" {
 
 variable "notification-email" {}
 
-variable "staging-prometheus-IPs" {}
-
 variable "london-radius-ip-addresses" {
   type        = "list"
   description = "Frontend RADIUS server IP addresses - London"
@@ -155,3 +153,7 @@ variable "dublin-radius-ip-addresses" {
   type        = "list"
   description = "Frontend RADIUS server IP addresses - Dublin"
 }
+
+variable "prometheus-IP-london" {}
+
+variable "prometheus-IP-ireland" {}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -188,7 +188,8 @@ module "frontend" {
     "${split(",", var.backend-subnet-IPs)}",
   ]
 
-  prometheus-IPs = "${var.production-prometheus-IPs}/32"
+  prometheus-IP-london  = "${var.prometheus-IP-london}/32"
+  prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 
   radius-CIDR-blocks = [
     "${split(",", var.frontend-radius-IPs)}",
@@ -416,8 +417,9 @@ module "govwifi-prometheus" {
     "aws" = "aws.AWS-main"
   }
 
-  source   = "../../govwifi-prometheus"
-  Env-Name = "${var.Env-Name}"
+  source     = "../../govwifi-prometheus"
+  Env-Name   = "${var.Env-Name}"
+  aws-region = "${var.aws-region}"
 
   ssh-key-name = "${var.ssh-key-name}"
 
@@ -436,5 +438,5 @@ module "govwifi-prometheus" {
   # Value defaults to 0 and should only be enabled (i.e., value = 1) in staging-london and wifi-london
   create_prometheus_server = 1
 
-  prometheus-IPs = "${var.production-prometheus-IPs}"
+  prometheus-IPs = "${var.prometheus-IP-london}"
 }

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -259,8 +259,6 @@ variable "devops-notification-email" {
   type = "string"
 }
 
-variable "production-prometheus-IPs" {}
-
 variable "prometheus-IP-london" {}
 
 variable "prometheus-IP-ireland" {}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -235,7 +235,6 @@ module "frontend" {
     "${split(",", var.backend-subnet-IPs)}",
   ]
 
-  prometheus-IPs        = "${var.production-prometheus-IPs}/32"
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 
@@ -384,5 +383,5 @@ module "govwifi-prometheus" {
   # Feature toggle creating Prometheus server.
   create_prometheus_server = 1
 
-  prometheus-IPs = "${var.production-prometheus-IPs}"
+  prometheus-IPs = "${var.prometheus-IP-ireland}"
 }

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -228,8 +228,6 @@ variable "devops-notification-email" {
   type = "string"
 }
 
-variable "production-prometheus-IPs" {}
-
 variable "prometheus-IP-london" {}
 
 variable "prometheus-IP-ireland" {}


### PR DESCRIPTION
We want to keep the Prometheus log data for a reasonable period
of time to facilitate debugging and recognise patterns. However
we don't want to keep it forever. We can easily adjust the length
of time we keep the data for in the future.

I have followed the guidance in the official documentation
on how this value should be set: https://prometheus.io/docs/prometheus/latest/storage/

Interestingly it is NOT set in the Prometheus config file. See here for more information:
https://stackoverflow.com/questions/59298811/increasing-prometheus-storage-retention