### PR TITLE
Added update-secrets function to run after .private for unencrypting-secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ run-terraform-init: check-env
 init-backend: check-env unencrypt-secrets run-terraform-init delete-secrets ## Initalize the terraform backend. Use this when first working on the project to download the required state file. Must run in form make <env> init-backend
 rencrypt-passwords: .private ## Rencrypt passwords after adding a new gpg id to the password store
 	PASSWORD_STORE_DIR=$$(pwd)/.private/passwords pass init $$(cat .private/passwords/.gpg-id)
-unencrypt-secrets: .private
+unencrypt-secrets: .private update-secrets
 	scripts/unencrypt-secrets.sh unencrypt
 delete-secrets: .private
 	scripts/unencrypt-secrets.sh delete


### PR DESCRIPTION
**WHAT**

This will do a `git pull` in .private before doing the unencytpion

**WHY**

Its very easy to forget to do a `cd .private; git pull` befpre doing a plan/apply meaning old passwords/api links etc may be accidently put into staging/prod

I can only assume at somepoint in the past people may have made local modifications to the .password before running it - but that should not be done (IMHO)