### PR TITLE
made tfenv checkout the version of terraform that is in repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,6 @@ jobs:
       - name: terraform fmt
         run: |
           brew install tfenv
-          tfenv install
+          tfenv install $(cat .terraform_version)
           find . -name '*.tf' | xargs tools/terraform-format.sh
 


### PR DESCRIPTION
as it was still using version 0.11.x where as repo is now on 0.13.6 and syntax is different

prob due to setting on "macos-latest" that it uses as default would be to pull latest version