### PR TITLE
Refactor Grafana Secrets Manager Terraform

### DIFF
--- a/govwifi-grafana/iam.tf
+++ b/govwifi-grafana/iam.tf
@@ -5,10 +5,7 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
     ]
 
     resources = [
-      data.aws_secretsmanager_secret.google_client_id.arn,
-      data.aws_secretsmanager_secret.google_client_secret.arn,
-      data.aws_secretsmanager_secret.grafana_admin.arn,
-      data.aws_secretsmanager_secret.grafana_server_root_url.arn
+      data.aws_secretsmanager_secret.grafana_credentials.arn
     ]
 
     principals {

--- a/govwifi-grafana/locals.tf
+++ b/govwifi-grafana/locals.tf
@@ -1,15 +1,15 @@
 locals {
-  grafana-admin = jsondecode(data.aws_secretsmanager_secret_version.grafana_admin.secret_string)["admin-pass"]
+  grafana-admin = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["admin-pass"]
 }
 
 locals {
-  grafana-server-root-url = jsondecode(data.aws_secretsmanager_secret_version.grafana_server_root_url.secret_string)["url"]
+  grafana-server-root-url = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["url"]
 }
 
 locals {
-  google-client-id = jsondecode(data.aws_secretsmanager_secret_version.google_client_id.secret_string)["id"]
+  google-client-id = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["id"]
 }
 
 locals {
-  google-client-secret = jsondecode(data.aws_secretsmanager_secret_version.google_client_secret.secret_string)["secret"]
+  google-client-secret = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["secret"]
 }

--- a/govwifi-grafana/secrets-manager.tf
+++ b/govwifi-grafana/secrets-manager.tf
@@ -1,31 +1,7 @@
-data "aws_secretsmanager_secret_version" "grafana_admin" {
-  secret_id = data.aws_secretsmanager_secret.grafana_admin.id
+data "aws_secretsmanager_secret_version" "grafana_credentials" {
+  secret_id = data.aws_secretsmanager_secret.grafana_credentials.id
 }
 
-data "aws_secretsmanager_secret" "grafana_admin" {
-  name = var.use_env_prefix ? "staging/grafana/admin-pass" : "grafana/admin-pass"
-}
-
-data "aws_secretsmanager_secret_version" "grafana_server_root_url" {
-  secret_id = data.aws_secretsmanager_secret.grafana_server_root_url.id
-}
-
-data "aws_secretsmanager_secret" "grafana_server_root_url" {
-  name = var.use_env_prefix ? "staging/grafana/server-root-url" : "grafana/server-root-url"
-}
-
-data "aws_secretsmanager_secret_version" "google_client_id" {
-  secret_id = data.aws_secretsmanager_secret.google_client_id.id
-}
-
-data "aws_secretsmanager_secret" "google_client_id" {
-  name = var.use_env_prefix ? "staging/grafana/google-client-id" : "grafana/google-client-id"
-}
-
-data "aws_secretsmanager_secret_version" "google_client_secret" {
-  secret_id = data.aws_secretsmanager_secret.google_client_secret.id
-}
-
-data "aws_secretsmanager_secret" "google_client_secret" {
-  name = var.use_env_prefix ? "staging/grafana/google-client-secret" : "grafana/google-client-secret"
+data "aws_secretsmanager_secret" "grafana_credentials" {
+  name = var.use_env_prefix ? "staging/grafana/credentials" : "grafana/credentials"
 }


### PR DESCRIPTION
### What

Move to a single credential object with multiple key/values.

- I manually created a new secret name entry `grafana/credentials` which contains all the credentials associated with Grafana.
- This has been tested by terminating and successfully recreating the staging instance.

### Why

Previously we created a single secret name entry for each of the values. This cluttered the AWS console and made it harder to find credentials. This refactor will make it easier to add credentials to services without having to create individual entries.