### PR TITLE
Fix Logging API ECS task policy

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -228,10 +228,13 @@ resource "aws_iam_role_policy" "logging-api-task-policy" {
       "Effect": "Allow",
       "Action":[
         "s3:GetObject",
-        "s3:ListObject",
+        "s3:ListBucket",
         "s3:PutObject"  
       ],
-      "Resource": "arn:aws:s3:::${var.metrics-bucket-name}/*"
+      "Resource": [
+        "arn:aws:s3:::${var.metrics-bucket-name}",
+        "arn:aws:s3:::${var.metrics-bucket-name}/*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### What

Replace "ListObject" (not an accepted AWS action) with "ListBucket" which is required by the Ruby SDK command we're using (list_objects_v2).

Add `metrics-bucket` ARN (without "/*") because it's a dependency of the "ListBucket" action.

### Why

The current policy is broken and won't allow connections between the ECS task definition and S3.