### PR TITLE
Fix Deploy Errors In GovWifi Slack Alert

### DIFF
--- a/govwifi-slack-alerts/main.tf
+++ b/govwifi-slack-alerts/main.tf
@@ -1,22 +1,20 @@
 resource "aws_iam_role" "govwifi-wifi-london-aws-chatbot-role" {
   name        = "govwifi-aws-chatbot-role"
   path        = "/"
-  description = "Role to enable Amazon Chatbot to talk to Slack."
+  description = "Role to enable Amazon Chatbot to function."
 
   assume_role_policy = <<POLICY
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "cloudwatch:Describe*",
-                "cloudwatch:Get*",
-                "cloudwatch:List*"
-            ],
-            "Effect": "Allow",
-            "Resource": "*"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "chatbot.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
 }
 POLICY
 }
@@ -27,15 +25,17 @@ resource "aws_cloudformation_stack" "aws-slack-chatbot" {
   template_body = <<-STACK
   {
     "Resources": {
+      "GovwifiSlackChatbot": {
       "Type" : "AWS::Chatbot::SlackChannelConfiguration",
       "Properties" : {
           "ConfigurationName" : "govwifi-monitoring-chat-configuration",
           "IamRoleArn" : "${aws_iam_role.govwifi-wifi-london-aws-chatbot-role.arn}",
-          "LoggingLevel" : "Off",
-          "SlackChannelId" : "govwifi-monitoring",
-          "SlackWorkspaceId" : "gds-slack-workplace-id",
+          "LoggingLevel" : "NONE",
+          "SlackChannelId" : "${var.gds-slack-channel-id}",
+          "SlackWorkspaceId" : "${var.gds-slack-workplace-id}",
           "SnsTopicArns" : [ "${var.critical-notifications-topic-arn}","${var.capacity-notifications-topic-arn}","${var.route53-critical-notifications-topic-arn}" ]
         }
+      }
     }
   }
   STACK

--- a/govwifi-slack-alerts/variables.tf
+++ b/govwifi-slack-alerts/variables.tf
@@ -3,3 +3,7 @@ variable "critical-notifications-topic-arn" {}
 variable "capacity-notifications-topic-arn" {}
 
 variable "route53-critical-notifications-topic-arn" {}
+
+variable "gds-slack-workplace-id" {}
+
+variable "gds-slack-channel-id" {}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -503,4 +503,6 @@ module "govwifi-slack-alerts" {
   critical-notifications-topic-arn         = "${module.critical-notifications.topic-arn}"
   capacity-notifications-topic-arn         = "${module.capacity-notifications.topic-arn}"
   route53-critical-notifications-topic-arn = "${module.route53-critical-notifications.topic-arn}"
+  gds-slack-workplace-id                   = "${var.gds-slack-workplace-id}"
+  gds-slack-channel-id                     = "${var.gds-slack-channel-id}"
 }

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -277,3 +277,7 @@ variable "google-client-secret" {}
 variable "google-client-id" {}
 
 variable "grafana-server-root-url" {}
+
+variable "gds-slack-workplace-id" {}
+
+variable "gds-slack-channel-id" {}


### PR DESCRIPTION
Add missing Slack channel ID. Correct mistakes in policy. Change role description. Other small fixes.