### PR TITLE
Update frontend ecsTaskExecutionRole names

### DIFF
--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ecsTaskExecutionRole" {
-  name               = "ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}"
+  name               = "api-ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -35,7 +35,6 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.users_db.arn,
       data.aws_secretsmanager_secret.session_db.arn,
       data.aws_secretsmanager_secret.volumetrics_elasticsearch_endpoint.arn,
-      data.aws_secretsmanager_secret.users_db.arn,
       data.aws_secretsmanager_secret.notify_api_key.arn,
       data.aws_secretsmanager_secret.notify_bearer_token.arn
 

--- a/govwifi-frontend/iam-roles.tf
+++ b/govwifi-frontend/iam-roles.tf
@@ -166,7 +166,7 @@ data "aws_iam_policy_document" "admin_bucket_policy" {
 }
 
 resource "aws_iam_role" "ecsTaskExecutionRole" {
-  name               = "ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}-SecretsManager"
+  name               = "ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 

--- a/govwifi-frontend/iam-roles.tf
+++ b/govwifi-frontend/iam-roles.tf
@@ -166,7 +166,7 @@ data "aws_iam_policy_document" "admin_bucket_policy" {
 }
 
 resource "aws_iam_role" "ecsTaskExecutionRole" {
-  name               = "ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}"
+  name               = "frontend-ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 


### PR DESCRIPTION
### What

* Remove unnecessary "SecretsManager" suffix from the govwifi-frontend `ecsTaskExecutionRole` definition. 
* Append the GovWifi cluster name to the beginning of the `ecsTaskExecutionRole` (e.g. admin, api, frontend).

### Why

This aligns the naming pattern across the three ECS clusters.

The frontend ECS cluster only has this one `ecsTaskExecutionRole`. Although this execution role is exclusively used to retrieve secrets from Secrets Manager the other ECS clusters don't follow this naming pattern. The rest are called `ecsTaskExecutionRole` without any AWS-specific service suffix.

This outlier is confusing.