### PR TITLE
Migrate User Signup API ECS task credentials to Secrets Manager

### DIFF
--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -20,7 +20,7 @@ resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole_policy" {
 }
 
 resource "aws_iam_role_policy" "secrets_manager_policy" {
-  name   = "${var.aws-region-name}-auth-api-access-secrets-manager-${var.Env-Name}"
+  name   = "${var.aws-region-name}-api-cluster-access-secrets-manager-${var.Env-Name}"
   role   = aws_iam_role.ecsTaskExecutionRole.id
   policy = data.aws_iam_policy_document.secrets_manager_policy.json
 }
@@ -32,7 +32,10 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
     ]
 
     resources = [
-      data.aws_secretsmanager_secret.users_db.arn
+      data.aws_secretsmanager_secret.users_db.arn,
+      data.aws_secretsmanager_secret.notify_api_key.arn,
+      data.aws_secretsmanager_secret.notify_bearer_token.arn
+
     ]
   }
 }

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -5,3 +5,19 @@ data "aws_secretsmanager_secret_version" "users_db" {
 data "aws_secretsmanager_secret" "users_db" {
   name = var.use_env_prefix ? "staging/rds/users-db/credentials" : "rds/users-db/credentials"
 }
+
+data "aws_secretsmanager_secret_version" "notify_api_key" {
+  secret_id = data.aws_secretsmanager_secret.notify_api_key.id
+}
+
+data "aws_secretsmanager_secret" "notify_api_key" {
+  name = var.use_env_prefix ? "staging/admin-api/notify-api-key" : "admin-api/notify-api-key"
+}
+
+data "aws_secretsmanager_secret_version" "notify_bearer_token" {
+  secret_id = data.aws_secretsmanager_secret.notify_bearer_token.id
+}
+
+data "aws_secretsmanager_secret" "notify_bearer_token" {
+  name = var.use_env_prefix ? "staging/user-signup-api/notify-bearer-token" : "user-signup-api/notify-bearer-token"
+}

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -110,12 +110,6 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
           "name": "DB_NAME",
           "value": "govwifi_${var.env}_users"
         },{
-          "name": "DB_PASS",
-          "value": "${var.user-db-password}"
-        },{
-          "name": "DB_USER",
-          "value": "${var.user-db-username}"
-        },{
           "name": "DB_HOSTNAME",
           "value": "${var.user-db-hostname}"
         },{
@@ -127,9 +121,6 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
         },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.Env-Name}"
-        },{
-          "name": "NOTIFY_API_KEY",
-          "value": "${var.notify-api-key}"
         },{
           "name": "PERFORMANCE_URL",
           "value": "${var.performance-url}"
@@ -151,9 +142,21 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
         },{
           "name": "FIRETEXT_TOKEN",
           "value": "${var.firetext-token}"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "DB_PASS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:password::"
+        },{
+          "name": "DB_USER",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
+        },{
+          "name": "NOTIFY_API_KEY",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.notify_api_key.arn}:notify-api-key::"
         },{
           "name": "GOVNOTIFY_BEARER_TOKEN",
-          "value": "${var.govnotify-bearer-token}"
+          "valueFrom": "${data.aws_secretsmanager_secret_version.notify_bearer_token.arn}:token::"
         }
       ],
       "links": null,

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -359,12 +359,6 @@ resource "aws_ecs_task_definition" "user-signup-api-scheduled-task" {
           "name": "DB_NAME",
           "value": "govwifi_${var.env}_users"
         },{
-          "name": "DB_PASS",
-          "value": "${var.user-db-password}"
-        },{
-          "name": "DB_USER",
-          "value": "${var.user-db-username}"
-        },{
           "name": "DB_HOSTNAME",
           "value": "${var.user-db-hostname}"
         },{
@@ -376,9 +370,6 @@ resource "aws_ecs_task_definition" "user-signup-api-scheduled-task" {
         },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.Env-Name}"
-        },{
-          "name": "NOTIFY_API_KEY",
-          "value": "${var.notify-api-key}"
         },{
           "name": "PERFORMANCE_URL",
           "value": "${var.performance-url}"
@@ -395,11 +386,23 @@ resource "aws_ecs_task_definition" "user-signup-api-scheduled-task" {
           "name": "FIRETEXT_TOKEN",
           "value": "${var.firetext-token}"
         },{
-          "name": "GOVNOTIFY_BEARER_TOKEN",
-          "value": "${var.govnotify-bearer-token}"
-        },{
           "name": "S3_METRICS_BUCKET",
           "value": "${var.metrics-bucket-name}"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "DB_PASS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:password::"
+        },{
+          "name": "DB_USER",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
+        },{
+          "name": "NOTIFY_API_KEY",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.notify_api_key.arn}:notify-api-key::"
+        },{
+          "name": "GOVNOTIFY_BEARER_TOKEN",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.notify_bearer_token.arn}:token::"
         }
       ],
       "links": null,


### PR DESCRIPTION
### What

* Manually add credentials for GOV.UK Notify bearer token to Secrets Manager
* Update IAM permissions on the ECS task to allow access to Notify bearer token and API key
* Update ECS task definition and scheduled task definition to retrieve credentials from Secrets Manager
* Refactor `secrets_manager_policy` name to be more abstract

These changes have been applied to `staging` and `staging-london`.

### Why

Part of our cloud credential migration strand. See this [Trello card](https://trello.com/c/N4tGfVn7/1155-sub-task-migrate-user-signup-api-ecs-credentials).