### PR TITLE
Migrate database credentials to Secrets Manager

### DIFF
--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -55,8 +55,8 @@ resource "aws_db_instance" "admin_db" {
   instance_class              = var.db-instance-type
   identifier                  = "wifi-admin-${var.Env-Name}-db"
   name                        = "govwifi_admin_${var.rack-env}"
-  username                    = var.admin-db-user
-  password                    = var.admin-db-password
+  username                    = local.admin_db_username
+  password                    = local.admin_db_password
   backup_retention_period     = var.db-backup-retention-days
   multi_az                    = true
   storage_encrypted           = var.db-encrypt-at-rest

--- a/govwifi-admin/locals.tf
+++ b/govwifi-admin/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  admin_db_username = jsondecode(data.aws_secretsmanager_secret_version.admin_db.secret_string)["username"]
+}
+
+locals {
+  admin_db_password = jsondecode(data.aws_secretsmanager_secret_version.admin_db.secret_string)["password"]
+}

--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -10,8 +10,8 @@ resource "aws_db_instance" "db" {
   instance_class              = var.session-db-instance-type
   identifier                  = "wifi-${var.Env-Name}-db"
   name                        = "govwifi_${var.Env-Name}"
-  username                    = var.db-user
-  password                    = var.db-password
+  username                    = local.session_db_username
+  password                    = local.session_db_password
   backup_retention_period     = var.db-backup-retention-days
   multi_az                    = true
   storage_encrypted           = var.db-encrypt-at-rest

--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -46,8 +46,8 @@ resource "aws_db_instance" "read_replica" {
   apply_immediately           = true
   instance_class              = var.rr-instance-type
   identifier                  = "${var.Env-Name}-db-rr"
-  username                    = var.db-user
-  password                    = var.db-password
+  username                    = local.session_db_username
+  password                    = local.session_db_username
   backup_retention_period     = 0
   multi_az                    = false
   storage_encrypted           = var.db-encrypt-at-rest

--- a/govwifi-backend/db-users.tf
+++ b/govwifi-backend/db-users.tf
@@ -10,8 +10,8 @@ resource "aws_db_instance" "users_db" {
   instance_class              = var.user-db-instance-type
   identifier                  = "wifi-${var.env}-user-db"
   name                        = "govwifi_${var.env}_users"
-  username                    = var.user-db-username
-  password                    = var.user-db-password
+  username                    = local.users_db_username
+  password                    = local.users_db_password
   backup_retention_period     = var.db-backup-retention-days
   multi_az                    = true
   storage_encrypted           = var.db-encrypt-at-rest
@@ -46,8 +46,8 @@ resource "aws_db_instance" "users_read_replica" {
   apply_immediately           = true
   instance_class              = var.user-rr-instance-type
   identifier                  = "wifi-${var.env}-user-rr"
-  username                    = var.user-db-username
-  password                    = var.user-db-password
+  username                    = local.users_db_username
+  password                    = local.users_db_username
   backup_retention_period     = 0
   multi_az                    = true
   vpc_security_group_ids      = [aws_security_group.be-db-in.id]

--- a/govwifi-backend/locals.tf
+++ b/govwifi-backend/locals.tf
@@ -5,3 +5,11 @@ locals {
 locals {
   session_db_password = jsondecode(data.aws_secretsmanager_secret_version.session_db_credentials.secret_string)["password"]
 }
+
+locals {
+  users_db_username = jsondecode(data.aws_secretsmanager_secret_version.users_db_credentials.secret_string)["username"]
+}
+
+locals {
+  users_db_password = jsondecode(data.aws_secretsmanager_secret_version.users_db_credentials.secret_string)["password"]
+}

--- a/govwifi-backend/locals.tf
+++ b/govwifi-backend/locals.tf
@@ -1,7 +1,7 @@
 locals {
-  session_db_username = jsondecode(data.aws_secretsmanager_secret_version.db_session_credentials.secret_string)["username"]
+  session_db_username = jsondecode(data.aws_secretsmanager_secret_version.session_db_credentials.secret_string)["username"]
 }
 
 locals {
-  session_db_password = jsondecode(data.aws_secretsmanager_secret_version.db_session_credentials.secret_string)["password"]
+  session_db_password = jsondecode(data.aws_secretsmanager_secret_version.session_db_credentials.secret_string)["password"]
 }

--- a/govwifi-backend/locals.tf
+++ b/govwifi-backend/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  session_db_username = jsondecode(data.aws_secretsmanager_secret_version.db_session_credentials.secret_string)["username"]
+}
+
+locals {
+  session_db_password = jsondecode(data.aws_secretsmanager_secret_version.db_session_credentials.secret_string)["password"]
+}

--- a/govwifi-backend/secrets-manager.tf
+++ b/govwifi-backend/secrets-manager.tf
@@ -1,0 +1,7 @@
+data "aws_secretsmanager_secret_version" "db_session_credentials" {
+  secret_id = data.aws_secretsmanager_secret.db_session_credentials.id
+}
+
+data "aws_secretsmanager_secret" "db_session_credentials" {
+  name = var.use_env_prefix ? "staging/rds/session-db/credentials" : "rds/session-db/credentials"
+}

--- a/govwifi-backend/secrets-manager.tf
+++ b/govwifi-backend/secrets-manager.tf
@@ -5,3 +5,11 @@ data "aws_secretsmanager_secret_version" "session_db_credentials" {
 data "aws_secretsmanager_secret" "session_db_credentials" {
   name = var.use_env_prefix ? "staging/rds/session-db/credentials" : "rds/session-db/credentials"
 }
+
+data "aws_secretsmanager_secret_version" "users_db_credentials" {
+  secret_id = data.aws_secretsmanager_secret.users_db_credentials.id
+}
+
+data "aws_secretsmanager_secret" "users_db_credentials" {
+  name = var.use_env_prefix ? "staging/rds/users-db/credentials" : "rds/users-db/credentials"
+}

--- a/govwifi-backend/secrets-manager.tf
+++ b/govwifi-backend/secrets-manager.tf
@@ -1,7 +1,7 @@
-data "aws_secretsmanager_secret_version" "db_session_credentials" {
-  secret_id = data.aws_secretsmanager_secret.db_session_credentials.id
+data "aws_secretsmanager_secret_version" "session_db_credentials" {
+  secret_id = data.aws_secretsmanager_secret.session_db_credentials.id
 }
 
-data "aws_secretsmanager_secret" "db_session_credentials" {
+data "aws_secretsmanager_secret" "session_db_credentials" {
   name = var.use_env_prefix ? "staging/rds/session-db/credentials" : "rds/session-db/credentials"
 }


### PR DESCRIPTION
### What

Retrieve encrypted database credentials from Secrets Manager instead of `govwifi-build`.

* Create the Terraform to retrieve database username and password from Secrets manager for Sessions, User Details and Admin databases.
* The values have been manually created in Secrets Manager already.
* Running `plan` returns "No changes. Infrastructure is up-to-date." since the values are unchanged.


### Why

This is part of our migration to a cloud credential management system. See [this card for more details](https://trello.com/c/XRpBfPHh/1226-sub-task-migrate-db-credentials).