### PR TITLE
fixed all perms issues - the kms alias needs to be used in conjunction with a grep basically

### DIFF
--- a/govwifi-api/database-backup-task.tf
+++ b/govwifi-api/database-backup-task.tf
@@ -243,7 +243,7 @@ resource "aws_iam_role_policy" "backup-rds-to-s3-scheduled-task-policy" {
       "Sid": "sid0",
           "Effect": "Allow",
           "Action": "ecs:RunTask",
-          "Resource": "${replace( aws_ecs_task_definition.backup-rds-to-s3-task-definition[0].arn, "/:\\d+$/", ":*",)}"
+          "Resource": "${replace(aws_ecs_task_definition.backup-rds-to-s3-task-definition[0].arn, "/:\\d+$/", ":*",)}"
     },{
       "Sid": "sid1",
       "Effect": "Allow",

--- a/govwifi-api/database-backup-task.tf
+++ b/govwifi-api/database-backup-task.tf
@@ -243,7 +243,7 @@ resource "aws_iam_role_policy" "backup-rds-to-s3-scheduled-task-policy" {
       "Sid": "sid0",
           "Effect": "Allow",
           "Action": "ecs:RunTask",
-          "Resource": "${replace(aws_ecs_task_definition.backup-rds-to-s3-task-definition[0].arn, "/:\\d+$/", ":*",)}"
+          "Resource": "${replace(aws_ecs_task_definition.backup-rds-to-s3-task-definition[0].arn, "/:\\d+$/", ":*", )}"
     },{
       "Sid": "sid1",
       "Effect": "Allow",

--- a/govwifi-api/database-backup-task.tf
+++ b/govwifi-api/database-backup-task.tf
@@ -220,7 +220,7 @@ resource "aws_iam_role_policy" "backup-rds-to-s3-task-policy" {
       "Resource": "*",
       "Condition": {
         "StringLike": {
-          "kms:RequestAlias": "alias/${var.Env-Name}_mysql_rds_backup_s3_key*"
+          "kms:RequestAlias": "alias/${var.Env-Name}_mysql_rds_backup_s3_key"
         }
       }
     }

--- a/govwifi-backend/s3.tf
+++ b/govwifi-backend/s3.tf
@@ -12,7 +12,6 @@ resource "aws_s3_bucket" "pp-data-bucket" {
     Environment = title(var.Env-Name)
     Category    = "Statistics data / backup"
   }
-
   versioning {
     enabled = true
   }
@@ -53,7 +52,7 @@ resource "aws_s3_bucket" "rds-mysql-backup-bucket" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.mysql_rds_backup_s3_key[0].arn
+        kms_master_key_id = "alias/${var.Env-Name}_mysql_rds_backup_s3_key"
         sse_algorithm     = "aws:kms"
       }
     }


### PR DESCRIPTION
## What

Corrected the IAM permissions so that the script can now write to the KMS encrypted S3 bucket

## Why

Terraform doesn't fail when you allow an invalid resource permissions e.g.

`Resource  = "arn:aws:kms:..:..:key/..._key",`   <- not a valid kms key name
`Resource  = "arn:aws:kms:..:..:alias/..._key",` <- alias doesn't work here

needs to be like:
```
Resource  = "*"
Condition = {
  StringLike = {
     kms:RequestAlias = "alias/..._key"
   }
}
```