### PR TITLE
Change the size of the Elastic Search instance to medium

### DIFF
--- a/govwifi-elasticsearch/elasticsearch.tf
+++ b/govwifi-elasticsearch/elasticsearch.tf
@@ -20,7 +20,7 @@ resource "aws_elasticsearch_domain" "govwifi-elasticsearch" {
   elasticsearch_version = "7.9"
 
   cluster_config {
-    instance_type            = "t2.small.elasticsearch"
+    instance_type            = "t3.medium.elasticsearch"
     instance_count           = 1
     dedicated_master_enabled = false
     zone_awareness_enabled   = false


### PR DESCRIPTION
We tried to use the 'small' size previously, but it takes
too long to provision (>1 hour). This caused Terraform to
time out and break.

The new size (medium) is up and running in around 10 minutes.