### PR TITLE
Get grafana and prometheus talking

### DIFF
--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -75,10 +75,10 @@ resource "aws_security_group" "grafana-ec2-out" {
   }
 
   egress {
-    from_port   = 0
-    to_port     = 65535
+    from_port   = 9090
+    to_port     = 9090
     protocol    = "tcp"
-    cidr_blocks = var.bastion-ips
+    cidr_blocks = var.prometheus-IPs
   }
 
   egress {

--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -95,4 +95,3 @@ resource "aws_security_group" "grafana-ec2-out" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
-

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -46,6 +46,12 @@ variable "bastion-ips" {
   default     = []
 }
 
+variable "prometheus-IPs" {
+  description = "The list of allowed prometheus servers to connect to the EC2 instances on 9090."
+  type        = list(string)
+  default     = []
+}
+
 variable "subnet-ids" {
   description = "List of AWS subnet IDs to place the EC2 instances and ELB into"
   type        = list(string)

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -60,6 +60,7 @@ resource "aws_instance" "prometheus_instance" {
     var.fe-admin-in,
     var.fe-radius-out,
     var.fe-radius-in,
+    aws_security_group.grafana-data-in.id,
   ]
 
   tags = {
@@ -97,6 +98,6 @@ resource "aws_eip_association" "prometheus_eip_assoc" {
   count       = var.create_prometheus_server
   depends_on  = [aws_instance.prometheus_instance]
   instance_id = aws_instance.prometheus_instance[0].id
-  public_ip   = var.prometheus-IPs
+  public_ip   = var.prometheus-IP
 }
 

--- a/govwifi-prometheus/security_groups.tf
+++ b/govwifi-prometheus/security_groups.tf
@@ -1,0 +1,16 @@
+resource "aws_security_group" "grafana-data-in" {
+  name        = "grafana-data-in-${var.Env-Name}"
+  description = "Allow Inbound Traffic from the Grafana instance to collect data"
+  vpc_id      = var.frontend-vpc-id
+
+  tags = {
+    Name = "${title(var.Env-Name)} Grafana Data Traffic In"
+  }
+
+  ingress {
+    from_port   = 9090
+    to_port     = 9090
+    protocol    = "tcp"
+    cidr_blocks = split(",",var.grafana-IP)
+  }
+}

--- a/govwifi-prometheus/security_groups.tf
+++ b/govwifi-prometheus/security_groups.tf
@@ -11,6 +11,6 @@ resource "aws_security_group" "grafana-data-in" {
     from_port   = 9090
     to_port     = 9090
     protocol    = "tcp"
-    cidr_blocks = split(",",var.grafana-IP)
+    cidr_blocks = split(",", var.grafana-IP)
   }
 }

--- a/govwifi-prometheus/variables.tf
+++ b/govwifi-prometheus/variables.tf
@@ -16,7 +16,14 @@ variable "prometheus_volume_size" {
   default = "40"
 }
 
-variable "prometheus-IPs" {
+variable "prometheus-IP" {
+  description = "The EIP of the EC2 instance"
+  type        = string
+}
+
+variable "grafana-IP" {
+  description = "The grafana IP allowed into prometheus servers to connect to the EC2 instances on 9090."
+  type        = string
 }
 
 variable "frontend-vpc-id" {

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -425,7 +425,8 @@ module "govwifi-prometheus" {
   # Value defaults to 0 and is only enabled (i.e., value = 1) in staging-london
   create_prometheus_server = 1
 
-  prometheus-IPs = var.prometheus-IP-london
+  prometheus-IP = var.prometheus-IP-london
+  grafana-IP    = "${var.grafana-IP}/32"
 }
 
 module "govwifi-grafana" {
@@ -453,7 +454,7 @@ module "govwifi-grafana" {
 
   bastion-ips = concat(
     split(",", var.bastion-server-IP),
-    split(",", var.backend-subnet-IPs),
+    split(",", var.backend-subnet-IPs)
   )
 
   administrator-IPs = var.administrator-IPs
@@ -462,6 +463,11 @@ module "govwifi-grafana" {
   google-client-secret    = var.google-client-secret
   grafana-admin           = var.grafana-admin
   grafana-server-root-url = var.grafana-server-root-url
+
+  prometheus-IPs = concat(
+    split(",", "${var.prometheus-IP-london}/32"),
+    split(",", "${var.prometheus-IP-ireland}/32")
+  )
 }
 
 module "govwifi-elasticsearch" {

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -350,6 +350,7 @@ module "govwifi-prometheus" {
   # Value defaults to 0 and should only be enabled (i.e., value = 1)
   create_prometheus_server = 0
 
-  prometheus-IPs = var.prometheus-IP-ireland
+  prometheus-IP = var.prometheus-IP-ireland
+  grafana-IP    = "${var.grafana-IP}/32"
 }
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -455,7 +455,8 @@ module "govwifi-prometheus" {
   # Value defaults to 0 and should only be enabled (i.e., value = 1) in staging-london and wifi-london
   create_prometheus_server = 1
 
-  prometheus-IPs = var.prometheus-IP-london
+  prometheus-IP = var.prometheus-IP-london
+  grafana-IP    = "${var.grafana-IP}/32"
 }
 
 module "govwifi-grafana" {
@@ -492,6 +493,11 @@ module "govwifi-grafana" {
   google-client-secret    = var.google-client-secret
   grafana-admin           = var.grafana-admin
   grafana-server-root-url = var.grafana-server-root-url
+
+  prometheus-IPs = concat(
+    split(",", "${var.prometheus-IP-london}/32"),
+    split(",", "${var.prometheus-IP-ireland}/32")
+  )
 }
 
 module "govwifi-slack-alerts" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -383,6 +383,7 @@ module "govwifi-prometheus" {
   # Feature toggle creating Prometheus server.
   create_prometheus_server = 1
 
-  prometheus-IPs = var.prometheus-IP-ireland
+  prometheus-IP = var.prometheus-IP-ireland
+  grafana-IP    = "${var.grafana-IP}/32"
 }
 


### PR DESCRIPTION
This changes a few terraform parameters to make more sense IP wise and makes inbound and outbound access between all Prometheus servers in an env (Prod/Staging) to be able to communicate with the Grafana server for that env on port 9090

NB First change in **govwifi-grafana/security_groups.tf** does not replace the bastion segment - it was declared twice so removed the duplicate