### PR TITLE
Migrate service account credentials

### DIFF
--- a/govwifi-slack-alerts/locals.tf
+++ b/govwifi-slack-alerts/locals.tf
@@ -1,3 +1,7 @@
 locals {
-  slack-workplace-id = jsondecode(data.aws_secretsmanager_secret_version.slack_workplace_id.secret_string)["id"]
+  slack-workplace-id = jsondecode(data.aws_secretsmanager_secret_version.slack_credentials.secret_string)["workplace-id"]
+}
+
+locals {
+  slack-channel-id = jsondecode(data.aws_secretsmanager_secret_version.slack_credentials.secret_string)["channel-id"]
 }

--- a/govwifi-slack-alerts/locals.tf
+++ b/govwifi-slack-alerts/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  slack-workplace-id = jsondecode(data.aws_secretsmanager_secret_version.slack_credentials.secret_string)["workplace-id"]
+  slack-workplace-id = jsondecode(data.aws_secretsmanager_secret_version.slack_credentials.secret_string)["workspace-id"]
 }
 
 locals {

--- a/govwifi-slack-alerts/locals.tf
+++ b/govwifi-slack-alerts/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  slack-workplace-id = jsondecode(data.aws_secretsmanager_secret_version.slack_workplace_id.secret_string)["id"]
+}

--- a/govwifi-slack-alerts/main.tf
+++ b/govwifi-slack-alerts/main.tf
@@ -31,7 +31,7 @@ resource "aws_cloudformation_stack" "aws-slack-chatbot" {
           "ConfigurationName" : "govwifi-monitoring-chat-configuration",
           "IamRoleArn" : "${aws_iam_role.govwifi-wifi-london-aws-chatbot-role.arn}",
           "LoggingLevel" : "NONE",
-          "SlackChannelId" : "${var.gds-slack-channel-id}",
+          "SlackChannelId" : "${local.slack-channel-id}",
           "SlackWorkspaceId" : "${local.slack-workplace-id}",
           "SnsTopicArns" : [ "${var.critical-notifications-topic-arn}","${var.capacity-notifications-topic-arn}","${var.route53-critical-notifications-topic-arn}" ]
         }

--- a/govwifi-slack-alerts/main.tf
+++ b/govwifi-slack-alerts/main.tf
@@ -32,7 +32,7 @@ resource "aws_cloudformation_stack" "aws-slack-chatbot" {
           "IamRoleArn" : "${aws_iam_role.govwifi-wifi-london-aws-chatbot-role.arn}",
           "LoggingLevel" : "NONE",
           "SlackChannelId" : "${var.gds-slack-channel-id}",
-          "SlackWorkspaceId" : "${var.gds-slack-workplace-id}",
+          "SlackWorkspaceId" : "${local.slack-workplace-id}",
           "SnsTopicArns" : [ "${var.critical-notifications-topic-arn}","${var.capacity-notifications-topic-arn}","${var.route53-critical-notifications-topic-arn}" ]
         }
       }

--- a/govwifi-slack-alerts/secrets-manager.tf
+++ b/govwifi-slack-alerts/secrets-manager.tf
@@ -1,0 +1,7 @@
+data "aws_secretsmanager_secret_version" "slack_workplace_id" {
+  secret_id = data.aws_secretsmanager_secret.slack_workplace_id.id
+}
+
+data "aws_secretsmanager_secret" "slack_workplace_id" {
+  name = "slack/workplace-id"
+}

