### PR TITLE
Update Terraform target command and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 check-env:
@@ -28,10 +29,10 @@ wifi:
 	$(eval export AWS_REGION=eu-west-1)
 
 plan_task: check-env
-	scripts/run-terraform.sh plan ${terraform_flags}
+	for variable in ${modules}; do module_flags="$$module_flags -target=module.$$variable"; done; scripts/run-terraform.sh plan ${terraform_flags} $$module_flags
 plan: check-env unencrypt-secrets plan_task delete-secrets ## Run terraform plan after decrypting secrets. Must run in form make <env> plan
 apply_task: check-env
-	scripts/run-terraform.sh apply ${terraform_flags}
+	for variable in ${modules}; do module_flags="$$module_flags -target=module.$$variable"; done; scripts/run-terraform.sh apply ${terraform_flags} $$module_flags
 apply: check-env unencrypt-secrets apply_task delete-secrets ## Run terraform apply after decrypting secrets. Must run in form make <env> apply
 .PHONY: terraform
 terraform_task: check-env

--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ make <ENV> plan
 make <ENV> apply
 ```
 
+### Running terraform target
+
 Use the `terraform_target` command to run a targeted `plan | apply`:
 
 ```bash
-$ make <env> terraform_target terraform_cmd="<plan | apply> -target=<module name>"
+$ make <ENV> terraform_target terraform_cmd="<plan | apply> -target=<module name>"
 ```
 
 ## Bootstrapping terraform

--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ in the main.tf file of the new environment / environment to be migrated
 Run
 
 ```
-make <env> plan
+make <ENV> plan
 ```
 And then
 
 ```
-make <env> apply
+make <ENV> apply
 ```
 
 This should create the remote state bucket for you if migrating, or create the
@@ -125,13 +125,13 @@ entire infrastructure with a local state file if creating a new env
 Then uncomment the backend section and run
 
 ```
-make <env> init-backend
+make <ENV> init-backend
 ```
 
 Then run
 
 ```
-make <env> apply
+make <ENV> apply
 ```
 
 This should then copy the state file to s3 and use this for all operations
@@ -151,12 +151,12 @@ Where validation-domain is wifi.service.gov.uk for prod, and wifi.staging.servic
 
 Once this is created, you will need to validate the domain. There is some logic
 to listen to emails on the required domain and copy them to an s3 bucket in the
-govwifi-terraform repo. You can look in the `<env>-admin-emailbucket` to find
+govwifi-terraform repo. You can look in the `<ENV>-admin-emailbucket` to find
 this - it will likely be the last modified file. You can also use the CLI
 
 ```
-aws s3 ls s3://<env>-admin-emailbucket/
-aws s3 cp s3://<env>-admin-emailbucket/<filename-of-last-modified-file> -
+aws s3 ls s3://<ENV>-admin-emailbucket/
+aws s3 cp s3://<ENV>-admin-emailbucket/<filename-of-last-modified-file> -
 ```
 
 Find the validation link and load it in a browser

--- a/README.md
+++ b/README.md
@@ -60,10 +60,18 @@ make <ENV> apply
 
 ### Running terraform target
 
-Use the `terraform_target` command to run a targeted `plan | apply`:
+There are two ways to do this
+
+1 - use the above commands with 'module="moduleA moduleB"' space seperated list of module(s)
+
+```
+make <ENV> plan modules="backend api"
+make <ENV> apply modules="backend"
+```
+2 - to do more intricate work that may need more terraform commands you use the `terraform_target` command to run a targeted `plan | apply`:
 
 ```bash
-$ make <ENV> terraform_target terraform_cmd="<plan | apply> -target=<module name>"
+$ make <ENV> terraform_target terraform_cmd="<plan | apply> -target=<module name> [-target=<module name>]..."
 ```
 
 ## Bootstrapping terraform

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ We've incorporated this functionality into our `make` commands. **Note**: this s
 To `plan`/`apply` a specific resource use the standard `make <ENV> plan | apply` followed by a space separated list of one or more modules:
 
 ```
-$ make <ENV> plan modules="module.backend.some.resource module.api.some.resource"
-$ make <ENV> apply modules="module.frontend.some.resource"
+$ make <ENV> plan modules="backend.some.resource module.api.some.resource"
+$ make <ENV> apply modules="frontend.some.resource"
 ```
 
 To retrieve the module name, run a `plan` and copy the module name from the Terraform output:

--- a/README.md
+++ b/README.md
@@ -60,18 +60,37 @@ make <ENV> apply
 
 ### Running terraform target
 
-There are two ways to do this
+Terraform allows for ["resource targeting"](https://www.terraform.io/docs/cli/commands/plan.html#resource-targeting), or running `plan`/`apply` on specific resources. 
 
-1 - use the above commands with 'module="moduleA moduleB"' space seperated list of module(s)
+We've incorporated this functionality into our `make` commands. **Note**: this should only be done in exceptional circumstances.
+
+To `plan`/`apply` a specific resource use the standard `make <ENV> plan | apply` followed by a space separated list of one or more modules:
 
 ```
-make <ENV> plan modules="backend api"
-make <ENV> apply modules="backend"
+$ make <ENV> plan modules="module.backend.some.resource module.api.some.resource"
+$ make <ENV> apply modules="module.frontend.some.resource"
 ```
-2 - to do more intricate work that may need more terraform commands you use the `terraform_target` command to run a targeted `plan | apply`:
+
+To retrieve the module name, run a `plan` and copy the module name from the Terraform output:
 
 ```bash
-$ make <ENV> terraform_target terraform_cmd="<plan | apply> -target=<module name> [-target=<module name>]..."
+$ make staging plan
+...
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # module.api.aws_iam_role_policy.some_policy  <-- module name
+...
+```
+
+If combining other Terraform commands (e.g., `-var` or `-replace`) with targeting a resource, use the `terraform_target` command:
+
+```bash
+$ make <ENV> terraform_target terraform_cmd="<plan | apply> -replace <your command>"
 ```
 
 ## Bootstrapping terraform


### PR DESCRIPTION
### What

* Update `plan | apply` make command to accept a list of module names.
* Create new header for resource targeting and expand documentation.

### Why

Allow for easier use of Terraform targeting and ensure we've well-documented the approach.