### PR TITLE
Increased ECS task CPU and RAM

### DIFF
--- a/govwifi-api/database-backup-task.tf
+++ b/govwifi-api/database-backup-task.tf
@@ -24,8 +24,8 @@ resource "aws_ecs_task_definition" "backup-rds-to-s3-task-definition" {
   task_role_arn            = aws_iam_role.backup-rds-to-s3-task-role[0].arn
   execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
   requires_compatibilities = ["FARGATE"]
-  cpu                      = 256
-  memory                   = 1024
+  cpu                      = 2048
+  memory                   = 8192
   network_mode             = "awsvpc"
 
   container_definitions = <<EOF


### PR DESCRIPTION
## WHAT

Beefed up the ECS tasks CPU and RAM as below (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html):

### CPU
- was - 256 (1/4 of a CPU) 
- now - 2048 (2 CPUs) 

### RAM
- was - 1024 (1 GB RAM
- now - 8192 (8 GB RAM)

## WHY

I started the backup process for prod and it was taking a long time to do nothing - these backups are a LOT larger than in Staging and need gziping and gpging inline