### PR TITLE
Add policy to allow all access to elastic search.

### DIFF
--- a/govwifi-elasticsearch/elasticsearch.tf
+++ b/govwifi-elasticsearch/elasticsearch.tf
@@ -40,5 +40,20 @@ resource "aws_elasticsearch_domain" "govwifi-elasticsearch" {
     ebs_enabled = true
     volume_size = "10"
   }
-}
 
+  access_policies = <<DOC
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "es:*",
+      "Resource": "arn:aws:es:${var.aws-region}:${var.aws-account-id}:domain/govwifi-elasticsearch/*"
+    }
+  ]
+}
+DOC
+}

--- a/govwifi-elasticsearch/variables.tf
+++ b/govwifi-elasticsearch/variables.tf
@@ -16,3 +16,5 @@ variable "vpc-id" {
 variable "vpc-cidr-block" {
 }
 
+variable "aws-account-id" {
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -482,7 +482,7 @@ module "govwifi-elasticsearch" {
   Env-Name      = var.Env-Name
   Env-Subdomain = var.Env-Subdomain
   aws-region    = var.aws-region
-
+  aws-account-id = var.aws-account-id
   vpc-id         = module.backend.backend-vpc-id
   vpc-cidr-block = module.backend.vpc-cidr-block
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -478,10 +478,10 @@ module "govwifi-elasticsearch" {
     aws = aws.AWS-main
   }
 
-  source        = "../../govwifi-elasticsearch"
-  Env-Name      = var.Env-Name
-  Env-Subdomain = var.Env-Subdomain
-  aws-region    = var.aws-region
+  source         = "../../govwifi-elasticsearch"
+  Env-Name       = var.Env-Name
+  Env-Subdomain  = var.Env-Subdomain
+  aws-region     = var.aws-region
   aws-account-id = var.aws-account-id
   vpc-id         = module.backend.backend-vpc-id
   vpc-cidr-block = module.backend.vpc-cidr-block


### PR DESCRIPTION
The elastic search instance was locked down by default. 

This opens it up, though access is still restricted by security group.