### PR TITLE
Migrate Grafana credentials to use Secrets Manager

### DIFF
--- a/govwifi-grafana/iam.tf
+++ b/govwifi-grafana/iam.tf
@@ -1,0 +1,19 @@
+data "aws_iam_policy_document" "secrets_manager_policy" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = [
+      data.aws_secretsmanager_secret.google_client_id.arn,
+      data.aws_secretsmanager_secret.google_client_secret.arn,
+      data.aws_secretsmanager_secret.grafana_admin.arn,
+      data.aws_secretsmanager_secret.grafana_server_root_url.arn
+    ]
+
+    principals {
+      identifiers = ["ec2.amazonaws.com"]
+      type = "Service"
+    }
+  }
+}

--- a/govwifi-grafana/iam.tf
+++ b/govwifi-grafana/iam.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
 
     principals {
       identifiers = ["ec2.amazonaws.com"]
-      type = "Service"
+      type        = "Service"
     }
   }
 }

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -92,13 +92,7 @@ resource "aws_vpc_endpoint" "vpc-endpoint" {
 
   service_name = "com.amazonaws.eu-west-2.secretsmanager"
 
-  subnet_ids = [
-    # Need to add the following subnets
-    # staging Backend - AZ: eu-west-2a - GovWifi subnet
-    # staging Backend - AZ: eu-west-2b - GovWifi subnet
-    # staging Backend - AZ: eu-west-2c - GovWifi subnet
-    var.backend-subnet-ids
-  ]
+  subnet_ids = var.backend-subnet-ids
 
   vpc_endpoint_type = "Interface"
 
@@ -117,7 +111,7 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.google_client_id.arn,
       data.aws_secretsmanager_secret.google_client_secret.arn,
       data.aws_secretsmanager_secret.grafana_admin.arn,
-      data.aws_secretsmanager_secret.grafana_server_root_url.arn,
+      data.aws_secretsmanager_secret.grafana_server_root_url.arn
     ]
 
     principals {

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -77,26 +77,3 @@ data "template_file" "grafana_user_data" {
   }
 }
 
-resource "aws_vpc_endpoint" "vpc-endpoint" {
-
-  policy = data.aws_iam_policy_document.secrets_manager_policy.json
-
-  private_dns_enabled = true
-
-  security_group_ids = [
-    aws_security_group.grafana-alb-in.id,
-    aws_security_group.grafana-alb-out.id,
-    aws_security_group.grafana-ec2-in.id,
-    aws_security_group.grafana-ec2-out.id
-  ]
-
-  service_name = "com.amazonaws.eu-west-2.secretsmanager"
-
-  subnet_ids = var.backend-subnet-ids
-
-  vpc_endpoint_type = "Interface"
-
-  vpc_id            = var.vpc-id
-
-  timeouts {}
-}

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -100,23 +100,3 @@ resource "aws_vpc_endpoint" "vpc-endpoint" {
 
   timeouts {}
 }
