### PR TITLE
removed the name change of ecs task and added the secretmanager perms for admin db and enc key

### DIFF
--- a/govwifi-api/database-backup-task.tf
+++ b/govwifi-api/database-backup-task.tf
@@ -262,7 +262,6 @@ resource "aws_cloudwatch_event_target" "backup-rds-to-s3" {
 {
   "containerOverrides": [
     {
-      "name": "database-backup",
       "command": ["pwd; ls -l; ./database_backup.sh"]
     }
   ]

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -34,11 +34,11 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
     resources = [
       data.aws_secretsmanager_secret.users_db.arn,
       data.aws_secretsmanager_secret.session_db.arn,
+      data.aws_secretsmanager_secret.admin_db.arn,
       data.aws_secretsmanager_secret.volumetrics_elasticsearch_endpoint.arn,
-      data.aws_secretsmanager_secret.users_db.arn,
       data.aws_secretsmanager_secret.notify_api_key.arn,
-      data.aws_secretsmanager_secret.notify_bearer_token.arn
-
+      data.aws_secretsmanager_secret.notify_bearer_token.arn,
+      data.aws_secretsmanager_secret.database_s3_encryption.arn
     ]
   }
 }


### PR DESCRIPTION
**WHAT**

Removed name change and added more secrets to the ECS role policy

**WHY**

Name change was breaking so removed that to keep original name
Task was not allowed to use two of the secrets