### PR TITLE
Add an Elasticsearch instance to production.

### DIFF
--- a/govwifi-elasticsearch/elasticsearch.tf
+++ b/govwifi-elasticsearch/elasticsearch.tf
@@ -16,7 +16,7 @@ resource "aws_security_group" "elasticsearch-inbound" {
 }
 
 resource "aws_elasticsearch_domain" "govwifi-elasticsearch" {
-  domain_name           = "govwifi-elasticsearch"
+  domain_name           = var.domain-name
   elasticsearch_version = "7.9"
 
   cluster_config {
@@ -51,7 +51,7 @@ resource "aws_elasticsearch_domain" "govwifi-elasticsearch" {
         "AWS": "*"
       },
       "Action": "es:*",
-      "Resource": "arn:aws:es:${var.aws-region}:${var.aws-account-id}:domain/govwifi-elasticsearch/*"
+      "Resource": "arn:aws:es:${var.aws-region}:${var.aws-account-id}:domain/${var.domain-name}/*"
     }
   ]
 }

--- a/govwifi-elasticsearch/variables.tf
+++ b/govwifi-elasticsearch/variables.tf
@@ -18,3 +18,6 @@ variable "vpc-cidr-block" {
 
 variable "aws-account-id" {
 }
+
+variable "domain-name" {
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -480,6 +480,7 @@ module "govwifi-elasticsearch" {
   }
 
   source         = "../../govwifi-elasticsearch"
+  domain-name    = "${var.Env-Name}-elasticsearch"
   Env-Name       = var.Env-Name
   Env-Subdomain  = var.Env-Subdomain
   aws-region     = var.aws-region
@@ -487,5 +488,5 @@ module "govwifi-elasticsearch" {
   vpc-id         = module.backend.backend-vpc-id
   vpc-cidr-block = module.backend.vpc-cidr-block
 
-  backend-subnet-id = element(module.backend.backend-subnet-ids, 0)
+  backend-subnet-id = module.backend.backend-subnet-ids[0]
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -517,3 +517,22 @@ module "govwifi-slack-alerts" {
   gds-slack-workplace-id                   = var.gds-slack-workplace-id
   gds-slack-channel-id                     = var.gds-slack-channel-id
 }
+
+module "govwifi-elasticsearch" {
+  providers = {
+    aws = aws.AWS-main
+  }
+
+  source         = "../../govwifi-elasticsearch"
+  domain-name    = "${var.Env-Name}-elasticsearch"
+  Env-Name       = var.Env-Name
+  Env-Subdomain  = var.Env-Subdomain
+  aws-region     = var.aws-region
+  aws-account-id = var.aws-account-id
+  vpc-id         = module.backend.backend-vpc-id
+  vpc-cidr-block = module.backend.vpc-cidr-block
+
+  backend-subnet-id = module.backend.backend-subnet-ids[0]
+}
+
+


### PR DESCRIPTION
This commit adds an instance of Elasticsearch to the production
environment (Wifi-london).

Previously we added one to staging (#360)

This one has a similar configuration and starts off being a minimal
size as we expect minimal load.

The domain name has  had to be changed to avoid name collision between environments

Trello: https://trello.com/c/sNXzOvwe/709-provision-managed-elastic-search-in-aws-using-terraform-in-production-4