### PR TITLE
bumped version number to 7.5.2

### DIFF
--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -83,5 +83,5 @@ variable "grafana-device-name" {
 variable "grafana-docker-version" {
   description = "Grafana Docker Version Number"
   type        = string
-  default     = "7.4.0"
+  default     = "7.5.2"
 }


### PR DESCRIPTION
https://grafana.com/docs/grafana/latest/release-notes/

Going from 7.4.0 (4th Feb 2021) to 7.5.2 (30th March 2021)