### PR TITLE
made all launch_types that are FARGATE forced to ver 1.3.0

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -165,12 +165,13 @@ EOF
 }
 
 resource "aws_ecs_service" "admin-service" {
-  depends_on      = [aws_alb_listener.alb_listener]
-  name            = "admin-${var.Env-Name}"
-  cluster         = aws_ecs_cluster.admin-cluster.id
-  task_definition = aws_ecs_task_definition.admin-task.arn
-  desired_count   = var.instance-count
-  launch_type     = "FARGATE"
+  depends_on       = [aws_alb_listener.alb_listener]
+  name             = "admin-${var.Env-Name}"
+  cluster          = aws_ecs_cluster.admin-cluster.id
+  task_definition  = aws_ecs_task_definition.admin-task.arn
+  desired_count    = var.instance-count
+  launch_type      = "FARGATE"
+  platform_version = "1.3.0"
 
   load_balancer {
     target_group_arn = aws_alb_target_group.admin-tg.arn

--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -85,11 +85,12 @@ EOF
 }
 
 resource "aws_ecs_service" "authorisation-api-service" {
-  name            = "authorisation-api-service-${var.Env-Name}"
-  cluster         = aws_ecs_cluster.api-cluster.id
-  task_definition = aws_ecs_task_definition.authorisation-api-task.arn
-  desired_count   = var.authorisation-api-count
-  launch_type     = "FARGATE"
+  name             = "authorisation-api-service-${var.Env-Name}"
+  cluster          = aws_ecs_cluster.api-cluster.id
+  task_definition  = aws_ecs_task_definition.authorisation-api-task.arn
+  desired_count    = var.authorisation-api-count
+  launch_type      = "FARGATE"
+  platform_version = "1.3.0"
 
   network_configuration {
     security_groups = concat(

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -127,12 +127,13 @@ EOF
 }
 
 resource "aws_ecs_service" "logging-api-service" {
-  count           = var.logging-enabled
-  name            = "logging-api-service-${var.Env-Name}"
-  cluster         = aws_ecs_cluster.api-cluster.id
-  task_definition = aws_ecs_task_definition.logging-api-task[0].arn
-  desired_count   = var.backend-instance-count
-  launch_type     = "FARGATE"
+  count            = var.logging-enabled
+  name             = "logging-api-service-${var.Env-Name}"
+  cluster          = aws_ecs_cluster.api-cluster.id
+  task_definition  = aws_ecs_task_definition.logging-api-task[0].arn
+  desired_count    = var.backend-instance-count
+  launch_type      = "FARGATE"
+  platform_version = "1.3.0"
 
   network_configuration {
     security_groups = concat(

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -67,6 +67,7 @@ resource "aws_cloudwatch_event_target" "logging-daily-session-deletion" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids
@@ -105,6 +106,7 @@ resource "aws_cloudwatch_event_target" "gdpr-set-user-last-login" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids
@@ -144,6 +146,7 @@ resource "aws_cloudwatch_event_target" "publish-monthly-metrics-logging" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
     platform_version    = "1.3.0"
 
     network_configuration {
@@ -501,6 +504,7 @@ resource "aws_cloudwatch_event_target" "sync-s3-to-elasticsearch" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -147,7 +147,6 @@ resource "aws_cloudwatch_event_target" "publish-monthly-metrics-logging" {
     task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
-    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids

--- a/govwifi-api/safe-restart-scheduled-task.tf
+++ b/govwifi-api/safe-restart-scheduled-task.tf
@@ -202,6 +202,7 @@ resource "aws_cloudwatch_event_target" "daily-safe-restart" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.safe-restart-task-definition[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -184,12 +184,13 @@ EOF
 }
 
 resource "aws_ecs_service" "user-signup-api-service" {
-  count           = var.user-signup-enabled
-  name            = "user-signup-api-service-${var.Env-Name}"
-  cluster         = aws_ecs_cluster.api-cluster.id
-  task_definition = aws_ecs_task_definition.user-signup-api-task[0].arn
-  desired_count   = var.backend-instance-count
-  launch_type     = "FARGATE"
+  count            = var.user-signup-enabled
+  name             = "user-signup-api-service-${var.Env-Name}"
+  cluster          = aws_ecs_cluster.api-cluster.id
+  task_definition  = aws_ecs_task_definition.user-signup-api-task[0].arn
+  desired_count    = var.backend-instance-count
+  launch_type      = "FARGATE"
+  platform_version = "1.3.0"
 
   network_configuration {
     security_groups = concat(

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -9,6 +9,7 @@ resource "aws_cloudwatch_event_target" "retrieve-notifications" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids
@@ -105,6 +106,7 @@ resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids
@@ -143,6 +145,7 @@ resource "aws_cloudwatch_event_target" "smoke-test-user-deletion" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids
@@ -181,6 +184,7 @@ resource "aws_cloudwatch_event_target" "trim-sessions-database-table" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids
@@ -326,6 +330,7 @@ resource "aws_cloudwatch_event_target" "active-users-signup-surveys" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids
@@ -364,6 +369,7 @@ resource "aws_cloudwatch_event_target" "inactive-users-signup-surveys" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
     launch_type         = "FARGATE"
+    platform_version    = "1.3.0"
 
     network_configuration {
       subnets = var.subnet-ids


### PR DESCRIPTION
**WHAT**

Most scripts were not set to use a particular version of FARGATE so are using default which is LATEST (currently 1.4.0)
This changes forces them all to use version 1.3.0 as of now

**WHY** 

FARGATE 1.4.0 doesn't work currently with our VPC/access rules for SecretsManager secret retrieval so they are failing 
The failure to run only stays in the ECS "Stopped" section for around an hour with no alerting currently setup

![image](https://user-images.githubusercontent.com/77979241/120332881-10cc7200-c2e7-11eb-9c50-6eacb1d61dec.png)
