### PR TITLE
Add a managed elasticsearch instance to staging backend VPC

### DIFF
--- a/govwifi-backend/outputs.tf
+++ b/govwifi-backend/outputs.tf
@@ -21,3 +21,7 @@ output "rds-monitoring-role" {
 output "be-admin-in" {
   value = "${aws_security_group.be-admin-in.id}"
 }
+
+output "vpc-cidr-block" {
+  value = "${var.vpc-cidr-block}"
+}

--- a/govwifi-elasticsearch/elasticsearch.tf
+++ b/govwifi-elasticsearch/elasticsearch.tf
@@ -1,0 +1,43 @@
+resource "aws_security_group" "elasticsearch-inbound" {
+  name        = "elasticsearch-inbound"
+  description = "Allow Outbound Traffic From the API"
+  vpc_id      = "${var.vpc-id}"
+
+  tags = {
+    Name = "${title(var.Env-Name)} Elasticsearch inbound traffic"
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc-cidr-block}"]
+  }
+}
+
+resource "aws_elasticsearch_domain" "govwifi-elasticsearch" {
+  domain_name           = "govwifi-elasticsearch"
+  elasticsearch_version = "7.9"
+
+  cluster_config {
+    instance_type            = "t2.small.elasticsearch"
+    instance_count           = 1
+    dedicated_master_enabled = false
+    zone_awareness_enabled   = false
+  }
+
+  vpc_options {
+    subnet_ids = [
+      "${var.backend-subnet-id}",
+    ]
+
+    security_group_ids = [
+      "${aws_security_group.elasticsearch-inbound.id}",
+    ]
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = "10"
+  }
+}

--- a/govwifi-elasticsearch/variables.tf
+++ b/govwifi-elasticsearch/variables.tf
@@ -1,0 +1,11 @@
+variable "Env-Name" {}
+
+variable "Env-Subdomain" {}
+
+variable "aws-region" {}
+
+variable "backend-subnet-id" {}
+
+variable "vpc-id" {}
+
+variable "vpc-cidr-block" {}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -463,3 +463,19 @@ module "govwifi-grafana" {
   grafana-admin           = "${var.grafana-admin}"
   grafana-server-root-url = "${var.grafana-server-root-url}"
 }
+
+module "govwifi-elasticsearch" {
+  providers = {
+    "aws" = "aws.AWS-main"
+  }
+
+  source        = "../../govwifi-elasticsearch"
+  Env-Name      = "${var.Env-Name}"
+  Env-Subdomain = "${var.Env-Subdomain}"
+  aws-region    = "${var.aws-region}"
+
+  vpc-id         = "${module.backend.backend-vpc-id}"
+  vpc-cidr-block = "${module.backend.vpc-cidr-block}"
+
+  backend-subnet-id = "${element(module.backend.backend-subnet-ids, 0)}"
+}


### PR DESCRIPTION
The requirements for this are minimal, so we start off with a one
node instance in staging. Only inbound traffic with HTTPS is allowed
from anywhere within the subnet.ip