### PR TITLE
Remove duplicated Logging API task policies.

### DIFF
--- a/govwifi-account/iam-roles.tf
+++ b/govwifi-account/iam-roles.tf
@@ -3279,34 +3279,6 @@ POLICY
 
 }
 
-resource "aws_iam_role_policy" "staging-logging-api-task-role_staging-logging-api-task-policy" {
-  name = "staging-logging-api-task-policy"
-  role = "staging-logging-api-task-role"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Resource": "arn:aws:s3:::govwifi-staging-admin/*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Resource": "arn:aws:s3:::govwifi-staging-metrics-bucket/*"
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_role_policy" "staging-logging-scheduled-task-role_staging-logging-scheduled-task-policy" {
   name = "staging-logging-scheduled-task-policy"
   role = "staging-logging-scheduled-task-role"
@@ -3455,34 +3427,6 @@ resource "aws_iam_role_policy" "staging-user-signup-scheduled-task-role_staging-
           "iam:PassedToService": "ecs-tasks.amazonaws.com"
         }
       }
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "wifi-logging-api-task-role_wifi-logging-api-task-policy" {
-  name = "wifi-logging-api-task-policy"
-  role = "wifi-logging-api-task-role"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Resource": "arn:aws:s3:::govwifi-production-admin/*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Resource": "arn:aws:s3:::govwifi-wifi-metrics-bucket/*"
     }
   ]
 }


### PR DESCRIPTION
### What

* Use `terraform state rm` to manually remove the duplicated policies from the state file.
* Delete the duplicated polices from `iam-roles.tf`.

### Why

The Logging API task policy is declared in `logging-api-cluster.tf` and should be the single source of truth. The duplicated policies in `iam-roles.tf` were overwriting this policy and causing AWS/Terraform confusion.

When we imported all the IAM-related resources from AWS we also imported policies which are declared in other parts of our Terraform. 

We'll have to repeat this state removal and code removal process whenever this comes up again.

The command I used to remove the policies from the state file:

`make <env> terraform terraform_cmd="state rm module.govwifi-account.aws_iam_role_policy.wifi-logging-api-task-role_wifi-logging-api-task-policy"`

`env` will always be `wifi-london`.