-
-data "aws_iam_policy_document" "secrets_manager_policy" {
-  statement {
-    actions = [
-      "secretsmanager:GetSecretValue"
-    ]
-
-    resources = [
-      data.aws_secretsmanager_secret.google_client_id.arn,
-      data.aws_secretsmanager_secret.google_client_secret.arn,
-      data.aws_secretsmanager_secret.grafana_admin.arn,
-      data.aws_secretsmanager_secret.grafana_server_root_url.arn
-    ]
-
-    principals {
-      identifiers = ["ec2.amazonaws.com"]
-      type = "Service"
-    }
-  }
-}

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -68,10 +68,10 @@ data "template_file" "grafana_user_data" {
 
   vars = {
     grafana_log_group       = "${var.Env-Name}-grafana-log-group"
-    grafana_admin           = var.grafana-admin
-    google_client_secret    = var.google-client-secret
-    google_client_id        = var.google-client-id
-    grafana_server_root_url = var.grafana-server-root-url
+    grafana_admin           = local.grafana-admin
+    google_client_secret    = local.google-client-secret
+    google_client_id        = local.google-client-id
+    grafana_server_root_url = local.grafana-server-root-url
     grafana_device_name     = var.grafana-device-name
     grafana_docker_version  = var.grafana-docker-version
   }

--- a/govwifi-grafana/locals.tf
+++ b/govwifi-grafana/locals.tf
@@ -1,0 +1,15 @@
+locals {
+  grafana-admin = jsondecode(data.aws_secretsmanager_secret_version.grafana_admin.secret_string)["admin-pass"]
+}
+
+locals {
+  grafana-server-root-url = jsondecode(data.aws_secretsmanager_secret_version.grafana_server_root_url.secret_string)["url"]
+}
+
+locals {
+  google-client-id = jsondecode(data.aws_secretsmanager_secret_version.google_client_id.secret_string)["id"]
+}
+
+locals {
+  google-client-secret = jsondecode(data.aws_secretsmanager_secret_version.google_client_secret.secret_string)["secret"]
+}

--- a/govwifi-grafana/secrets-manager.tf
+++ b/govwifi-grafana/secrets-manager.tf
@@ -1,0 +1,31 @@
+data "aws_secretsmanager_secret_version" "grafana_admin" {
+  secret_id = data.aws_secretsmanager_secret.grafana_admin.id
+}
+
+data "aws_secretsmanager_secret" "grafana_admin" {
+  name = var.use_env_prefix ? "staging/grafana/admin-pass" : "grafana/admin-pass"
+}
+
+data "aws_secretsmanager_secret_version" "grafana_server_root_url" {
+  secret_id = data.aws_secretsmanager_secret.grafana_server_root_url.id
+}
+
+data "aws_secretsmanager_secret" "grafana_server_root_url" {
+  name = var.use_env_prefix ? "staging/grafana/server-root-url" : "grafana/server-root-url"
+}
+
+data "aws_secretsmanager_secret_version" "google_client_id" {
+  secret_id = data.aws_secretsmanager_secret.google_client_id.id
+}
+
+data "aws_secretsmanager_secret" "google_client_id" {
+  name = var.use_env_prefix ? "staging/grafana/google-client-id" : "grafana/google-client-id"
+}
+
+data "aws_secretsmanager_secret_version" "google_client_secret" {
+  secret_id = data.aws_secretsmanager_secret.google_client_secret.id
+}
+
+data "aws_secretsmanager_secret" "google_client_secret" {
+  name = var.use_env_prefix ? "staging/grafana/google-client-secret" : "grafana/google-client-secret"
+}

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -97,3 +97,6 @@ variable "critical-notifications-arn" {
   description = "Arn of the critical-nofications sns topic"
   type        = string
 }
+
+variable "use_env_prefix" {
+}

--- a/govwifi-grafana/vpc-endpoint.tf
+++ b/govwifi-grafana/vpc-endpoint.tf
@@ -17,5 +17,5 @@ resource "aws_vpc_endpoint" "vpc-endpoint" {
 
   vpc_endpoint_type = "Interface"
 
-  vpc_id            = var.vpc-id
+  vpc_id = var.vpc-id
 }

--- a/govwifi-grafana/vpc-endpoint.tf
+++ b/govwifi-grafana/vpc-endpoint.tf
@@ -1,0 +1,21 @@
+resource "aws_vpc_endpoint" "vpc-endpoint" {
+
+  policy = data.aws_iam_policy_document.secrets_manager_policy.json
+
+  private_dns_enabled = true
+
+  security_group_ids = [
+    aws_security_group.grafana-alb-in.id,
+    aws_security_group.grafana-alb-out.id,
+    aws_security_group.grafana-ec2-in.id,
+    aws_security_group.grafana-ec2-out.id
+  ]
+
+  service_name = "com.amazonaws.eu-west-2.secretsmanager"
+
+  subnet_ids = var.backend-subnet-ids
+
+  vpc_endpoint_type = "Interface"
+
+  vpc_id            = var.vpc-id
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -487,6 +487,8 @@ module "govwifi-grafana" {
     split(",", "${var.prometheus-IP-london}/32"),
     split(",", "${var.prometheus-IP-ireland}/32")
   )
+
+  use_env_prefix = var.use_env_prefix
 }
 
 module "govwifi-elasticsearch" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -515,6 +515,8 @@ module "govwifi-grafana" {
     split(",", "${var.prometheus-IP-london}/32"),
     split(",", "${var.prometheus-IP-ireland}/32")
   )
+
+  use_env_prefix = var.use_env_prefix
 }
 
 module "govwifi-slack-alerts" {


### PR DESCRIPTION
### What

* Manually add Grafana server credentials to Secrets Manager.
* Configure the Terraform to retrieve Grafana credentials from Secrets Manager instead of `govwifi-build`.
* Create a VPC endpoint to ensure traffic from the Grafana instance to Secrets Manager stays in our network (i.e., doesn't go over public networks). See [this AWS documentation](https://aws.amazon.com/blogs/security/how-to-connect-to-aws-secrets-manager-service-within-a-virtual-private-cloud/).
* Configure an IAM policy for the VPC endpoint to allow the instance access to specific secrets in Secrets Manager only.

I applied these changes in Staging, terminated the instance, recreated it with the new retrieval process, checked the `user_data` file on the instance and ensured it successfully retrieved the credentials.

### Why

Part of the credential migration work stream. See this [Trello card](https://trello.com/c/ndY6t4Jh/1176-sub-task-migrate-ec2-grafana-credentials).