### PR TITLE
bumped minimum number of API threads to 3 from 2 for perf + dr reasons

### DIFF
--- a/govwifi-api/logging-scaling-policy.tf
+++ b/govwifi-api/logging-scaling-policy.tf
@@ -3,7 +3,7 @@ resource "aws_appautoscaling_target" "logging-ecs-target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.logging-api-service.name}"
   max_capacity       = 20
-  min_capacity       = 2
+  min_capacity       = 3
   scalable_dimension = "ecs:service:DesiredCount"
 }
 

--- a/govwifi-api/scaling-policy.tf
+++ b/govwifi-api/scaling-policy.tf
@@ -2,7 +2,7 @@ resource "aws_appautoscaling_target" "auth-ecs-target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
   max_capacity       = 20
-  min_capacity       = 2
+  min_capacity       = 3
   scalable_dimension = "ecs:service:DesiredCount"
 }
 


### PR DESCRIPTION
Discovered issues when 1 dies leaving just 1 instance - also better to have minimum 3 so at least one in each AZ.
