### PR TITLE
need to add the Env-Name so staging and wifi keys are diff

### DIFF
--- a/govwifi-backend/kms.tf
+++ b/govwifi-backend/kms.tf
@@ -11,6 +11,6 @@ resource "aws_kms_key" "mysql_rds_backup_s3_key" {
 
 resource "aws_kms_alias" "mysql_rds_backup_s3_key_alias" {
   count         = var.backup_mysql_rds ? 1 : 0
-  name          = "alias/mysql_rds_backup_s3_key"
+  name          = "alias/${var.Env-Name}_mysql_rds_backup_s3_key"
   target_key_id = aws_kms_key.mysql_rds_backup_s3_key[0].key_id
 }


### PR DESCRIPTION
**WHAT**

Make the KMS keys in staging and prod (wifi) have diff names

**WHY**

If not done the keys have same name in staging and prod and they error as resource already there.
Also keys should be diff security wise prod to staging