### PR TITLE
Remove versioning from RDS mysqldump backup buckets

### DIFF
--- a/govwifi-backend/s3.tf
+++ b/govwifi-backend/s3.tf
@@ -59,7 +59,7 @@ resource "aws_s3_bucket" "rds-mysql-backup-bucket" {
   }
 
   versioning {
-    enabled = true
+    enabled = false
   }
 }
 


### PR DESCRIPTION
## What

Remove versioning from S3 buckets used for database backups

## Why

Not needed and makes retention policy more complicated - https://docs.aws.amazon.com/AmazonS3/latest/userguide/RemDelMarker.html