### PR TITLE
Add missing sections tying roles+tasks

### DIFF
--- a/govwifi-account/iam-roles.tf
+++ b/govwifi-account/iam-roles.tf
@@ -3558,6 +3558,37 @@ POLICY
 
 }
 
+resource "aws_iam_role_policy" "backup-rds-to-s3-scheduled-task-role_backup-rds-to-s3-scheduled-task-policy" {
+  name = "backup-rds-to-s3-scheduled-task-policy"
+  role = "backup-rds-to-s3-scheduled-task-role"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ecs:RunTask",
+      "Resource": "arn:aws:ecs:eu-west-2:${var.aws-account-id}:task-definition/backup-rds-to-s3-task-staging:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": [
+        "*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "iam:PassedToService": "ecs-tasks.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+POLICY
+
+}
+
 resource "aws_iam_role_policy" "wifi-user-signup-scheduled-task-role_wifi-user-signup-scheduled-task-policy" {
   name = "wifi-user-signup-scheduled-task-policy"
   role = "wifi-user-signup-scheduled-task-role"

--- a/govwifi-api/database-backup-task.tf
+++ b/govwifi-api/database-backup-task.tf
@@ -21,8 +21,8 @@ resource "aws_ecr_repository" "database-backup-ecr" {
 resource "aws_ecs_task_definition" "backup-rds-to-s3-task-definition" {
   count                    = var.backup_mysql_rds ? 1 : 0
   family                   = "backup-rds-to-s3-task-${var.Env-Name}"
-  execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
   task_role_arn            = aws_iam_role.backup-rds-to-s3-task-role[0].arn
+  execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
   requires_compatibilities = ["FARGATE"]
   cpu                      = 256
   memory                   = 1024
@@ -251,7 +251,7 @@ resource "aws_cloudwatch_event_target" "backup-rds-to-s3" {
       security_groups = concat(
         var.backend-sg-list,
         [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api-out.id],
       )
 
       assign_public_ip = true
@@ -262,7 +262,8 @@ resource "aws_cloudwatch_event_target" "backup-rds-to-s3" {
 {
   "containerOverrides": [
     {
-      "command": ["pwd; ls -l; ./database_backup.sh"]
+      "name": "database-backup-to-s3",
+      "command": ["./database_backup.sh"]
     }
   ]
 }


### PR DESCRIPTION
**WHAT**

Added some policy tying roles and tasks similar to the tasks im cloning - an experiment to see if this works...

**WHY**

Some missing parts are in the iam section in accounts that got missed that tie the policies together - it was stopping the backup task getting access to SecretsManager

The issue I'm seeing is in AWS:
`Stopped reason ResourceInitializationError: unable to pull secrets or registry auth: execution resource retrieval failed: unable to retrieve secret from asm: service call has been retried 5 time(s): failed to fetch secret arn:aws:secretsmanager:eu-west-2:788375279931...`