### PR TITLE
Add an  Elasticsearch instance to production.

### DIFF
--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -517,3 +517,19 @@ module "govwifi-slack-alerts" {
   gds-slack-workplace-id                   = var.gds-slack-workplace-id
   gds-slack-channel-id                     = var.gds-slack-channel-id
 }
+
+module "govwifi-elasticsearch" {
+  providers = {
+    aws = aws.AWS-main
+  }
+
+  source         = "../../govwifi-elasticsearch"
+  Env-Name       = var.Env-Name
+  Env-Subdomain  = var.Env-Subdomain
+  aws-region     = var.aws-region
+  aws-account-id = var.aws-account-id
+  vpc-id         = module.backend.backend-vpc-id
+  vpc-cidr-block = module.backend.vpc-cidr-block
+
+  backend-subnet-id = element(module.backend.backend-subnet-ids, 0)
+}


### PR DESCRIPTION
This commit adds an instance of Elasticsearch to the production
environment (Wifi-london).

Previously we added one to staging (https://github.com/alphagov/govwifi-terraform/pull/360)

This one has a similar configuration and starts off being a minimal
size as we expect minimal load.

Trello: https://trello.com/c/sNXzOvwe/709-provision-managed-elastic-search-in-aws-using-terraform-in-production-4