### PR TITLE
Fix error on DB password retrieval

### DIFF
--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -47,7 +47,7 @@ resource "aws_db_instance" "read_replica" {
   instance_class              = var.rr-instance-type
   identifier                  = "${var.Env-Name}-db-rr"
   username                    = local.session_db_username
-  password                    = local.session_db_username
+  password                    = local.session_db_password
   backup_retention_period     = 0
   multi_az                    = false
   storage_encrypted           = var.db-encrypt-at-rest

--- a/govwifi-backend/db-users.tf
+++ b/govwifi-backend/db-users.tf
@@ -47,7 +47,7 @@ resource "aws_db_instance" "users_read_replica" {
   instance_class              = var.user-rr-instance-type
   identifier                  = "wifi-${var.env}-user-rr"
   username                    = local.users_db_username
-  password                    = local.users_db_username
+  password                    = local.users_db_password
   backup_retention_period     = 0
   multi_az                    = true
   vpc_security_group_ids      = [aws_security_group.be-db-in.id]


### PR DESCRIPTION
### What

Fix copy/paste error on the User DB and Session DB password retrieval from Secrets Manager.


### Why

Currently the passwords point to the username which is incorrect.