### PR TITLE
Get database backup script working

### DIFF
--- a/govwifi-account/iam-roles.tf
+++ b/govwifi-account/iam-roles.tf
@@ -3558,37 +3558,6 @@ POLICY
 
 }
 
-resource "aws_iam_role_policy" "backup-rds-to-s3-scheduled-task-role_backup-rds-to-s3-scheduled-task-policy" {
-  name = "backup-rds-to-s3-scheduled-task-policy"
-  role = "backup-rds-to-s3-scheduled-task-role"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "ecs:RunTask",
-      "Resource": "arn:aws:ecs:eu-west-2:${var.aws-account-id}:task-definition/backup-rds-to-s3-task-staging:*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iam:PassRole",
-      "Resource": [
-        "*"
-      ],
-      "Condition": {
-        "StringLike": {
-          "iam:PassedToService": "ecs-tasks.amazonaws.com"
-        }
-      }
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_role_policy" "wifi-user-signup-scheduled-task-role_wifi-user-signup-scheduled-task-policy" {
   name = "wifi-user-signup-scheduled-task-policy"
   role = "wifi-user-signup-scheduled-task-role"

--- a/govwifi-account/iam-users.tf
+++ b/govwifi-account/iam-users.tf
@@ -76,12 +76,6 @@ resource "aws_iam_user" "monitoring-stats-user" {
   force_destroy = false
 }
 
-resource "aws_iam_user" "mysql-s3-bucket-push-user" {
-  name          = "mysql-s3-bucket-push-user"
-  path          = "/"
-  force_destroy = false
-}
-
 resource "aws_iam_user" "it-govwifi-backup-reader" {
   name          = "it-govwifi-backup-reader"
   path          = "/"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -380,6 +380,7 @@ module "api" {
   metrics-bucket-name = module.govwifi-dashboard.metrics-bucket-name
 
   use_env_prefix = var.use_env_prefix
+  backup_mysql_rds = var.backup_mysql_rds
 }
 
 module "critical-notifications" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -379,7 +379,7 @@ module "api" {
 
   metrics-bucket-name = module.govwifi-dashboard.metrics-bucket-name
 
-  use_env_prefix = var.use_env_prefix
+  use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
 }
 


### PR DESCRIPTION
## WHAT

Delete user that was to copy the files to S3 (all done via ECS now) remove superfluous roles and enable backup script for production.

## WHY

Tidy up unneeded users/roles and ensure backups taken for LIVE