### PR TITLE
Migrate Admin API ECS credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ apply: check-env unencrypt-secrets apply_task delete-secrets ## Run terraform ap
 .PHONY: terraform
 terraform_task: check-env
 # if running a targeted terraform plan/apply, remove `delete-secrets` command from the list
-terraform: check-env unencrypt-secrets delete-secrets
+terraform: check-env unencrypt-secrets
 	scripts/run-terraform.sh ${terraform_cmd}
 destroy_task: check-env
 	scripts/run-terraform.sh destroy

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ apply: check-env unencrypt-secrets apply_task delete-secrets ## Run terraform ap
 .PHONY: terraform
 terraform_task: check-env
 # if running a targeted terraform plan/apply, remove `delete-secrets` command from the list
-terraform: check-env unencrypt-secrets
+terraform: check-env unencrypt-secrets delete-secrets
 	scripts/run-terraform.sh ${terraform_cmd}
 destroy_task: check-env
 	scripts/run-terraform.sh destroy

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -51,12 +51,6 @@ resource "aws_ecs_task_definition" "admin-task" {
           "name": "RACK_ENV",
           "value": "${var.rack-env}"
         },{
-          "name": "SECRET_KEY_BASE",
-          "value": "${var.secret-key-base}"
-        },{
-          "name": "DEVISE_SECRET_KEY",
-          "value": "${var.secret-key-base}"
-        },{
           "name": "RAILS_LOG_TO_STDOUT",
           "value": "1"
         },{
@@ -132,20 +126,26 @@ resource "aws_ecs_task_definition" "admin-task" {
           "name": "ZENDESK_API_USER",
           "value": "${var.zendesk-api-user}"
         },{
-          "name": "ZENDESK_API_TOKEN",
-          "value": "${var.zendesk-api-token}"
-        },{
           "name": "GOOGLE_MAPS_PUBLIC_API_KEY",
           "value": "${var.public-google-api-key}"
-        },{
-          "name": "OTP_SECRET_ENCRYPTION_KEY",
-          "value": "${var.otp-secret-encryption-key}"
         }
       ],
       "secrets": [
         {
           "name": "NOTIFY_API_KEY",
           "valueFrom": "${data.aws_secretsmanager_secret_version.notify_api_key.arn}:notify-api-key::"
+        },{
+          "name": "ZENDESK_API_TOKEN",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.zendesk_api_token.arn}:zendesk-api-token::"
+        },{
+          "name": "SECRET_KEY_BASE",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.key_base.arn}:secret-key-base::"
+        },{
+          "name": "DEVISE_SECRET_KEY",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.key_base.arn}:secret-key-base::"
+        },{
+          "name": "OTP_SECRET_ENCRYPTION_KEY",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.otp_encryption_key.arn}:key::"
         }
       ],
       "image": "${var.admin-docker-image}",

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -48,9 +48,6 @@ resource "aws_ecs_task_definition" "admin-task" {
           "name": "DB_HOST",
           "value": "${aws_db_instance.admin_db.address}"
         },{
-          "name": "NOTIFY_API_KEY",
-          "value": "${var.notify-api-key}"
-        },{
           "name": "RACK_ENV",
           "value": "${var.rack-env}"
         },{
@@ -143,6 +140,12 @@ resource "aws_ecs_task_definition" "admin-task" {
         },{
           "name": "OTP_SECRET_ENCRYPTION_KEY",
           "value": "${var.otp-secret-encryption-key}"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "NOTIFY_API_KEY",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.notify_api_key.arn}:notify-api-key::"
         }
       ],
       "image": "${var.admin-docker-image}",

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -115,10 +115,10 @@ resource "aws_ecs_task_definition" "admin-task" {
       "secrets": [
         {
           "name": "DB_PASS",
-          "valueFrom": "${data.aws_secretsmanager_secret_version.admin_db.arn}:username::"
+          "valueFrom": "${data.aws_secretsmanager_secret_version.admin_db.arn}:password::"
         },{
           "name": "DB_USER",
-          "valueFrom": "${data.aws_secretsmanager_secret_version.admin_db.arn}:password::"
+          "valueFrom": "${data.aws_secretsmanager_secret_version.admin_db.arn}:username::"
         },{
           "name": "DEVISE_SECRET_KEY",
           "valueFrom": "${data.aws_secretsmanager_secret_version.key_base.arn}:secret-key-base::"

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -36,12 +36,6 @@ resource "aws_ecs_task_definition" "admin-task" {
       "name": "admin",
       "environment": [
         {
-          "name": "DB_USER",
-          "value": "${var.admin-db-user}"
-        },{
-          "name": "DB_PASS",
-          "value": "${var.admin-db-password}"
-        },{
           "name": "DB_NAME",
           "value": "govwifi_admin_${var.rack-env}"
         },{
@@ -96,23 +90,11 @@ resource "aws_ecs_task_definition" "admin-task" {
           "name": "LOGGING_API_SEARCH_ENDPOINT",
           "value": "${var.logging-api-search-url}"
         },{
-          "name": "RR_DB_USER",
-          "value": "${var.rr-db-user}"
-        },{
-          "name": "RR_DB_PASS",
-          "value": "${var.rr-db-password}"
-        },{
           "name": "RR_DB_HOST",
           "value": "${var.rr-db-host}"
         },{
           "name": "RR_DB_NAME",
           "value": "${var.rr-db-name}"
-        },{
-          "name": "USER_DB_USER",
-          "value": "${var.user-db-user}"
-        },{
-          "name": "USER_DB_PASS",
-          "value": "${var.user-db-password}"
         },{
           "name": "USER_DB_HOST",
           "value": "${var.user-db-host}"
@@ -132,20 +114,38 @@ resource "aws_ecs_task_definition" "admin-task" {
       ],
       "secrets": [
         {
-          "name": "NOTIFY_API_KEY",
-          "valueFrom": "${data.aws_secretsmanager_secret_version.notify_api_key.arn}:notify-api-key::"
+          "name": "DB_PASS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.admin_db.arn}:username::"
         },{
-          "name": "ZENDESK_API_TOKEN",
-          "valueFrom": "${data.aws_secretsmanager_secret_version.zendesk_api_token.arn}:zendesk-api-token::"
-        },{
-          "name": "SECRET_KEY_BASE",
-          "valueFrom": "${data.aws_secretsmanager_secret_version.key_base.arn}:secret-key-base::"
+          "name": "DB_USER",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.admin_db.arn}:password::"
         },{
           "name": "DEVISE_SECRET_KEY",
           "valueFrom": "${data.aws_secretsmanager_secret_version.key_base.arn}:secret-key-base::"
         },{
+          "name": "NOTIFY_API_KEY",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.notify_api_key.arn}:notify-api-key::"
+        },{
           "name": "OTP_SECRET_ENCRYPTION_KEY",
           "valueFrom": "${data.aws_secretsmanager_secret_version.otp_encryption_key.arn}:key::"
+        },{
+          "name": "RR_DB_PASS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.session_db.arn}:password::"
+        },{
+          "name": "RR_DB_USER",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.session_db.arn}:username::"
+        },{
+          "name": "SECRET_KEY_BASE",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.key_base.arn}:secret-key-base::"
+        },{
+          "name": "USER_DB_PASS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:password::"
+        },{
+          "name": "USER_DB_USER",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
+        },{
+          "name": "ZENDESK_API_TOKEN",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.zendesk_api_token.arn}:zendesk-api-token::"
         }
       ],
       "image": "${var.admin-docker-image}",

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -134,7 +134,10 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret_version.notify_api_key.arn,
       data.aws_secretsmanager_secret_version.zendesk_api_token.arn,
       data.aws_secretsmanager_secret_version.key_base.arn,
-      data.aws_secretsmanager_secret_version.otp_encryption_key.arn
+      data.aws_secretsmanager_secret_version.otp_encryption_key.arn,
+      data.aws_secretsmanager_secret_version.session_db.arn,
+      data.aws_secretsmanager_secret_version.users_db.arn,
+      data.aws_secretsmanager_secret_version.admin_db.arn
     ]
   }
 }

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -118,3 +118,20 @@ resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole_policy" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+resource "aws_iam_role_policy" "secrets_manager_policy" {
+  name   = "${var.aws-region-name}-admin-api-access-secrets-manager-${var.Env-Name}"
+  role   = aws_iam_role.ecsTaskExecutionRole.id
+  policy = data.aws_iam_policy_document.secrets_manager_policy.json
+}
+
+data "aws_iam_policy_document" "secrets_manager_policy" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = [
+      data.aws_secretsmanager_secret_version.notify_api_key.arn
+    ]
+  }
+}

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -131,7 +131,10 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
     ]
 
     resources = [
-      data.aws_secretsmanager_secret_version.notify_api_key.arn
+      data.aws_secretsmanager_secret_version.notify_api_key.arn,
+      data.aws_secretsmanager_secret_version.zendesk_api_token.arn,
+      data.aws_secretsmanager_secret_version.key_base.arn,
+      data.aws_secretsmanager_secret_version.otp_encryption_key.arn
     ]
   }
 }

