### PR TITLE
Migrate healthcheck creds to secrets manager

### DIFF
--- a/govwifi-account/iam-user-policy.tf
+++ b/govwifi-account/iam-user-policy.tf
@@ -1,3 +1,136 @@
+resource "aws_iam_user_policy" "dashboard-staging-read-only-user_dashboard-staging-read-only-policy" {
+  name = "dashboard-staging-read-only-policy"
+  user = "dashboard-staging-read-only-user"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::govwifi-staging-metrics-bucket/*"
+    },
+    {
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::govwifi-staging-metrics-bucket"
+    }
+  ]
+}
+POLICY
+
+}
+
+resource "aws_iam_user_policy" "dashboard-wifi-read-only-user_dashboard-wifi-read-only-policy" {
+  name = "dashboard-wifi-read-only-policy"
+  user = "dashboard-wifi-read-only-user"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::govwifi-wifi-metrics-bucket/*"
+    },
+    {
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::govwifi-wifi-metrics-bucket"
+    }
+  ]
+}
+POLICY
+
+}
+
+resource "aws_iam_user_policy" "govwifi-jenkins-deploy_can-restart-ecs-services" {
+  name = "can-restart-ecs-services"
+  user = "govwifi-jenkins-deploy"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VisualEditor0",
+      "Effect": "Allow",
+      "Action": "ecs:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+
+}
+
+resource "aws_iam_user_policy" "govwifi-jenkins-deploy_read-wordlist-policy" {
+  name = "read-wordlist-policy"
+  user = "govwifi-jenkins-deploy"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VisualEditor0",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucketVersions",
+        "s3:GetBucketVersioning",
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::govwifi-wordlist"
+    },
+    {
+      "Sid": "VisualEditor1",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:PutObjectVersionAcl"
+      ],
+      "Resource": "arn:aws:s3:::govwifi-wordlist/*"
+    }
+  ]
+}
+POLICY
+
+}
+
+resource "aws_iam_user_policy" "jenkins-read-wordlist-user_jenkins-read-wordlist-policy" {
+  name = "jenkins-read-wordlist-policy"
+  user = "jenkins-read-wordlist-user"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::govwifi-wordlist/wordlist-short"
+    }
+  ]
+}
+POLICY
+
+}
+
 resource "aws_iam_user_policy" "monitoring-stats-user_monitoring-stats-user-policy" {
   name = "monitoring-stats-user-policy"
   user = "monitoring-stats-user"

--- a/govwifi-backend/db-users.tf
+++ b/govwifi-backend/db-users.tf
@@ -37,7 +37,7 @@ resource "aws_db_instance" "users_db" {
 resource "aws_db_instance" "users_read_replica" {
   count                       = var.user-db-replica-count
   replicate_source_db         = var.user-replica-source-db
-  kms_key_id                  = var.rds-kms-key-id
+  kms_key_id                  = data.aws_kms_key.rds_kms_key.arn
   storage_encrypted           = var.db-encrypt-at-rest
   storage_type                = "gp2"
   engine_version              = "8.0"

--- a/govwifi-backend/kms.tf
+++ b/govwifi-backend/kms.tf
@@ -1,0 +1,3 @@
+data "aws_kms_key" "rds_kms_key" {
+  key_id = "alias/aws/rds"
+}

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -171,3 +171,6 @@ variable "prometheus-IP-ireland" {
 variable "grafana-IP" {
 }
 
+variable "use_env_prefix" {
+}
+

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -21,8 +21,9 @@ resource "aws_ecr_repository" "govwifi-raddb-ecr" {
 }
 
 resource "aws_ecs_task_definition" "radius-task" {
-  family        = "radius-task-${var.Env-Name}"
-  task_role_arn = aws_iam_role.ecs-task-role.arn
+  family             = "radius-task-${var.Env-Name}"
+  task_role_arn      = aws_iam_role.ecs-task-role.arn
+  execution_role_arn = aws_iam_role.ecsTaskExecutionRole.arn
 
   volume {
     name = "raddb-certs"
@@ -75,29 +76,32 @@ resource "aws_ecs_task_definition" "radius-task" {
         "name": "LOGGING_API_BASE_URL",
         "value": "${var.logging-api-base-url}"
       },{
-        "name": "BACKEND_API_KEY",
-        "value": "${var.shared-key}"
-      },{
-        "name": "HEALTH_CHECK_RADIUS_KEY",
-        "value": "${var.healthcheck-radius-key}"
-      },{
-        "name": "HEALTH_CHECK_SSID",
-        "value": "${var.healthcheck-ssid}"
-      },{
-        "name": "HEALTH_CHECK_IDENTITY",
-        "value": "${var.healthcheck-identity}"
-      },{
-        "name": "HEALTH_CHECK_PASSWORD",
-        "value": "${var.healthcheck-password}"
-      },{
-        "name": "SERVICE_DOMAIN",
-        "value": "${var.Env-Subdomain}"
-      },{
         "name": "RADIUSD_PARAMS",
         "value": "${var.radiusd-params}"
       },{
         "name": "RACK_ENV",
         "value": "${var.rack-env}"
+      },{
+        "name": "SERVICE_DOMAIN",
+        "value": "${var.Env-Subdomain}"
+      }
+    ],
+    "secrets": [
+      {
+        "name": "BACKEND_API_KEY",
+        "valueFrom": "${data.aws_secretsmanager_secret_version.shared_key.arn}:shared-key::"
+      },{
+        "name": "HEALTH_CHECK_IDENTITY",
+        "valueFrom": "${data.aws_secretsmanager_secret_version.healthcheck.arn}:identity::"
+      },{
+        "name": "HEALTH_CHECK_PASSWORD",
+        "valueFrom": "${data.aws_secretsmanager_secret_version.healthcheck.arn}:pass::"
+      },{
+        "name": "HEALTH_CHECK_RADIUS_KEY",
+        "valueFrom": "${data.aws_secretsmanager_secret_version.healthcheck.arn}:key::"
+      },{
+        "name": "HEALTH_CHECK_SSID",
+        "valueFrom": "${data.aws_secretsmanager_secret_version.healthcheck.arn}:ssid::"
       }
     ],
     "image": "${var.frontend-docker-image}",

--- a/govwifi-frontend/iam-roles.tf
+++ b/govwifi-frontend/iam-roles.tf
@@ -104,7 +104,6 @@ EOF
 
 }
 
-# Unused until a loadbalancer is set up
 resource "aws_iam_role" "ecs-task-role" {
   name = "${var.aws-region-name}-frontend-ecs-task-role-${var.Env-Name}"
 
@@ -166,3 +165,44 @@ data "aws_iam_policy_document" "admin_bucket_policy" {
   }
 }
 
+resource "aws_iam_role" "ecsTaskExecutionRole" {
+  name               = "ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}-SecretsManager"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole" {
+  role       = aws_iam_role.ecsTaskExecutionRole.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "secrets_manager_policy" {
+  name   = "${var.aws-region-name}-radius-access-secrets-manager-${var.Env-Name}"
+  role   = aws_iam_role.ecsTaskExecutionRole.id
+  policy = data.aws_iam_policy_document.secrets_manager_policy.json
+}
+
+data "aws_iam_policy_document" "secrets_manager_policy" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = [
+      data.aws_secretsmanager_secret.healthcheck.arn,
+      data.aws_secretsmanager_secret.shared_key.arn
+    ]
+  }
+}

--- a/govwifi-frontend/locals.tf
+++ b/govwifi-frontend/locals.tf
@@ -1,4 +1,3 @@
 locals {
   frontend_metrics_namespace = "${var.Env-Name}-frontend"
 }
-

--- a/govwifi-frontend/secrets-manager.tf
+++ b/govwifi-frontend/secrets-manager.tf
@@ -1,0 +1,15 @@
+data "aws_secretsmanager_secret_version" "healthcheck" {
+  secret_id = data.aws_secretsmanager_secret.healthcheck.id
+}
+
+data "aws_secretsmanager_secret" "healthcheck" {
+  name = var.use_env_prefix ? "staging/radius/healthcheck" : "radius/healthcheck"
+}
+
+data "aws_secretsmanager_secret_version" "shared_key" {
+  secret_id = data.aws_secretsmanager_secret.shared_key.id
+}
+
+data "aws_secretsmanager_secret" "shared_key" {
+  name = var.use_env_prefix ? "staging/radius/shared-key" : "radius/shared-key"
+}

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -124,3 +124,5 @@ variable "prometheus-IP-london" {
 variable "prometheus-IP-ireland" {
 }
 
+variable "use_env_prefix" {
+}

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
+}
+
+locals {
+  docker_image_path = jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"]
+}
+
+locals {
+  route53_zone_id = jsondecode(data.aws_secretsmanager_secret_version.route53_zone_id.secret_string)["route53-zone-id"]
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -126,6 +126,8 @@ module "backend" {
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
   grafana-IP            = "${var.grafana-IP}/32"
+
+  use_env_prefix = var.use_env_prefix
 }
 
 # London Frontend ==================================================================
@@ -202,6 +204,8 @@ module "frontend" {
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 
   radius-CIDR-blocks = split(",", var.frontend-radius-IPs)
+
+  use_env_prefix = var.use_env_prefix
 }
 
 module "govwifi-admin" {

--- a/govwifi/staging-london/secrets-manager.tf
+++ b/govwifi/staging-london/secrets-manager.tf
@@ -1,0 +1,23 @@
+data "aws_secretsmanager_secret_version" "aws_account_id" {
+  secret_id = data.aws_secretsmanager_secret.aws_account_id.id
+}
+
+data "aws_secretsmanager_secret" "aws_account_id" {
+  name = var.use_env_prefix ? "staging/aws/account-id" : "aws/account-id"
+}
+
+data "aws_secretsmanager_secret_version" "docker_image_path" {
+  secret_id = data.aws_secretsmanager_secret.docker_image_path.id
+}
+
+data "aws_secretsmanager_secret" "docker_image_path" {
+  name = var.use_env_prefix ? "staging/aws/ecr/docker-image-path/govwifi" : "aws/ecr/docker-image-path/govwifi"
+}
+
+data "aws_secretsmanager_secret_version" "route53_zone_id" {
+  secret_id = data.aws_secretsmanager_secret.route53_zone_id.id
+}
+
+data "aws_secretsmanager_secret" "route53_zone_id" {
+  name = var.use_env_prefix ? "staging/aws/route53/zone-id" : "aws/route53/zone-id"
+}

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -311,3 +311,9 @@ variable "volumetrics-elasticsearch-endpoint" {
   type        = string
   description = "URL for the ElasticSearch instance endpoint"
 }
+
+variable "use_env_prefix" {
+  default     = true
+  type        = bool
+  description = "Conditional to indicate whether to retrieve a secret with a env prefix in its name."
+}

--- a/govwifi/staging/locals.tf
+++ b/govwifi/staging/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
+}
+
+locals {
+  docker_image_path = jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"]
+}
+
+locals {
+  route53_zone_id = jsondecode(data.aws_secretsmanager_secret_version.route53_zone_id.secret_string)["route53-zone-id"]
+}

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -6,7 +6,7 @@ module "tfstate" {
   source             = "../../terraform-state"
   product-name       = var.product-name
   Env-Name           = var.Env-Name
-  aws-account-id     = var.aws-account-id
+  aws-account-id     = local.aws_account_id
   aws-region         = var.aws-region
   aws-region-name    = var.aws-region-name
   backup-region-name = var.backup-region-name
@@ -58,7 +58,7 @@ module "backend" {
 
   # AWS VPC setup -----------------------------------------
   aws-region      = var.aws-region
-  route53-zone-id = var.route53-zone-id
+  route53-zone-id = local.route53_zone_id
   aws-region-name = var.aws-region-name
   vpc-cidr-block  = "10.100.0.0/16"
   zone-count      = var.zone-count
@@ -87,7 +87,7 @@ module "backend" {
   bastion-ssh-key-name      = "govwifi-staging-bastion-key-20181025"
   enable-bastion-monitoring = false
   users                     = var.users
-  aws-account-id            = var.aws-account-id
+  aws-account-id            = local.aws_account_id
 
   db-encrypt-at-rest       = true
   db-maintenance-window    = "sat:00:42-sat:01:12"
@@ -104,7 +104,7 @@ module "backend" {
   rr-storage-gb    = 0
 
   user-db-replica-count  = 1
-  user-replica-source-db = "arn:aws:rds:eu-west-2:${var.aws-account-id}:db:wifi-staging-user-db"
+  user-replica-source-db = "arn:aws:rds:eu-west-2:${local.aws_account_id}:db:wifi-staging-user-db"
   user-rr-instance-type  = "db.t2.small"
 
   user-rr-hostname           = var.user-rr-hostname
@@ -125,6 +125,8 @@ module "backend" {
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
   grafana-IP            = "${var.grafana-IP}/32"
+
+  use_env_prefix = var.use_env_prefix
 }
 
 # Emails ======================================================================
@@ -137,8 +139,8 @@ module "emails" {
   product-name             = var.product-name
   Env-Name                 = var.Env-Name
   Env-Subdomain            = var.Env-Subdomain
-  aws-account-id           = var.aws-account-id
-  route53-zone-id          = var.route53-zone-id
+  aws-account-id           = local.aws_account_id
+  route53-zone-id          = local.route53_zone_id
   aws-region               = var.aws-region
   aws-region-name          = var.aws-region-name
   mail-exchange-server     = "10 inbound-smtp.eu-west-1.amazonaws.com"
@@ -171,7 +173,7 @@ module "frontend" {
   # AWS VPC setup -----------------------------------------
   aws-region      = var.aws-region
   aws-region-name = var.aws-region-name
-  route53-zone-id = var.route53-zone-id
+  route53-zone-id = local.route53_zone_id
   vpc-cidr-block  = "10.101.0.0/16"
   zone-count      = var.zone-count
   zone-names      = var.zone-names
@@ -195,8 +197,8 @@ module "frontend" {
   ami                   = var.ami
   ssh-key-name          = var.ssh-key-name
   users                 = var.users
-  frontend-docker-image = format("%s/frontend:staging", var.docker-image-path)
-  raddb-docker-image    = format("%s/raddb:staging", var.docker-image-path)
+  frontend-docker-image = format("%s/frontend:staging", local.docker_image_path)
+  raddb-docker-image    = format("%s/raddb:staging", local.docker_image_path)
 
   # admin bucket
   admin-bucket-name = "govwifi-staging-admin"
@@ -226,6 +228,8 @@ module "frontend" {
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 
   radius-CIDR-blocks = split(",", var.frontend-radius-IPs)
+
+  use_env_prefix = var.use_env_prefix
 }
 
 module "api" {
@@ -248,7 +252,7 @@ module "api" {
   aws-account-id         = var.aws-account-id
   aws-region-name        = var.aws-region-name
   aws-region             = var.aws-region
-  route53-zone-id        = var.route53-zone-id
+  route53-zone-id        = local.route53_zone_id
   vpc-id                 = module.backend.backend-vpc-id
 
   user-signup-enabled  = 0
@@ -261,7 +265,7 @@ module "api" {
   capacity-notifications-arn = module.notifications.topic-arn
   devops-notifications-arn   = module.notifications.topic-arn
 
-  auth-docker-image         = format("%s/authorisation-api:staging", var.docker-image-path)
+  auth-docker-image         = format("%s/authorisation-api:staging", local.docker_image_path)
   user-signup-docker-image  = ""
   logging-docker-image      = ""
   safe-restart-docker-image = ""

--- a/govwifi/staging/secrets-manager.tf
+++ b/govwifi/staging/secrets-manager.tf
@@ -1,0 +1,23 @@
+data "aws_secretsmanager_secret_version" "aws_account_id" {
+  secret_id = data.aws_secretsmanager_secret.aws_account_id.id
+}
+
+data "aws_secretsmanager_secret" "aws_account_id" {
+  name = var.use_env_prefix ? "staging/aws/account-id" : "aws/account-id"
+}
+
+data "aws_secretsmanager_secret_version" "docker_image_path" {
+  secret_id = data.aws_secretsmanager_secret.docker_image_path.id
+}
+
+data "aws_secretsmanager_secret" "docker_image_path" {
+  name = var.use_env_prefix ? "staging/aws/ecr/docker-image-path/govwifi" : "aws/ecr/docker-image-path/govwifi"
+}
+
+data "aws_secretsmanager_secret_version" "route53_zone_id" {
+  secret_id = data.aws_secretsmanager_secret.route53_zone_id.id
+}
+
+data "aws_secretsmanager_secret" "route53_zone_id" {
+  name = var.use_env_prefix ? "staging/aws/route53/zone-id" : "aws/route53/zone-id"
+}

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -179,3 +179,9 @@ variable "elb-public-IPs" {
 variable "aws-parent-account-id" {
   description = "Unused in this configuration"
 }
+
+variable "use_env_prefix" {
+  default     = true
+  type        = bool
+  description = "Conditional to indicate whether to retrieve a secret with a env prefix in its name."
+}

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
+}
+
+locals {
+  docker_image_path = jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"]
+}
+
+locals {
+  route53_zone_id = jsondecode(data.aws_secretsmanager_secret_version.route53_zone_id.secret_string)["route53-zone-id"]
+}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -142,6 +142,8 @@ module "backend" {
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
   grafana-IP            = "${var.grafana-IP}/32"
+
+  use_env_prefix = var.use_env_prefix
 }
 
 # London Frontend ======DIFFERENT AWS REGION===================================
@@ -216,6 +218,8 @@ module "frontend" {
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 
   radius-CIDR-blocks = split(",", var.frontend-radius-IPs)
+
+  use_env_prefix = var.use_env_prefix
 }
 
 module "govwifi-admin" {

--- a/govwifi/wifi-london/secrets-manager.tf
+++ b/govwifi/wifi-london/secrets-manager.tf
@@ -1,0 +1,23 @@
+data "aws_secretsmanager_secret_version" "aws_account_id" {
+  secret_id = data.aws_secretsmanager_secret.aws_account_id.id
+}
+
+data "aws_secretsmanager_secret" "aws_account_id" {
+  name = "aws/account-id"
+}
+
+data "aws_secretsmanager_secret_version" "docker_image_path" {
+  secret_id = data.aws_secretsmanager_secret.docker_image_path.id
+}
+
+data "aws_secretsmanager_secret" "docker_image_path" {
+  name = "aws/ecr/docker-image-path/govwifi"
+}
+
+data "aws_secretsmanager_secret_version" "route53_zone_id" {
+  secret_id = data.aws_secretsmanager_secret.route53_zone_id.id
+}
+
+data "aws_secretsmanager_secret" "route53_zone_id" {
+  name = "aws/route53/zone-id"
+}

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -310,3 +310,9 @@ variable "allowed-sites-api-elb-ssl-cert-arn" {
 variable "backend-subnet-IPs-list" {
   description = "Unused in this configuration"
 }
+
+variable "use_env_prefix" {
+  default     = false
+  type        = bool
+  description = "Conditional to indicate whether to retrieve a secret with a env prefix in its name."
+}

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
+}
+
+locals {
+  docker_image_path = jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"]
+}
+
+locals {
+  route53_zone_id = jsondecode(data.aws_secretsmanager_secret_version.route53_zone_id.secret_string)["route53-zone-id"]
+}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -128,6 +128,8 @@ module "backend" {
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
   grafana-IP            = "${var.grafana-IP}/32"
+
+  use_env_prefix = var.use_env_prefix
 }
 
 # Emails ======================================================================
@@ -245,6 +247,8 @@ module "frontend" {
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
 
   radius-CIDR-blocks = split(",", var.frontend-radius-IPs)
+
+  use_env_prefix = var.use_env_prefix
 }
 
 module "api" {

--- a/govwifi/wifi/secrets-manager.tf
+++ b/govwifi/wifi/secrets-manager.tf
@@ -1,0 +1,23 @@
+data "aws_secretsmanager_secret_version" "aws_account_id" {
+  secret_id = data.aws_secretsmanager_secret.aws_account_id.id
+}
+
+data "aws_secretsmanager_secret" "aws_account_id" {
+  name = "aws/account-id"
+}
+
+data "aws_secretsmanager_secret_version" "docker_image_path" {
+  secret_id = data.aws_secretsmanager_secret.docker_image_path.id
+}
+
+data "aws_secretsmanager_secret" "docker_image_path" {
+  name = "aws/ecr/docker-image-path/govwifi"
+}
+
+data "aws_secretsmanager_secret_version" "route53_zone_id" {
+  secret_id = data.aws_secretsmanager_secret.route53_zone_id.id
+}
+
+data "aws_secretsmanager_secret" "route53_zone_id" {
+  name = "aws/route53/zone-id"
+}

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -244,3 +244,9 @@ variable "administrator-IPs-list" {
 variable "backend-subnet-IPs-list" {
   description = "Unused in this configuration"
 }
+
+variable "use_env_prefix" {
+  default     = false
+  type        = bool
+  description = "Conditional to indicate whether to retrieve a secret with a env prefix in its name."
+}


### PR DESCRIPTION
### What

Configure our code to pull credentials from Secrets Manager instead of govwifi-build. I'd previously tried migrating all the credentials from our staging file. I discovered this was too much change at once and de-scoped the work to just RADIUS healthcheck credentials and some common AWS credentials.

We also agreed as a team to phase out the env prefix naming pattern in our infrastructure (it will become redundant). We have to maintain two naming conventions while we're transitioning to the new naming pattern. I've implemented a conditional use_env_prefix and ternary operator to distinguish between the secret names in use.

I manually added the relevant credentials to Secrets Manager in the UI (values in govwifi-build/secrets-to-copy/govwifi/staging/secrets.auto.tfvars). For the credentials shared across Staging Ireland and London, I manually replicated the secrets across to the London region. Note: I did not manually add aws-parent-account-id since it isn't used in Staging Ireland.

I ran into some git issues when making the [previous PR](https://github.com/alphagov/govwifi-terraform/pull/412), @koetsier helpfully consolidated the work into a single commit. We  lose a sense of progress/story but it's easier to review.

This PR:

* Reconfigured our Terraform to retrieve these credentials from Secrets Manager.
* Credentials shared across multiple modules are configured in govwifi/staging/secrets-manager.tf for reference in the main.tf file.
* Custom credentials used in specific module directories are configured in those directories (e.g., gowifi-frontend/secrets-manager.tf).
* ECS cluster definitions required a custom configuration to allow the task definition to query Secrets Manager directly. This requires hard-coding the key names in the task definition.
* Refactored the KMS key ID for User Details RDS read replica by retrieving it directly from its AWS ARN instead of hard-coding the value in Secrets Manager.

### Why
Migrating to Secrets Manager delivers significant security value (automatic rotation, sunsetting of govwifi-build private repo). It was raised as a priority in Live Assessment and threat modelling sessions.

Trello card: https://trello.com/c/RjcxTwYV/1030-sub-task-migrate-secrets-to-copy-in-staging-ireland