### PR TITLE
Migrate logging api credentials

### DIFF
--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -33,6 +33,9 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
 
     resources = [
       data.aws_secretsmanager_secret.users_db.arn,
+      data.aws_secretsmanager_secret.session_db.arn,
+      data.aws_secretsmanager_secret.volumentrics_elasticsearch_endpoint.arn,
+      data.aws_secretsmanager_secret.users_db.arn,
       data.aws_secretsmanager_secret.notify_api_key.arn,
       data.aws_secretsmanager_secret.notify_bearer_token.arn
 

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -47,12 +47,6 @@ resource "aws_ecs_task_definition" "logging-api-task" {
           "name": "DB_NAME",
           "value": "govwifi_${var.Env-Name}"
         },{
-          "name": "DB_PASS",
-          "value": "${var.db-password}"
-        },{
-          "name": "DB_USER",
-          "value": "${var.db-user}"
-        },{
           "name": "DB_HOSTNAME",
           "value": "${var.db-hostname}"
         },{
@@ -97,8 +91,7 @@ resource "aws_ecs_task_definition" "logging-api-task" {
         },{
           "name": "DB_USER",
           "valueFrom": "${data.aws_secretsmanager_secret_version.session_db.arn}:username::"
-        },
-        {
+        },{
           "name": "USER_DB_PASS",
           "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:password::"
         },{

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -59,12 +59,6 @@ resource "aws_ecs_task_definition" "logging-api-task" {
           "name": "USER_DB_NAME",
           "value": "govwifi_${var.env}_users"
         },{
-          "name": "USER_DB_PASS",
-          "value": "${var.user-db-password}"
-        },{
-          "name": "USER_DB_USER",
-          "value": "${var.user-db-username}"
-        },{
           "name": "USER_DB_HOSTNAME",
           "value": "${var.user-db-hostname}"
         },{
@@ -94,6 +88,22 @@ resource "aws_ecs_task_definition" "logging-api-task" {
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "DB_PASS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.session_db.arn}:password::"
+        },{
+          "name": "DB_USER",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.session_db.arn}:username::"
+        },
+        {
+          "name": "USER_DB_PASS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:password::"
+        },{
+          "name": "USER_DB_USER",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
         }
       ],
       "links": null,

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -400,23 +400,11 @@ resource "aws_ecs_task_definition" "logging-api-scheduled-task" {
           "name": "DB_NAME",
           "value": "govwifi_${var.Env-Name}"
         },{
-          "name": "DB_PASS",
-          "value": "${var.db-password}"
-        },{
-          "name": "DB_USER",
-          "value": "${var.db-user}"
-        },{
           "name": "DB_HOSTNAME",
           "value": "${var.db-hostname}"
         },{
           "name": "USER_DB_NAME",
           "value": "govwifi_${var.env}_users"
-        },{
-          "name": "USER_DB_PASS",
-          "value": "${var.user-db-password}"
-        },{
-          "name": "USER_DB_USER",
-          "value": "${var.user-db-username}"
         },{
           "name": "USER_DB_HOSTNAME",
           "value": "${var.user-db-hostname}"
@@ -450,13 +438,28 @@ resource "aws_ecs_task_definition" "logging-api-scheduled-task" {
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
-        },
-        {
+        },{
           "name": "S3_METRICS_BUCKET",
           "value": "${var.metrics-bucket-name}"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "DB_PASS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.session_db.arn}:password::"
+        },{
+          "name": "DB_USER",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.session_db.arn}:username::"
+        },
+        {
+          "name": "USER_DB_PASS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:password::"
+        },{
+          "name": "USER_DB_USER",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
         },{
           "name": "VOLUMETRICS_ENDPOINT",
-          "value": "${var.volumetrics-elasticsearch-endpoint}"
+          "valueFrom": "${data.aws_secretsmanager_secret_version.volumentrics_elasticsearch_endpoint.arn}:endpoint::"
         }
       ],
       "links": null,

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -450,8 +450,7 @@ resource "aws_ecs_task_definition" "logging-api-scheduled-task" {
         },{
           "name": "DB_USER",
           "valueFrom": "${data.aws_secretsmanager_secret_version.session_db.arn}:username::"
-        },
-        {
+        },{
           "name": "USER_DB_PASS",
           "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:password::"
         },{

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -1,9 +1,25 @@
+data "aws_secretsmanager_secret_version" "session_db" {
+  secret_id = data.aws_secretsmanager_secret.session_db.id
+}
+
+data "aws_secretsmanager_secret" "session_db" {
+  name = var.use_env_prefix ? "staging/rds/session-db/credentials" : "rds/session-db/credentials"
+}
+
 data "aws_secretsmanager_secret_version" "users_db" {
   secret_id = data.aws_secretsmanager_secret.users_db.id
 }
 
 data "aws_secretsmanager_secret" "users_db" {
   name = var.use_env_prefix ? "staging/rds/users-db/credentials" : "rds/users-db/credentials"
+}
+
+data "aws_secretsmanager_secret_version" "volumentrics_elasticsearch_endpoint" {
+  secret_id = data.aws_secretsmanager_secret.volumentrics_elasticsearch_endpoint.id
+}
+
+data "aws_secretsmanager_secret" "volumentrics_elasticsearch_endpoint" {
+  name = var.use_env_prefix ? "staging/logging-api/volumetrics-elasticsearch-endpoint" : "logging-api/volumetrics-elasticsearch-endpoint"
 }
 
 data "aws_secretsmanager_secret_version" "notify_api_key" {


### PR DESCRIPTION
### What

Retrieve Logging API ECS task credentials from Secrets Manager:

* Manually add credentials for the volumetrics Elasticsearch endpoint    
* Update IAM permissions to allow access to the volumetrics endpoint
* Update ECS task definition and scheduled task definition to retrieve credentials from Secrets Manager
* Remove an unnecessary line spacing

### Why

Part of our migration to a cloud credential management system. See this [trello card](https://trello.com/c/gOirLVGZ/1161-sub-task-migrate-logging-api-ecs-credentials).