### PR TITLE
Revert "Update frontend ecsTaskExecutionRole names"

### DIFF
--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ecsTaskExecutionRole" {
-  name               = "api-ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}"
+  name               = "ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 

--- a/govwifi-frontend/iam-roles.tf
+++ b/govwifi-frontend/iam-roles.tf
@@ -166,7 +166,7 @@ data "aws_iam_policy_document" "admin_bucket_policy" {
 }
 
 resource "aws_iam_role" "ecsTaskExecutionRole" {
-  name               = "frontend-ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}"
+  name               = "ecsTaskExecutionRole-${var.rack-env}-${var.aws-region-name}-SecretsManager"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 


### PR DESCRIPTION
Reverts alphagov/govwifi-terraform#449

When we applied these changes in staging it triggered our `staging-radius-cannot-connect-to-api` alert. This is unexpected behaviour that we should investigate before rolling the refactor out to production.