### PR TITLE
large file uploads also need decrypt/rencrypt/etc more kms perms

### DIFF
--- a/govwifi-api/database-backup-task.tf
+++ b/govwifi-api/database-backup-task.tf
@@ -215,8 +215,11 @@ resource "aws_iam_role_policy" "backup-rds-to-s3-task-policy" {
       "Sid": "sid4",
       "Effect": "Allow",
       "Action": [
+        "kms:GenerateDataKey",
+        "kms:Encrypt", 
         "kms:Decrypt",
-        "kms:GenerateDataKey"
+        "kms:ReEncrypt*",
+        "kms:DescribeKey
       ],
       "Resource": "*",
       "Condition": {


### PR DESCRIPTION
## WHAT

Allow more KMS perms as multipart upload (for large files) needs them

## WHY

In staging this was fine - but in prod its writing files in chunks so needs to decrypt/re-encrypt/etc files

https://github.com/aws/aws-cli/issues/4251