### PR TITLE
Add govwifi-account documentation

### DIFF
--- a/govwifi-account/README.md
+++ b/govwifi-account/README.md
@@ -1,0 +1,8 @@
+# govwifi-account
+
+## Purpose
+
+Module contains IAM related resources: groups, policies, roles, users, and user-policies,
+
+These resources were imported from AWS in order to ensure all of our IAM related AWS resources also existed in some format in Terraform.
+


### PR DESCRIPTION
### What

Add README to `govwifi-account` module explaining the module purpose.

### Why

To document the fact that we did a manual import of AWS resources. We imported a bunch of IAM configuration to ensure we had a record of our AWS configuration in code. It isn't clear from the code history why we did this or that all of the resources come from a manual import.