### PR TITLE
Adds a new cron job to delete smoke test users

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -62,6 +62,14 @@ resource "aws_cloudwatch_event_rule" "daily_user_deletion_event" {
   is_enabled          = true
 }
 
+resource "aws_cloudwatch_event_rule" "smoke_test_user_deletion_event" {
+  count               = "${var.event-rule-count}"
+  name                = "${var.Env-Name}-smoke-test-user-deletion"
+  description         = "Triggers daily 1:00 am UTC"
+  schedule_expression = "cron(30 23 * * ? *)"
+  is_enabled          = true
+}
+
 resource "aws_cloudwatch_event_rule" "daily_gdpr_set_user_last_login" {
   count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-daily-gdpr-set-user-last-login"

--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_event_rule" "daily_user_deletion_event" {
 resource "aws_cloudwatch_event_rule" "smoke_test_user_deletion_event" {
   count               = "${var.event-rule-count}"
   name                = "${var.Env-Name}-smoke-test-user-deletion"
-  description         = "Triggers daily 1:00 am UTC"
+  description         = "Triggers daily 23:30 pm UTC"
   schedule_expression = "cron(30 23 * * ? *)"
   is_enabled          = true
 }

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -345,6 +345,7 @@ resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
 }
 EOF
 }
+
 resource "aws_cloudwatch_event_target" "smoke-test-user-deletion" {
   count     = "${var.user-signup-enabled}"
   target_id = "${var.Env-Name}-smoke-test-user-deletion"


### PR DESCRIPTION
A new task has been created in the signup api to delete smoke test users. This adds a cron job to run at 23:30 after the old user deletion at 23:00