### PR TITLE
Add Secondary Staging Account ID Variable

### DIFF
--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -177,6 +177,11 @@ variable "aws-account-id" {
   description = "The ID of the AWS tenancy."
 }
 
+variable "aws-secondary-account-id" {
+  type        = string
+  description = "The ID the Secondary Staging AWS Account."
+}
+
 variable "admin-secret-key-base" {
   type        = string
   description = "Rails secret key base for the Admin platform"

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -96,6 +96,11 @@ variable "aws-account-id" {
   description = "The ID of the AWS tenancy."
 }
 
+variable "aws-secondary-account-id" {
+  type        = string
+  description = "The ID the Secondary Staging AWS Account."
+}
+
 variable "docker-image-path" {
   type        = string
   description = "ARN used to identify the common path element used for the docker image repositories."


### PR DESCRIPTION
This is not yet used on the Master/Main branch, but adding ahead of time to prevent warnings
when secrets are pulled in.