### PR TITLE
make all "unknown" var cidr_blocks be passed via distinct 

### DIFF
--- a/govwifi-admin/security_groups.tf
+++ b/govwifi-admin/security_groups.tf
@@ -52,7 +52,7 @@ resource "aws_security_group" "admin-ec2-in" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = var.bastion-ips
+    cidr_blocks = distinct(var.bastion-ips)
   }
 }
 
@@ -86,7 +86,7 @@ resource "aws_security_group" "admin-db-in" {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = data.aws_subnet.backend_subnet.*.cidr_block
+    cidr_blocks = distinct(data.aws_subnet.backend_subnet.*.cidr_block)
   }
 }
 

--- a/govwifi-api/elb.tf
+++ b/govwifi-api/elb.tf
@@ -50,7 +50,7 @@ resource "aws_security_group" "api-alb-in" {
     from_port   = 8443
     to_port     = 8443
     protocol    = "tcp"
-    cidr_blocks = var.radius-server-ips
+    cidr_blocks = distinct(var.radius-server-ips)
   }
 }
 

--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -32,14 +32,14 @@ resource "aws_security_group" "be-ecs-out" {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = split(",", var.backend-subnet-IPs)
+    cidr_blocks = distinct(split(",", var.backend-subnet-IPs))
   }
 
   egress {
     from_port   = 11211
     to_port     = 11211
     protocol    = "tcp"
-    cidr_blocks = split(",", var.backend-subnet-IPs)
+    cidr_blocks = distinct(split(",", var.backend-subnet-IPs))
   }
 }
 
@@ -56,7 +56,7 @@ resource "aws_security_group" "be-db-in" {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = split(",", var.backend-subnet-IPs)
+    cidr_blocks = distinct(split(",", var.backend-subnet-IPs))
   }
 }
 
@@ -73,7 +73,7 @@ resource "aws_security_group" "be-admin-in" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = concat(split(",", var.bastion-server-IP), split(",", var.backend-subnet-IPs))
+    cidr_blocks = distinct(concat(split(",", var.bastion-server-IP), split(",", var.backend-subnet-IPs)))
   }
 }
 
@@ -92,7 +92,7 @@ resource "aws_security_group" "be-vpn-in" {
     protocol  = "tcp"
 
     # Temporarily add ITHC IPs. Remove when ITHC complete.
-    cidr_blocks = split(",", var.administrator-IPs)
+    cidr_blocks = distinct(split(",", var.administrator-IPs))
   }
 }
 
@@ -133,14 +133,14 @@ resource "aws_security_group" "be-radius-api-in" {
     from_port   = 8080
     to_port     = 8080
     protocol    = "tcp"
-    cidr_blocks = split(",", var.frontend-radius-IPs)
+    cidr_blocks = distinct(split(",", var.frontend-radius-IPs))
   }
 
   ingress {
     from_port   = 8443
     to_port     = 8443
     protocol    = "tcp"
-    cidr_blocks = split(",", var.frontend-radius-IPs)
+    cidr_blocks = distinct(split(",", var.frontend-radius-IPs))
   }
 }
 

--- a/govwifi-frontend/security_groups.tf
+++ b/govwifi-frontend/security_groups.tf
@@ -47,7 +47,7 @@ resource "aws_security_group" "fe-admin-in" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = var.bastion-ips
+    cidr_blocks = distinct(var.bastion-ips)
   }
 }
 
@@ -150,7 +150,7 @@ resource "aws_security_group" "fe-radius-in" {
     from_port   = 8080
     to_port     = 8080
     protocol    = "tcp"
-    cidr_blocks = data.aws_ip_ranges.route53_healthcheck.cidr_blocks
+    cidr_blocks = distinct(data.aws_ip_ranges.route53_healthcheck.cidr_blocks)
   }
 
   ingress {
@@ -158,7 +158,7 @@ resource "aws_security_group" "fe-radius-in" {
     from_port   = 3000
     to_port     = 3000
     protocol    = "tcp"
-    cidr_blocks = data.aws_ip_ranges.route53_healthcheck.cidr_blocks
+    cidr_blocks = distinct(data.aws_ip_ranges.route53_healthcheck.cidr_blocks)
   }
 
   ingress {
@@ -167,7 +167,7 @@ resource "aws_security_group" "fe-radius-in" {
     to_port     = 9812
     protocol    = "tcp"
 
-    cidr_blocks = var.radius-CIDR-blocks
+    cidr_blocks = distinct(var.radius-CIDR-blocks)
   }
 }
 

--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -8,10 +8,11 @@ resource "aws_security_group" "grafana-alb-in" {
   }
 
   ingress {
+    description = ""
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = split(",", var.administrator-IPs)
+    cidr_blocks = distinct(split(",", var.administrator-IPs))
   }
 }
 
@@ -25,10 +26,11 @@ resource "aws_security_group" "grafana-alb-out" {
   }
 
   egress {
+    description = ""
     from_port   = 0
     to_port     = 65535
     protocol    = "tcp"
-    cidr_blocks = var.bastion-ips
+    cidr_blocks = distinct(var.bastion-ips)
   }
 }
 
@@ -54,7 +56,7 @@ resource "aws_security_group" "grafana-ec2-in" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = var.bastion-ips
+    cidr_blocks = distinct(var.bastion-ips)
   }
 }
 
@@ -68,20 +70,23 @@ resource "aws_security_group" "grafana-ec2-out" {
   }
 
   egress {
+    description = ""
     from_port   = 0
     to_port     = 65535
     protocol    = "tcp"
-    cidr_blocks = var.bastion-ips
+    cidr_blocks = distinct(var.bastion-ips)
   }
 
   egress {
+    description = ""
     from_port   = 9090
     to_port     = 9090
     protocol    = "tcp"
-    cidr_blocks = var.prometheus-IPs
+    cidr_blocks = distinct(var.prometheus-IPs)
   }
 
   egress {
+    description = ""
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
@@ -89,6 +94,7 @@ resource "aws_security_group" "grafana-ec2-out" {
   }
 
   egress {
+    description = ""
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"

--- a/govwifi-prometheus/security_groups.tf
+++ b/govwifi-prometheus/security_groups.tf
@@ -11,6 +11,6 @@ resource "aws_security_group" "grafana-data-in" {
     from_port   = 9090
     to_port     = 9090
     protocol    = "tcp"
-    cidr_blocks = split(",", var.grafana-IP)
+    cidr_blocks = distinct(split(",", var.grafana-IP))
   }
 }


### PR DESCRIPTION
make all "unknown" var cidr_blocks be passed via distinct to ensure all duplicates are removed or terraform is never happy 

e.g. prometheus ireland uses prometheus london so the same IP is in a cidr twice - and terraform tries to make both - but it only ever makes one so its always wanting to make duplicate

also added description = "" as that was also popping up going null <-> ""