### PR TITLE
Pin Grafana & Prometheus AMIs

### DIFF
--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -3,7 +3,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210315"]
   }
 
   filter {

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -3,7 +3,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210315"]
   }
 
   filter {


### PR DESCRIPTION
This is to stop the instances being continually destroyed and recreated by terraform every time a new AMI is released (this happens roughly once a week).