### PR TITLE
Fix Logging API ECS task definition

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -97,6 +97,9 @@ resource "aws_ecs_task_definition" "logging-api-task" {
         },{
           "name": "USER_DB_USER",
           "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
+        },{
+          "name": "VOLUMETRICS_ENDPOINT",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.volumetrics_elasticsearch_endpoint.arn}:endpoint::"
         }
       ],
       "links": null,


### PR DESCRIPTION
### What

* Add missing `VOLUMETRICS` credential to ECS task definition "secrets" block to retrieve endpoint from Secrets Manager.
* This value was added to the ECS scheduled task definition (see PR #431) but was missed on the task definition.

### Why

The Logging API is failing to write to the required endpoint because the task can't retrieve the value from Secrets Manager.