--- a/govwifi-slack-alerts/secrets-manager.tf
+++ b/govwifi-slack-alerts/secrets-manager.tf
@@ -1,7 +1,7 @@
-data "aws_secretsmanager_secret_version" "slack_workplace_id" {
-  secret_id = data.aws_secretsmanager_secret.slack_workplace_id.id
+data "aws_secretsmanager_secret_version" "slack_credentials" {
+  secret_id = data.aws_secretsmanager_secret.slack_credentials.id
 }
 
-data "aws_secretsmanager_secret" "slack_workplace_id" {
-  name = "slack/workplace-id"
+data "aws_secretsmanager_secret" "slack_credentials" {
+  name = "slack/credentials"
 }

--- a/govwifi-slack-alerts/variables.tf
+++ b/govwifi-slack-alerts/variables.tf
@@ -4,6 +4,4 @@ variable "capacity-notifications-topic-arn" {}
 
 variable "route53-critical-notifications-topic-arn" {}
 
-variable "gds-slack-workplace-id" {}
-
 variable "gds-slack-channel-id" {}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -6,7 +6,7 @@ module "tfstate" {
   source             = "../../terraform-state"
   product-name       = var.product-name
   Env-Name           = var.Env-Name
-  aws-account-id     = var.aws-account-id
+  aws-account-id     = local.aws_account_id
   aws-region         = var.aws-region
   aws-region-name    = var.aws-region-name
   backup-region-name = var.backup-region-name
@@ -93,7 +93,7 @@ module "backend" {
   bastion-ssh-key-name       = "govwifi-staging-bastion-key-20181025"
   enable-bastion-monitoring  = false
   users                      = var.users
-  aws-account-id             = var.aws-account-id
+  aws-account-id             = local.aws_account_id
   db-instance-count          = 1
   session-db-instance-type   = "db.t2.small"
   session-db-storage-gb      = 20
@@ -307,7 +307,7 @@ module "api" {
   backend-instance-count = 2
   backend-min-size       = 1
   backend-cpualarm-count = 1
-  aws-account-id         = var.aws-account-id
+  aws-account-id         = local.aws_account_id
   aws-region-name        = var.aws-region-name
   aws-region             = var.aws-region
   route53-zone-id        = var.route53-zone-id
@@ -501,7 +501,7 @@ module "govwifi-elasticsearch" {
   Env-Name       = var.Env-Name
   Env-Subdomain  = var.Env-Subdomain
   aws-region     = var.aws-region
-  aws-account-id = var.aws-account-id
+  aws-account-id = local.aws_account_id
   vpc-id         = module.backend.backend-vpc-id
   vpc-cidr-block = module.backend.vpc-cidr-block
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -171,8 +171,8 @@ module "frontend" {
   ami                   = var.ami
   ssh-key-name          = var.ssh-key-name
   users                 = var.users
-  frontend-docker-image = format("%s/frontend:staging", var.docker-image-path)
-  raddb-docker-image    = format("%s/raddb:staging", var.docker-image-path)
+  frontend-docker-image = format("%s/frontend:staging", local.docker_image_path)
+  raddb-docker-image    = format("%s/raddb:staging", local.docker_image_path)
   create-ecr            = 1
 
   # admin bucket
@@ -227,7 +227,7 @@ module "govwifi-admin" {
   instance-count  = 1
   min-size        = 1
 
-  admin-docker-image      = format("%s/admin:staging", var.docker-image-path)
+  admin-docker-image      = format("%s/admin:staging", local.docker_image_path)
   rack-env                = "staging"
   secret-key-base         = var.admin-secret-key-base
   ecr-repository-count    = 1
@@ -319,11 +319,11 @@ module "api" {
   capacity-notifications-arn = module.notifications.topic-arn
   devops-notifications-arn   = module.notifications.topic-arn
 
-  auth-docker-image             = format("%s/authorisation-api:staging", var.docker-image-path)
-  user-signup-docker-image      = format("%s/user-signup-api:staging", var.docker-image-path)
-  logging-docker-image          = format("%s/logging-api:staging", var.docker-image-path)
-  safe-restart-docker-image     = format("%s/safe-restarter:staging", var.docker-image-path)
-  backup-rds-to-s3-docker-image = format("%s/database-backup:staging", var.docker-image-path)
+  auth-docker-image             = format("%s/authorisation-api:staging", local.docker_image_path)
+  user-signup-docker-image      = format("%s/user-signup-api:staging", local.docker_image_path)
+  logging-docker-image          = format("%s/logging-api:staging", local.docker_image_path)
+  safe-restart-docker-image     = format("%s/safe-restarter:staging", local.docker_image_path)
+  backup-rds-to-s3-docker-image = format("%s/database-backup:staging", local.docker_image_path)
 
   notify-api-key          = var.notify-api-key
   wordlist-bucket-count   = 1

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -67,7 +67,7 @@ module "backend" {
 
   # AWS VPC setup -----------------------------------------
   aws-region      = var.aws-region
-  route53-zone-id = var.route53-zone-id
+  route53-zone-id = local.route53_zone_id
   aws-region-name = var.aws-region-name
   vpc-cidr-block  = "10.103.0.0/16"
   zone-count      = var.zone-count
@@ -147,7 +147,7 @@ module "frontend" {
   aws-region = var.aws-region
 
   aws-region-name = var.aws-region-name
-  route53-zone-id = var.route53-zone-id
+  route53-zone-id = local.route53_zone_id
   vpc-cidr-block  = "10.102.0.0/16"
   zone-count      = var.zone-count
   zone-names      = var.zone-names
@@ -310,7 +310,7 @@ module "api" {
   aws-account-id         = local.aws_account_id
   aws-region-name        = var.aws-region-name
   aws-region             = var.aws-region
-  route53-zone-id        = var.route53-zone-id
+  route53-zone-id        = local.route53_zone_id
   vpc-id                 = module.backend.backend-vpc-id
   iam-count              = 1
   safe-restart-enabled   = 1

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -249,7 +249,7 @@ module "api" {
   backend-instance-count = 2
   backend-min-size       = 1
   backend-cpualarm-count = 1
-  aws-account-id         = var.aws-account-id
+  aws-account-id         = local.aws_account_id
   aws-region-name        = var.aws-region-name
   aws-region             = var.aws-region
   route53-zone-id        = local.route53_zone_id

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -530,7 +530,6 @@ module "govwifi-slack-alerts" {
   critical-notifications-topic-arn         = module.critical-notifications.topic-arn
   capacity-notifications-topic-arn         = module.capacity-notifications.topic-arn
   route53-critical-notifications-topic-arn = module.route53-critical-notifications.topic-arn
-  gds-slack-workplace-id                   = var.gds-slack-workplace-id
   gds-slack-channel-id                     = var.gds-slack-channel-id
 }
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -6,7 +6,7 @@ module "tfstate" {
   source             = "../../terraform-state"
   product-name       = var.product-name
   Env-Name           = var.Env-Name
-  aws-account-id     = var.aws-account-id
+  aws-account-id     = local.aws_account_id
   aws-region         = var.aws-region
   aws-region-name    = var.aws-region-name
   backup-region-name = var.backup-region-name
@@ -61,7 +61,7 @@ module "govwifi-account" {
   }
 
   source                 = "../../govwifi-account"
-  aws-account-id         = var.aws-account-id
+  aws-account-id         = local.aws_account_id
   administrator-IPs      = var.administrator-IPs
   administrator-IPs-list = split(",", var.administrator-IPs)
 }
@@ -107,7 +107,7 @@ module "backend" {
   bastion-ssh-key-name       = "govwifi-bastion-key-20181025"
   enable-bastion-monitoring  = true
   users                      = var.users
-  aws-account-id             = var.aws-account-id
+  aws-account-id             = local.aws_account_id
   db-instance-count          = 1
   session-db-instance-type   = "db.m4.xlarge"
   session-db-storage-gb      = 1000
@@ -321,7 +321,7 @@ module "api" {
   backend-instance-count = 3
   backend-min-size       = 1
   backend-cpualarm-count = 1
-  aws-account-id         = var.aws-account-id
+  aws-account-id         = local.aws_account_id
   aws-region-name        = var.aws-region-name
   aws-region             = var.aws-region
   route53-zone-id        = var.route53-zone-id
@@ -543,7 +543,7 @@ module "govwifi-elasticsearch" {
   Env-Name       = var.Env-Name
   Env-Subdomain  = var.Env-Subdomain
   aws-region     = var.aws-region
-  aws-account-id = var.aws-account-id
+  aws-account-id = local.aws_account_id
   vpc-id         = module.backend.backend-vpc-id
   vpc-cidr-block = module.backend.vpc-cidr-block
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -187,8 +187,8 @@ module "frontend" {
   ami                   = var.ami
   ssh-key-name          = var.ssh-key-name
   users                 = var.users
-  frontend-docker-image = format("%s/frontend:production", var.docker-image-path)
-  raddb-docker-image    = format("%s/raddb:production", var.docker-image-path)
+  frontend-docker-image = format("%s/frontend:production", local.docker_image_path)
+  raddb-docker-image    = format("%s/raddb:production", local.docker_image_path)
   shared-key            = var.shared-key
 
   # admin bucket
@@ -241,7 +241,7 @@ module "govwifi-admin" {
   instance-count  = 2
   min-size        = 2
 
-  admin-docker-image      = format("%s/admin:production", var.docker-image-path)
+  admin-docker-image      = format("%s/admin:production", local.docker_image_path)
   rack-env                = "production"
   secret-key-base         = var.admin-secret-key-base
   ecs-instance-profile-id = module.backend.ecs-instance-profile-id
@@ -332,11 +332,11 @@ module "api" {
   capacity-notifications-arn = module.capacity-notifications.topic-arn
   devops-notifications-arn   = module.devops-notifications.topic-arn
 
-  auth-docker-image             = format("%s/authorisation-api:production", var.docker-image-path)
-  user-signup-docker-image      = format("%s/user-signup-api:production", var.docker-image-path)
-  logging-docker-image          = format("%s/logging-api:production", var.docker-image-path)
-  safe-restart-docker-image     = format("%s/safe-restarter:production", var.docker-image-path)
-  backup-rds-to-s3-docker-image = format("%s/database-backup:staging", var.docker-image-path)
+  auth-docker-image             = format("%s/authorisation-api:production", local.docker_image_path)
+  user-signup-docker-image      = format("%s/user-signup-api:production", local.docker_image_path)
+  logging-docker-image          = format("%s/logging-api:production", local.docker_image_path)
+  safe-restart-docker-image     = format("%s/safe-restarter:production", local.docker_image_path)
+  backup-rds-to-s3-docker-image = format("%s/database-backup:staging", local.docker_image_path)
 
   notify-api-key = var.notify-api-key
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -82,7 +82,7 @@ module "backend" {
   # AWS VPC setup -----------------------------------------
   aws-region      = var.aws-region
   aws-region-name = var.aws-region-name
-  route53-zone-id = var.route53-zone-id
+  route53-zone-id = local.route53_zone_id
   vpc-cidr-block  = "10.84.0.0/16"
   zone-count      = var.zone-count
   zone-names      = var.zone-names
@@ -163,7 +163,7 @@ module "frontend" {
   aws-region = var.aws-region
 
   aws-region-name = var.aws-region-name
-  route53-zone-id = var.route53-zone-id
+  route53-zone-id = local.route53_zone_id
   vpc-cidr-block  = "10.85.0.0/16"
   zone-count      = var.zone-count
   zone-names      = var.zone-names
@@ -324,7 +324,7 @@ module "api" {
   aws-account-id         = local.aws_account_id
   aws-region-name        = var.aws-region-name
   aws-region             = var.aws-region
-  route53-zone-id        = var.route53-zone-id
+  route53-zone-id        = local.route53_zone_id
   vpc-id                 = module.backend.backend-vpc-id
   iam-count              = 1
 

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -285,9 +285,6 @@ variable "google-client-id" {
 variable "grafana-server-root-url" {
 }
 
-variable "gds-slack-workplace-id" {
-}
-
 variable "gds-slack-channel-id" {
 }
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -6,7 +6,7 @@ module "tfstate" {
   source             = "../../terraform-state"
   product-name       = var.product-name
   Env-Name           = var.Env-Name
-  aws-account-id     = var.aws-account-id
+  aws-account-id     = local.aws_account_id
   aws-region         = var.aws-region
   aws-region-name    = var.aws-region-name
   backup-region-name = var.backup-region-name
@@ -93,7 +93,7 @@ module "backend" {
   bastion-ssh-key-name      = "govwifi-bastion-key-20181025"
   enable-bastion-monitoring = true
   users                     = var.users
-  aws-account-id            = var.aws-account-id
+  aws-account-id            = local.aws_account_id
 
   db-instance-count        = 0
   session-db-instance-type = "db.m4.xlarge"
@@ -111,7 +111,7 @@ module "backend" {
   critical-notifications-arn = module.critical-notifications.topic-arn
   capacity-notifications-arn = module.capacity-notifications.topic-arn
   rds-kms-key-id             = var.rds-kms-key-id
-  user-replica-source-db     = "arn:aws:rds:eu-west-2:${var.aws-account-id}:db:wifi-production-user-db"
+  user-replica-source-db     = "arn:aws:rds:eu-west-2:${local.aws_account_id}:db:wifi-production-user-db"
 
   # Seconds. Set to zero to disable monitoring
   db-monitoring-interval = 60
@@ -142,7 +142,7 @@ module "emails" {
   product-name             = var.product-name
   Env-Name                 = var.Env-Name
   Env-Subdomain            = var.Env-Subdomain
-  aws-account-id           = var.aws-account-id
+  aws-account-id           = local.aws_account_id
   route53-zone-id          = var.route53-zone-id
   aws-region               = var.aws-region
   aws-region-name          = var.aws-region-name
@@ -269,7 +269,7 @@ module "api" {
   authorisation-api-count = 3
   backend-min-size        = 1
   backend-cpualarm-count  = 1
-  aws-account-id          = var.aws-account-id
+  aws-account-id          = local.aws_account_id
   aws-region-name         = lower(var.aws-region-name)
   aws-region              = var.aws-region
   route53-zone-id         = var.route53-zone-id

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -67,7 +67,7 @@ module "backend" {
   # AWS VPC setup -----------------------------------------
   aws-region      = var.aws-region
   aws-region-name = var.aws-region-name
-  route53-zone-id = var.route53-zone-id
+  route53-zone-id = local.route53_zone_id
   vpc-cidr-block  = "10.42.0.0/16"
   zone-count      = var.zone-count
   zone-names      = var.zone-names
@@ -143,7 +143,7 @@ module "emails" {
   Env-Name                 = var.Env-Name
   Env-Subdomain            = var.Env-Subdomain
   aws-account-id           = local.aws_account_id
-  route53-zone-id          = var.route53-zone-id
+  route53-zone-id          = local.route53_zone_id
   aws-region               = var.aws-region
   aws-region-name          = var.aws-region-name
   mail-exchange-server     = "10 inbound-smtp.eu-west-1.amazonaws.com"
@@ -173,7 +173,7 @@ module "dns" {
   source             = "../../global-dns"
   Env-Name           = var.Env-Name
   Env-Subdomain      = var.Env-Subdomain
-  route53-zone-id    = var.route53-zone-id
+  route53-zone-id    = local.route53_zone_id
   status-page-domain = "bl6klm1cjshh.stspg-customer.com"
 }
 
@@ -191,7 +191,7 @@ module "frontend" {
   # AWS VPC setup -----------------------------------------
   aws-region      = var.aws-region
   aws-region-name = var.aws-region-name
-  route53-zone-id = var.route53-zone-id
+  route53-zone-id = local.route53_zone_id
   vpc-cidr-block  = "10.43.0.0/16"
   zone-count      = var.zone-count
   zone-names      = var.zone-names
@@ -272,7 +272,7 @@ module "api" {
   aws-account-id          = local.aws_account_id
   aws-region-name         = lower(var.aws-region-name)
   aws-region              = var.aws-region
-  route53-zone-id         = var.route53-zone-id
+  route53-zone-id         = local.route53_zone_id
   vpc-id                  = module.backend.backend-vpc-id
 
   user-signup-enabled  = 0

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -215,8 +215,8 @@ module "frontend" {
   ami                   = var.ami
   ssh-key-name          = var.ssh-key-name
   users                 = var.users
-  frontend-docker-image = format("%s/frontend:production", var.docker-image-path)
-  raddb-docker-image    = format("%s/raddb:production", var.docker-image-path)
+  frontend-docker-image = format("%s/frontend:production", local.docker_image_path)
+  raddb-docker-image    = format("%s/raddb:production", local.docker_image_path)
 
   shared-key = var.shared-key
 
@@ -285,9 +285,9 @@ module "api" {
   capacity-notifications-arn = module.capacity-notifications.topic-arn
   devops-notifications-arn   = module.devops-notifications.topic-arn
 
-  auth-docker-image             = format("%s/authorisation-api:production", var.docker-image-path)
-  logging-docker-image          = format("%s/logging-api:production", var.docker-image-path)
-  safe-restart-docker-image     = format("%s/safe-restarter:production", var.docker-image-path)
+  auth-docker-image             = format("%s/authorisation-api:production", local.docker_image_path)
+  logging-docker-image          = format("%s/logging-api:production", local.docker_image_path)
+  safe-restart-docker-image     = format("%s/safe-restarter:production", local.docker_image_path)
   backup-rds-to-s3-docker-image = ""
 
   db-user                   = var.db-user


### PR DESCRIPTION
### What

Retrieve service account credentials (AWS related and Slack) from Secrets Manager instead of `govwifi-build`.

Note: the Slack workplace ID is only present in `wifi-london`.

### Why

We are migrating credentials to Secrets Manager. See [this card for details](https://trello.com/c/MrsplSr0/1237-sub-task-migrate-aws-account-credentials).