--- a/govwifi-admin/secrets-manager.tf
+++ b/govwifi-admin/secrets-manager.tf
@@ -29,3 +29,27 @@ data "aws_secretsmanager_secret_version" "otp_encryption_key" {
 data "aws_secretsmanager_secret" "otp_encryption_key" {
   name = var.use_env_prefix ? "staging/admin-api/otp-secret-encryption-key" : "admin-api/otp-secret-encryption-key"
 }
+
+data "aws_secretsmanager_secret_version" "session_db" {
+  secret_id = data.aws_secretsmanager_secret.session_db.id
+}
+
+data "aws_secretsmanager_secret" "session_db" {
+  name = var.use_env_prefix ? "staging/rds/session-db/credentials" : "rds/session-db/credentials"
+}
+
+data "aws_secretsmanager_secret_version" "users_db" {
+  secret_id = data.aws_secretsmanager_secret.users_db.id
+}
+
+data "aws_secretsmanager_secret" "users_db" {
+  name = var.use_env_prefix ? "staging/rds/users-db/credentials" : "rds/users-db/credentials"
+}
+
+data "aws_secretsmanager_secret_version" "admin_db" {
+  secret_id = data.aws_secretsmanager_secret.admin_db.id
+}
+
+data "aws_secretsmanager_secret" "admin_db" {
+  name = var.use_env_prefix ? "staging/rds/admin-db/credentials" : "rds/admin-db/credentials"
+}

--- a/govwifi-admin/secrets-manager.tf
+++ b/govwifi-admin/secrets-manager.tf
@@ -5,3 +5,27 @@ data "aws_secretsmanager_secret_version" "notify_api_key" {
 data "aws_secretsmanager_secret" "notify_api_key" {
   name = var.use_env_prefix ? "staging/admin-api/notify-api-key" : "admin-api/notify-api-key"
 }
+
+data "aws_secretsmanager_secret_version" "zendesk_api_token" {
+  secret_id = data.aws_secretsmanager_secret.zendesk_api_token.id
+}
+
+data "aws_secretsmanager_secret" "zendesk_api_token" {
+  name = var.use_env_prefix ? "staging/admin-api/zendesk-api-token" : "admin-api/zendesk-api-token"
+}
+
+data "aws_secretsmanager_secret_version" "key_base" {
+  secret_id = data.aws_secretsmanager_secret.key_base.id
+}
+
+data "aws_secretsmanager_secret" "key_base" {
+  name = var.use_env_prefix ? "staging/admin-api/secret-key-base" : "admin-api/secret-key-base"
+}
+
+data "aws_secretsmanager_secret_version" "otp_encryption_key" {
+  secret_id = data.aws_secretsmanager_secret.otp_encryption_key.id
+}
+
+data "aws_secretsmanager_secret" "otp_encryption_key" {
+  name = var.use_env_prefix ? "staging/admin-api/otp-secret-encryption-key" : "admin-api/otp-secret-encryption-key"
+}

--- a/govwifi-admin/secrets-manager.tf
+++ b/govwifi-admin/secrets-manager.tf
@@ -1,0 +1,7 @@
+data "aws_secretsmanager_secret_version" "notify_api_key" {
+  secret_id = data.aws_secretsmanager_secret.notify_api_key.id
+}
+
+data "aws_secretsmanager_secret" "notify_api_key" {
+  name = var.use_env_prefix ? "staging/admin-api/notify-api-key" : "admin-api/notify-api-key"
+}

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -188,3 +188,5 @@ variable "bastion-ips" {
   default     = []
 }
 
+variable "use_env_prefix" {
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -285,6 +285,8 @@ module "govwifi-admin" {
     split(",", var.bastion-server-IP),
     split(",", var.backend-subnet-IPs),
   )
+
+  use_env_prefix = true
 }
 
 module "api" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -299,6 +299,8 @@ module "govwifi-admin" {
     split(",", var.bastion-server-IP),
     split(",", var.backend-subnet-IPs)
   )
+
+  use_env_prefix = false
 }
 
 module "api" {


### PR DESCRIPTION
### What

Update the Admin API ECS task and task definition to retrieve credentials from Secrets Manager instead of from `govwifi-build` repo.

* Manually add credentials to Secrets Manager.
* Update ECS task execution role to allow access to specific credentials in Secrets Manager.
* Update ECS task definition to pull credentials directly from Secrets Manager.

Deployed changes to Staging and have successfully run smoke tests against the changes.

### Why

We are migrating to a cloud credential management system. For more details see this [Trello card](https://trello.com/c/4lQWtoKG/1102-sub-task-migrate-admin-api-ecs-credentials).
