### PR TITLE
Fix: Increase Cloudwatch Alert Check Interval for Grafana Target Group

### DIFF
--- a/govwifi-grafana/alarms.tf
+++ b/govwifi-grafana/alarms.tf
@@ -49,15 +49,16 @@ resource "aws_cloudwatch_metric_alarm" "grafana-service-status" {
 
   namespace           = "AWS/ApplicationELB"
   metric_name         = "UnHealthyHostCount"
-  period              = "10"
+  period              = "60"
   evaluation_periods  = "1"
   statistic           = "Maximum"
   comparison_operator = "GreaterThanThreshold"
   threshold           = "0"
 
   dimensions = {
-    TargetGroup  = aws_alb_target_group.grafana-tg.id,
-    LoadBalancer = aws_lb.grafana-alb.id
+    TargetGroup      = aws_alb_target_group.grafana-tg.arn_suffix,
+    AvailabilityZone = "${var.aws-region}a",
+    LoadBalancer     = aws_lb.grafana-alb.arn_suffix
   }
 
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -471,7 +471,7 @@ module "govwifi-grafana" {
   Env-Name                   = var.Env-Name
   Env-Subdomain              = var.Env-Subdomain
   aws-region                 = var.aws-region
-  critical-notifications-arn = module.notifications.topic-arn
+  critical-notifications-arn = module.critical-notifications.topic-arn
 
   ssh-key-name = var.ssh-key-name
 


### PR DESCRIPTION
Metrics from the AWS/XXX namespaces only allow interval periods of 60
seconds or greater.

Also Target group and load balancer metrics only behave as expected when
 an "arn suffix" is used (they fail when you use the AWS "arn id"). Also updated.