### PR TITLE
Add elasticsearch endpoint environment variable

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -94,6 +94,9 @@ resource "aws_ecs_task_definition" "logging-api-task" {
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
+        },{
+          "name": "VOLUMETRICS_ENDPOINT",
+          "value": "${var.volumetrics-elasticsearch-endpoint}"
         }
       ],
       "links": null,

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -252,3 +252,9 @@ variable "metrics-bucket-name" {
   description = "Name of the S3 bucket to write metrics into"
 }
 
+variable "volumetrics-elasticsearch-endpoint" {
+  type        = string
+  default     = ""
+  description = "URL for the ElasticSearch instance endpoint"
+}
+

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -353,6 +353,7 @@ module "api" {
   admin-bucket-name                  = "govwifi-staging-admin"
   govnotify-bearer-token             = var.govnotify-bearer-token
   user-signup-api-is-public          = 1
+  volumetrics-elasticsearch-endpoint = var.volumetrics-elasticsearch-endpoint
 
   elb-sg-list = []
 

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -307,3 +307,7 @@ variable "aws-parent-account-id" {
   description = "Unused in this configuration"
 }
 
+variable "volumetrics-elasticsearch-endpoint" {
+  type        = string
+  description = "URL for the ElasticSearch instance endpoint"
+}


### PR DESCRIPTION
## What

Add the newly created secret to Terraform

## Why

We need this in place for the rake task to use when syncing data to ES.