### PR TITLE
Retrieve Auth API credentials from Secrets Manager

### DIFF
--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -39,12 +39,6 @@ resource "aws_ecs_task_definition" "authorisation-api-task" {
           "name": "DB_NAME",
           "value": "govwifi_${var.env}_users"
         },{
-          "name": "DB_PASS",
-          "value": "${var.user-db-password}"
-        },{
-          "name": "DB_USER",
-          "value": "${var.user-db-username}"
-        },{
           "name": "DB_HOSTNAME",
           "value": "${var.user-rr-hostname}"
         },{
@@ -56,6 +50,14 @@ resource "aws_ecs_task_definition" "authorisation-api-task" {
         },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.Env-Name}"
+        }
+      ],"secrets": [
+        {
+          "name": "DB_PASS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:password::"
+        },{
+          "name": "DB_USER",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
         }
       ],
       "links": null,

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -19,3 +19,20 @@ resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole_policy" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+resource "aws_iam_role_policy" "secrets_manager_policy" {
+  name   = "${var.aws-region-name}-auth-api-access-secrets-manager-${var.Env-Name}"
+  role   = aws_iam_role.ecsTaskExecutionRole.id
+  policy = data.aws_iam_policy_document.secrets_manager_policy.json
+}
+
+data "aws_iam_policy_document" "secrets_manager_policy" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = [
+      data.aws_secretsmanager_secret.users_db.arn
+    ]
+  }
+}

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -1,0 +1,7 @@
+data "aws_secretsmanager_secret_version" "users_db" {
+  secret_id = data.aws_secretsmanager_secret.users_db.id
+}
+
+data "aws_secretsmanager_secret" "users_db" {
+  name = var.use_env_prefix ? "staging/rds/users-db/credentials" : "rds/users-db/credentials"
+}

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -258,3 +258,6 @@ variable "volumetrics-elasticsearch-endpoint" {
   description = "URL for the ElasticSearch instance endpoint"
 }
 
+variable "use_env_prefix" {
+
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -369,6 +369,8 @@ module "api" {
   ]
 
   metrics-bucket-name = module.govwifi-dashboard.metrics-bucket-name
+
+  use_env_prefix = var.use_env_prefix
 }
 
 module "notifications" {

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -306,6 +306,8 @@ module "api" {
   backend-sg-list = [
     module.backend.be-admin-in,
   ]
+
+  use_env_prefix = var.use_env_prefix
 }
 
 module "notifications" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -376,6 +376,8 @@ module "api" {
   ]
 
   metrics-bucket-name = module.govwifi-dashboard.metrics-bucket-name
+
+  use_env_prefix = var.use_env_prefix
 }
 
 module "critical-notifications" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -316,6 +316,8 @@ module "api" {
   backend-sg-list = [
     module.backend.be-admin-in,
   ]
+
+  use_env_prefix = var.use_env_prefix
 }
 
 module "critical-notifications" {


### PR DESCRIPTION
### What

* Amend the ECS task definition to retrieve its credentials from Secrets Manager not `govwifi-build`.
* Conditionally retrieve the credentials based on the environment prefix.
* Add a Secrets Manager IAM policy to allow ECS task definition to connect to Secrets Manager.

This change has been deployed to Staging.

### Why

Part of our migration to cloud credential management work stream. See this [trello card](https://trello.com/c/ePNiRoq6/1123-sub-task-migrate-auth-api-ecs-credentials).