### PR TITLE
Update unencryption process and remove unused variables

### DIFF
--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -154,9 +154,6 @@ variable "zendesk-api-endpoint" {
 variable "zendesk-api-user" {
 }
 
-variable "zendesk-api-token" {
-}
-
 variable "public-google-api-key" {
 }
 

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -154,12 +154,6 @@ variable "rr-db-host" {
 variable "rr-db-name" {
 }
 
-variable "user-db-user" {
-}
-
-variable "user-db-password" {
-}
-
 variable "user-db-host" {
 }
 

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -122,9 +122,6 @@ variable "db-sg-list" {
 variable "rds-monitoring-role" {
 }
 
-variable "notify-api-key" {
-}
-
 variable "london-radius-ip-addresses" {
   type = list(string)
 }

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -153,10 +153,6 @@ variable "zendesk-api-user" {
 variable "public-google-api-key" {
 }
 
-variable "otp-secret-encryption-key" {
-  description = "Encryption key used to verify OTP authentication codes"
-}
-
 variable "bastion-ips" {
   description = "The list of allowed hosts to connect to the ec2 instances"
   type        = list(string)

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -53,10 +53,6 @@ variable "rack-env" {
   description = "E.g. staging"
 }
 
-variable "secret-key-base" {
-  description = "Rails secret key base variable used for the admin platform"
-}
-
 variable "ssh-key-name" {
   description = "SSH key applied to the EC2 instance"
 }

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -142,12 +142,6 @@ variable "sentry-dsn" {
 variable "logging-api-search-url" {
 }
 
-variable "rr-db-user" {
-}
-
-variable "rr-db-password" {
-}
-
 variable "rr-db-host" {
 }
 

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -94,9 +94,6 @@ variable "db-instance-count" {
 variable "admin-db-user" {
 }
 
-variable "admin-db-password" {
-}
-
 variable "db-backup-retention-days" {
 }
 

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -110,9 +110,6 @@ variable "user-signup-sentry-dsn" {
 variable "logging-sentry-dsn" {
 }
 
-variable "shared-key" {
-}
-
 variable "elb-sg-list" {
   type = list(string)
 }

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -70,12 +70,6 @@ variable "safe-restart-sentry-dsn" {
   default = ""
 }
 
-variable "user-db-username" {
-}
-
-variable "user-db-password" {
-}
-
 variable "user-db-hostname" {
 }
 

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -76,12 +76,6 @@ variable "user-db-hostname" {
 variable "user-rr-hostname" {
 }
 
-variable "db-user" {
-}
-
-variable "db-password" {
-}
-
 variable "db-hostname" {
 }
 

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -149,11 +149,6 @@ variable "safe-restart-docker-image" {
 variable "backup-rds-to-s3-docker-image" {
 }
 
-variable "notify-api-key" {
-  default     = ""
-  description = "API key used to authenticate with GOV.UK Notify"
-}
-
 variable "ecr-repository-count" {
   default     = 0
   description = "Whether or not to create ECR repository"

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -192,11 +192,6 @@ variable "firetext-token" {
   default = ""
 }
 
-variable "govnotify-bearer-token" {
-  type    = string
-  default = ""
-}
-
 variable "user-signup-api-is-public" {
   default = 0
 }

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -202,12 +202,6 @@ variable "metrics-bucket-name" {
   description = "Name of the S3 bucket to write metrics into"
 }
 
-variable "volumetrics-elasticsearch-endpoint" {
-  type        = string
-  default     = ""
-  description = "URL for the ElasticSearch instance endpoint"
-}
-
 variable "use_env_prefix" {
 
 }

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -146,11 +146,6 @@ variable "pp-domain-name" {
   default = ""
 }
 
-variable "rds-kms-key-id" {
-  type    = string
-  default = ""
-}
-
 variable "user-replica-source-db" {
   type    = string
   default = ""

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -67,12 +67,6 @@ variable "db-user" {
 variable "db-password" {
 }
 
-variable "user-db-username" {
-}
-
-variable "user-db-password" {
-}
-
 variable "user-db-hostname" {
 }
 

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -61,12 +61,6 @@ variable "bastion-server-ip" {
 variable "bastion-ssh-key-name" {
 }
 
-variable "db-user" {
-}
-
-variable "db-password" {
-}
-
 variable "user-db-hostname" {
 }
 

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -47,21 +47,6 @@ variable "ami" {
 variable "ssh-key-name" {
 }
 
-variable "shared-key" {
-}
-
-variable "healthcheck-radius-key" {
-}
-
-variable "healthcheck-ssid" {
-}
-
-variable "healthcheck-identity" {
-}
-
-variable "healthcheck-password" {
-}
-
 variable "dns-numbering-base" {
 }
 

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -57,26 +57,6 @@ variable "subnet-ids" {
   type        = list(string)
 }
 
-variable "grafana-admin" {
-  description = "Credential used for Grafana Admin user"
-  type        = string
-}
-
-variable "google-client-secret" {
-  description = "Credential used for Single Sign On"
-  type        = string
-}
-
-variable "google-client-id" {
-  description = "Credential used for Single Sign On"
-  type        = string
-}
-
-variable "grafana-server-root-url" {
-  description = "Grafana Server Root URL"
-  type        = string
-}
-
 variable "administrator-IPs" {
   description = "IPs associated with the GDS/CDIO VPN to allow access"
 }

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -252,7 +252,6 @@ module "govwifi-admin" {
 
   rds-monitoring-role = module.backend.rds-monitoring-role
 
-  notify-api-key             = var.notify-api-key
   london-radius-ip-addresses = var.london-radius-ip-addresses
   dublin-radius-ip-addresses = var.dublin-radius-ip-addresses
   sentry-dsn                 = var.admin-sentry-dsn
@@ -308,7 +307,6 @@ module "api" {
   safe-restart-docker-image     = format("%s/safe-restarter:staging", local.docker_image_path)
   backup-rds-to-s3-docker-image = format("%s/database-backup:staging", local.docker_image_path)
 
-  notify-api-key          = var.notify-api-key
   wordlist-bucket-count   = 1
   wordlist-file-path      = "../wordlist-short"
   ecr-repository-count    = 1

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -257,8 +257,6 @@ module "govwifi-admin" {
   logging-api-search-url     = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
   public-google-api-key      = var.public-google-api-key
 
-  otp-secret-encryption-key = var.otp-secret-encryption-key
-
   zendesk-api-endpoint = "https://govuk.zendesk.com/api/v2/"
   zendesk-api-user     = var.zendesk-api-user
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -114,8 +114,6 @@ module "backend" {
   # Passed to application
   db-user               = var.db-user
   db-password           = var.db-password
-  user-db-username      = var.user-db-username
-  user-db-password      = var.user-db-password
   user-db-hostname      = var.user-db-hostname
   user-db-instance-type = "db.t2.small"
   user-db-storage-gb    = 20

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -328,7 +328,6 @@ module "api" {
   user-signup-api-base-url           = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443"
   admin-bucket-name                  = "govwifi-staging-admin"
   user-signup-api-is-public          = 1
-  volumetrics-elasticsearch-endpoint = var.volumetrics-elasticsearch-endpoint
 
   elb-sg-list = []
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -249,8 +249,6 @@ module "govwifi-admin" {
   rr-db-host     = "db.london.staging.wifi.service.gov.uk"
   rr-db-name     = "govwifi_staging"
 
-  user-db-user     = var.user-db-username
-  user-db-password = var.user-db-password
   user-db-host     = var.user-db-hostname
   user-db-name     = "govwifi_staging_users"
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -181,14 +181,6 @@ module "frontend" {
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.london-api-base-url
 
-  shared-key = var.shared-key
-
-  # A site with this radkey must exist in the database for health checks to work
-  healthcheck-radius-key = var.hc-key
-  healthcheck-ssid       = var.hc-ssid
-  healthcheck-identity   = var.hc-identity
-  healthcheck-password   = var.hc-password
-
   # This must be based on us-east-1, as that's where the alarms go
   route53-critical-notifications-arn = module.route53-notifications.topic-arn
   devops-notifications-arn           = module.notifications.topic-arn
@@ -348,7 +340,6 @@ module "api" {
   safe-restart-sentry-dsn            = var.safe-restart-sentry-dsn
   user-signup-sentry-dsn             = var.user-signup-sentry-dsn
   logging-sentry-dsn                 = var.logging-sentry-dsn
-  shared-key                         = var.shared-key
   subnet-ids                         = module.backend.backend-subnet-ids
   ecs-instance-profile-id            = module.backend.ecs-instance-profile-id
   ecs-service-role                   = module.backend.ecs-service-role

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -329,7 +329,6 @@ module "api" {
   ecs-service-role                   = module.backend.ecs-service-role
   user-signup-api-base-url           = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443"
   admin-bucket-name                  = "govwifi-staging-admin"
-  govnotify-bearer-token             = var.govnotify-bearer-token
   user-signup-api-is-public          = 1
   volumetrics-elasticsearch-endpoint = var.volumetrics-elasticsearch-endpoint
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -112,8 +112,6 @@ module "backend" {
   db-monitoring-interval = 60
 
   # Passed to application
-  db-user               = var.db-user
-  db-password           = var.db-password
   user-db-hostname      = var.user-db-hostname
   user-db-instance-type = "db.t2.small"
   user-db-storage-gb    = 20
@@ -242,8 +240,6 @@ module "govwifi-admin" {
   db-backup-window         = "03:42-04:42"
   db-monitoring-interval   = 60
 
-  rr-db-user     = var.db-user
-  rr-db-password = var.db-password
   rr-db-host     = "db.london.staging.wifi.service.gov.uk"
   rr-db-name     = "govwifi_staging"
 
@@ -319,8 +315,6 @@ module "api" {
   ecr-repository-count    = 1
   background-jobs-enabled = 1
 
-  db-user     = var.db-user
-  db-password = var.db-password
   db-hostname = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
 
   user-db-hostname = var.user-db-hostname

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -327,9 +327,8 @@ module "api" {
   db-password = var.db-password
   db-hostname = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
 
-  user-db-username = var.user-db-username
   user-db-hostname = var.user-db-hostname
-  user-db-password = var.user-db-password
+
   user-rr-hostname = var.user-db-hostname
 
   # There is no read replica for the staging database

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -227,7 +227,7 @@ module "govwifi-admin" {
 
   ec2-sg-list = []
 
-  admin-db-user     = var.admin-db-username
+  admin-db-user = var.admin-db-username
 
   db-instance-count        = 1
   db-instance-type         = "db.t2.medium"
@@ -238,11 +238,11 @@ module "govwifi-admin" {
   db-backup-window         = "03:42-04:42"
   db-monitoring-interval   = 60
 
-  rr-db-host     = "db.london.staging.wifi.service.gov.uk"
-  rr-db-name     = "govwifi_staging"
+  rr-db-host = "db.london.staging.wifi.service.gov.uk"
+  rr-db-name = "govwifi_staging"
 
-  user-db-host     = var.user-db-hostname
-  user-db-name     = "govwifi_staging_users"
+  user-db-host = var.user-db-hostname
+  user-db-name = "govwifi_staging_users"
 
   db-sg-list = []
 
@@ -315,19 +315,19 @@ module "api" {
   user-rr-hostname = var.user-db-hostname
 
   # There is no read replica for the staging database
-  db-read-replica-hostname           = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
-  rack-env                           = "staging"
-  radius-server-ips                  = split(",", var.frontend-radius-IPs)
-  authentication-sentry-dsn          = var.auth-sentry-dsn
-  safe-restart-sentry-dsn            = var.safe-restart-sentry-dsn
-  user-signup-sentry-dsn             = var.user-signup-sentry-dsn
-  logging-sentry-dsn                 = var.logging-sentry-dsn
-  subnet-ids                         = module.backend.backend-subnet-ids
-  ecs-instance-profile-id            = module.backend.ecs-instance-profile-id
-  ecs-service-role                   = module.backend.ecs-service-role
-  user-signup-api-base-url           = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443"
-  admin-bucket-name                  = "govwifi-staging-admin"
-  user-signup-api-is-public          = 1
+  db-read-replica-hostname  = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
+  rack-env                  = "staging"
+  radius-server-ips         = split(",", var.frontend-radius-IPs)
+  authentication-sentry-dsn = var.auth-sentry-dsn
+  safe-restart-sentry-dsn   = var.safe-restart-sentry-dsn
+  user-signup-sentry-dsn    = var.user-signup-sentry-dsn
+  logging-sentry-dsn        = var.logging-sentry-dsn
+  subnet-ids                = module.backend.backend-subnet-ids
+  ecs-instance-profile-id   = module.backend.ecs-instance-profile-id
+  ecs-service-role          = module.backend.ecs-service-role
+  user-signup-api-base-url  = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443"
+  admin-bucket-name         = "govwifi-staging-admin"
+  user-signup-api-is-public = 1
 
   elb-sg-list = []
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -262,7 +262,6 @@ module "govwifi-admin" {
 
   zendesk-api-endpoint = "https://govuk.zendesk.com/api/v2/"
   zendesk-api-user     = var.zendesk-api-user
-  zendesk-api-token    = var.zendesk-api-token
 
   bastion-ips = concat(
     split(",", var.bastion-server-IP),

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -444,11 +444,6 @@ module "govwifi-grafana" {
 
   administrator-IPs = var.administrator-IPs
 
-  google-client-id        = var.google-client-id
-  google-client-secret    = var.google-client-secret
-  grafana-admin           = var.grafana-admin
-  grafana-server-root-url = var.grafana-server-root-url
-
   prometheus-IPs = concat(
     split(",", "${var.prometheus-IP-london}/32"),
     split(",", "${var.prometheus-IP-ireland}/32")

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -229,7 +229,6 @@ module "govwifi-admin" {
   ec2-sg-list = []
 
   admin-db-user     = var.admin-db-username
-  admin-db-password = var.admin-db-password
 
   db-instance-count        = 1
   db-instance-type         = "db.t2.medium"

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -217,7 +217,6 @@ module "govwifi-admin" {
 
   admin-docker-image      = format("%s/admin:staging", local.docker_image_path)
   rack-env                = "staging"
-  secret-key-base         = var.admin-secret-key-base
   ecr-repository-count    = 1
   ecs-instance-profile-id = module.backend.ecs-instance-profile-id
   ecs-service-role        = module.backend.ecs-service-role

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -142,31 +142,6 @@ variable "zendesk-api-token" {
   description = "Token for authenticating with Zendesk API"
 }
 
-variable "hc-key" {
-  type        = string
-  description = "Health check process shared secret"
-}
-
-variable "hc-ssid" {
-  type        = string
-  description = "Healt check simulated SSID"
-}
-
-variable "hc-identity" {
-  type        = string
-  description = "Healt check identity"
-}
-
-variable "hc-password" {
-  type        = string
-  description = "Health check password"
-}
-
-variable "shared-key" {
-  type        = string
-  description = "A random key to be shared between the frontend and backend to retrieve initial client setup."
-}
-
 variable "notify-api-key" {
   type        = string
   description = "API key used to authenticate with GOV.UK Notify"

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -112,11 +112,6 @@ variable "zendesk-api-user" {
   description = "Username for authenticating with Zendesk API"
 }
 
-variable "zendesk-api-token" {
-  type        = string
-  description = "Token for authenticating with Zendesk API"
-}
-
 variable "aws-account-id" {
   type        = string
   description = "The ID of the AWS tenancy."

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -117,11 +117,6 @@ variable "zendesk-api-token" {
   description = "Token for authenticating with Zendesk API"
 }
 
-variable "notify-api-key" {
-  type        = string
-  description = "API key used to authenticate with GOV.UK Notify"
-}
-
 variable "aws-account-id" {
   type        = string
   description = "The ID of the AWS tenancy."

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -122,11 +122,6 @@ variable "aws-secondary-account-id" {
   description = "The ID the Secondary Staging AWS Account."
 }
 
-variable "admin-secret-key-base" {
-  type        = string
-  description = "Rails secret key base for the Admin platform"
-}
-
 variable "docker-image-path" {
   type        = string
   description = "ARN used to identify the common path element used for the docker API image repositories."

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -107,11 +107,6 @@ variable "admin-db-username" {
   description = "Database main username for govwifi-admin"
 }
 
-variable "admin-db-password" {
-  type        = string
-  description = "Database main password for govwifi-admin"
-}
-
 variable "zendesk-api-user" {
   type        = string
   description = "Username for authenticating with Zendesk API"

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -148,11 +148,6 @@ variable "london-api-base-url" {
   default     = "https://api-elb.london.staging.wifi.service.gov.uk:8443"
 }
 
-variable "device-wifi-docker-image-path" {
-  type        = string
-  description = "ARN used to identify the common path element used for the docker image repositories."
-}
-
 variable "govnotify-bearer-token" {
   type = string
 }

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -112,26 +112,6 @@ variable "zendesk-api-user" {
   description = "Username for authenticating with Zendesk API"
 }
 
-variable "aws-account-id" {
-  type        = string
-  description = "The ID of the AWS tenancy."
-}
-
-variable "aws-secondary-account-id" {
-  type        = string
-  description = "The ID the Secondary Staging AWS Account."
-}
-
-variable "docker-image-path" {
-  type        = string
-  description = "ARN used to identify the common path element used for the docker API image repositories."
-}
-
-variable "route53-zone-id" {
-  type        = string
-  description = "Zone ID used by the Route53 DNS service."
-}
-
 variable "london-radius-ip-addresses" {
   type        = list(string)
   description = "Frontend RADIUS server IP addresses - London"

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -151,15 +151,7 @@ variable "backend-subnet-IPs-list" {
   description = "Unused in this configuration"
 }
 
-variable "metrics-aws-secret-access-key" {
-  description = "Unused in this configuration"
-}
-
 variable "administrator-IPs-list" {
-  description = "Unused in this configuration"
-}
-
-variable "metrics-aws-access-key" {
   description = "Unused in this configuration"
 }
 

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -100,16 +100,6 @@ variable "db-user" {
   description = "Database username"
 }
 
-variable "user-db-password" {
-  type        = string
-  description = "User details database main password"
-}
-
-variable "user-db-username" {
-  type        = string
-  description = "Users database username"
-}
-
 variable "user-db-hostname" {
   type        = string
   description = "User details database hostname"

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -135,18 +135,6 @@ variable "prometheus-IP-ireland" {
 variable "grafana-IP" {
 }
 
-variable "grafana-admin" {
-}
-
-variable "google-client-secret" {
-}
-
-variable "google-client-id" {
-}
-
-variable "grafana-server-root-url" {
-}
-
 variable "backend-subnet-IPs-list" {
   description = "Unused in this configuration"
 }

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -156,10 +156,6 @@ variable "google-client-id" {
 variable "grafana-server-root-url" {
 }
 
-variable "allowed-sites-api-elb-ssl-cert-arn" {
-  description = "Unused in this configuration"
-}
-
 variable "backend-subnet-IPs-list" {
   description = "Unused in this configuration"
 }

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -73,11 +73,6 @@ variable "public-google-api-key" {
   default = "AIzaSyCz1cPYKamsA_ZJCygL9EY0Zq6stkazTco"
 }
 
-variable "otp-secret-encryption-key" {
-  type        = string
-  description = "Encryption key used to verify OTP authentication codes"
-}
-
 variable "user-signup-sentry-dsn" {
   type = string
 }

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -128,10 +128,6 @@ variable "london-api-base-url" {
   default     = "https://api-elb.london.staging.wifi.service.gov.uk:8443"
 }
 
-variable "govnotify-bearer-token" {
-  type = string
-}
-
 variable "notification-email" {
 }
 

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -147,11 +147,6 @@ variable "aws-parent-account-id" {
   description = "Unused in this configuration"
 }
 
-variable "volumetrics-elasticsearch-endpoint" {
-  type        = string
-  description = "URL for the ElasticSearch instance endpoint"
-}
-
 variable "use_env_prefix" {
   default     = true
   type        = bool

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -143,10 +143,6 @@ variable "administrator-IPs-list" {
   description = "Unused in this configuration"
 }
 
-variable "aws-parent-account-id" {
-  description = "Unused in this configuration"
-}
-
 variable "use_env_prefix" {
   default     = true
   type        = bool

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -90,16 +90,6 @@ variable "admin-sentry-dsn" {
   type = string
 }
 
-variable "db-password" {
-  type        = string
-  description = "Database main password"
-}
-
-variable "db-user" {
-  type        = string
-  description = "Database username"
-}
-
 variable "user-db-hostname" {
   type        = string
   description = "User details database hostname"

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -114,8 +114,6 @@ module "backend" {
   db-monitoring-interval = 60
 
   # Passed to application
-  db-user               = ""
-  db-password           = ""
   user-db-hostname      = ""
   user-db-instance-type = ""
   user-db-storage-gb    = 0
@@ -262,8 +260,6 @@ module "api" {
 
   background-jobs-enabled = 0
 
-  db-user     = ""
-  db-password = ""
   db-hostname = ""
 
   user-db-hostname = ""
@@ -277,7 +273,6 @@ module "api" {
   safe-restart-sentry-dsn            = ""
   user-signup-sentry-dsn             = ""
   logging-sentry-dsn                 = ""
-  shared-key                         = ""
   subnet-ids                         = module.backend.backend-subnet-ids
   ecs-instance-profile-id            = module.backend.ecs-instance-profile-id
   ecs-service-role                   = module.backend.ecs-service-role

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -266,17 +266,17 @@ module "api" {
   user-rr-hostname = var.user-rr-hostname
 
   # There is no read replica for the staging database
-  db-read-replica-hostname           = ""
-  rack-env                           = "staging"
-  radius-server-ips                  = split(",", var.frontend-radius-IPs)
-  authentication-sentry-dsn          = var.auth-sentry-dsn
-  safe-restart-sentry-dsn            = ""
-  user-signup-sentry-dsn             = ""
-  logging-sentry-dsn                 = ""
-  subnet-ids                         = module.backend.backend-subnet-ids
-  ecs-instance-profile-id            = module.backend.ecs-instance-profile-id
-  ecs-service-role                   = module.backend.ecs-service-role
-  admin-bucket-name                  = ""
+  db-read-replica-hostname  = ""
+  rack-env                  = "staging"
+  radius-server-ips         = split(",", var.frontend-radius-IPs)
+  authentication-sentry-dsn = var.auth-sentry-dsn
+  safe-restart-sentry-dsn   = ""
+  user-signup-sentry-dsn    = ""
+  logging-sentry-dsn        = ""
+  subnet-ids                = module.backend.backend-subnet-ids
+  ecs-instance-profile-id   = module.backend.ecs-instance-profile-id
+  ecs-service-role          = module.backend.ecs-service-role
+  admin-bucket-name         = ""
 
   elb-sg-list = []
 

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -93,7 +93,6 @@ module "backend" {
   db-maintenance-window    = "sat:00:42-sat:01:12"
   db-backup-window         = "03:42-04:42"
   db-backup-retention-days = 1
-  rds-kms-key-id           = var.rds-kms-key-id
 
   db-instance-count        = 0
   session-db-instance-type = ""

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -117,8 +117,6 @@ module "backend" {
   # Passed to application
   db-user               = ""
   db-password           = ""
-  user-db-username      = var.user-db-username
-  user-db-password      = var.user-db-password
   user-db-hostname      = ""
   user-db-instance-type = ""
   user-db-storage-gb    = 0
@@ -269,9 +267,7 @@ module "api" {
   db-password = ""
   db-hostname = ""
 
-  user-db-username = var.user-db-username
   user-db-hostname = ""
-  user-db-password = var.user-db-password
   user-rr-hostname = var.user-rr-hostname
 
   # There is no read replica for the staging database

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -206,14 +206,6 @@ module "frontend" {
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.dublin-api-base-url
 
-  shared-key = var.shared-key
-
-  # A site with this radkey must exist in the database for health checks to work
-  healthcheck-radius-key = var.hc-key
-  healthcheck-ssid       = var.hc-ssid
-  healthcheck-identity   = var.hc-identity
-  healthcheck-password   = var.hc-password
-
   route53-critical-notifications-arn = module.route53-notifications.topic-arn
   devops-notifications-arn           = module.notifications.topic-arn
 

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -270,18 +270,18 @@ module "api" {
   user-rr-hostname = var.user-rr-hostname
 
   # There is no read replica for the staging database
-  db-read-replica-hostname  = ""
-  rack-env                  = "staging"
-  radius-server-ips         = split(",", var.frontend-radius-IPs)
-  authentication-sentry-dsn = var.auth-sentry-dsn
-  safe-restart-sentry-dsn   = ""
-  user-signup-sentry-dsn    = ""
-  logging-sentry-dsn        = ""
-  shared-key                = ""
-  subnet-ids                = module.backend.backend-subnet-ids
-  ecs-instance-profile-id   = module.backend.ecs-instance-profile-id
-  ecs-service-role          = module.backend.ecs-service-role
-  admin-bucket-name         = ""
+  db-read-replica-hostname           = ""
+  rack-env                           = "staging"
+  radius-server-ips                  = split(",", var.frontend-radius-IPs)
+  authentication-sentry-dsn          = var.auth-sentry-dsn
+  safe-restart-sentry-dsn            = ""
+  user-signup-sentry-dsn             = ""
+  logging-sentry-dsn                 = ""
+  shared-key                         = ""
+  subnet-ids                         = module.backend.backend-subnet-ids
+  ecs-instance-profile-id            = module.backend.ecs-instance-profile-id
+  ecs-service-role                   = module.backend.ecs-service-role
+  admin-bucket-name                  = ""
 
   elb-sg-list = []
 

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -79,16 +79,6 @@ variable "user-rr-hostname" {
   default     = "users-rr.dublin.staging.wifi.service.gov.uk"
 }
 
-variable "user-db-password" {
-  type        = string
-  description = "User details database main password"
-}
-
-variable "user-db-username" {
-  type        = string
-  description = "Users database username"
-}
-
 variable "rds-kms-key-id" {
   type = string
 }

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -61,11 +61,6 @@ variable "ami" {
 
 # Secrets
 
-variable "db-password" {
-  type        = string
-  description = "Database main password"
-}
-
 variable "aws-account-id" {
   type        = string
   description = "The ID of the AWS tenancy."

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -66,31 +66,6 @@ variable "db-password" {
   description = "Database main password"
 }
 
-variable "hc-key" {
-  type        = string
-  description = "Health check process shared secret"
-}
-
-variable "hc-ssid" {
-  type        = string
-  description = "Healt check simulated SSID"
-}
-
-variable "hc-identity" {
-  type        = string
-  description = "Healt check identity"
-}
-
-variable "hc-password" {
-  type        = string
-  description = "Healt check password"
-}
-
-variable "shared-key" {
-  type        = string
-  description = "A random key to be shared between the fronend and backend to retrieve initial client setup."
-}
-
 variable "aws-account-id" {
   type        = string
   description = "The ID of the AWS tenancy."

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -79,10 +79,6 @@ variable "user-rr-hostname" {
   default     = "users-rr.dublin.staging.wifi.service.gov.uk"
 }
 
-variable "rds-kms-key-id" {
-  type = string
-}
-
 variable "auth-sentry-dsn" {
   type = string
 }

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -61,16 +61,6 @@ variable "ami" {
 
 # Secrets
 
-variable "docker-image-path" {
-  type        = string
-  description = "ARN used to identify the common path element used for the docker image repositories."
-}
-
-variable "route53-zone-id" {
-  type        = string
-  description = "Zone ID used by the Route53 DNS service."
-}
-
 variable "london-api-base-url" {
   type        = string
   description = "Base URL for authentication, user signup and logging APIs"

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -61,11 +61,6 @@ variable "ami" {
 
 # Secrets
 
-variable "aws-account-id" {
-  type        = string
-  description = "The ID of the AWS tenancy."
-}
-
 variable "aws-secondary-account-id" {
   type        = string
   description = "The ID the Secondary Staging AWS Account."

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -61,11 +61,6 @@ variable "ami" {
 
 # Secrets
 
-variable "aws-secondary-account-id" {
-  type        = string
-  description = "The ID the Secondary Staging AWS Account."
-}
-
 variable "docker-image-path" {
   type        = string
   description = "ARN used to identify the common path element used for the docker image repositories."

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -117,10 +117,6 @@ variable "elb-public-IPs" {
   description = "Unused in this configuration"
 }
 
-variable "aws-parent-account-id" {
-  description = "Unused in this configuration"
-}
-
 variable "use_env_prefix" {
   default     = true
   type        = bool

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -128,8 +128,6 @@ module "backend" {
   # Passed to application
   db-user               = var.db-user
   db-password           = var.db-password
-  user-db-username      = var.user-db-username
-  user-db-password      = var.user-db-password
   user-db-hostname      = var.user-db-hostname
   user-rr-hostname      = var.user-rr-hostname
   user-db-instance-type = "db.t2.medium"
@@ -265,8 +263,6 @@ module "govwifi-admin" {
   rr-db-host     = "rr.london.wifi.service.gov.uk"
   rr-db-name     = "govwifi_wifi"
 
-  user-db-user     = var.user-db-username
-  user-db-password = var.user-db-password
   user-db-host     = var.user-rr-hostname
   user-db-name     = "govwifi_production_users"
 
@@ -347,9 +343,7 @@ module "api" {
   ecs-instance-profile-id            = module.backend.ecs-instance-profile-id
   ecs-service-role                   = module.backend.ecs-service-role
   user-signup-api-base-url           = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443"
-  user-db-username                   = var.user-db-username
   user-db-hostname                   = var.user-db-hostname
-  user-db-password                   = var.user-db-password
   user-rr-hostname                   = var.user-rr-hostname
   admin-bucket-name                  = "govwifi-production-admin"
   background-jobs-enabled            = 1

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -471,11 +471,6 @@ module "govwifi-grafana" {
 
   administrator-IPs = var.administrator-IPs
 
-  google-client-id        = var.google-client-id
-  google-client-secret    = var.google-client-secret
-  grafana-admin           = var.grafana-admin
-  grafana-server-root-url = var.grafana-server-root-url
-
   prometheus-IPs = concat(
     split(",", "${var.prometheus-IP-london}/32"),
     split(",", "${var.prometheus-IP-ireland}/32")

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -335,7 +335,6 @@ module "api" {
   user-rr-hostname                   = var.user-rr-hostname
   admin-bucket-name                  = "govwifi-production-admin"
   background-jobs-enabled            = 1
-  govnotify-bearer-token             = var.govnotify-bearer-token
   user-signup-api-is-public          = 1
 
   elb-sg-list = []

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -277,7 +277,6 @@ module "govwifi-admin" {
 
   zendesk-api-endpoint = "https://govuk.zendesk.com/api/v2/"
   zendesk-api-user     = var.zendesk-api-user
-  zendesk-api-token    = var.zendesk-api-token
 
   bastion-ips = concat(
     split(",", var.bastion-server-IP),

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -126,8 +126,6 @@ module "backend" {
   db-monitoring-interval = 60
 
   # Passed to application
-  db-user               = var.db-user
-  db-password           = var.db-password
   user-db-hostname      = var.user-db-hostname
   user-rr-hostname      = var.user-rr-hostname
   user-db-instance-type = "db.t2.medium"
@@ -258,8 +256,6 @@ module "govwifi-admin" {
   db-backup-window         = "03:42-04:42"
   db-monitoring-interval   = 60
 
-  rr-db-user     = var.db-user
-  rr-db-password = var.db-password
   rr-db-host     = "rr.london.wifi.service.gov.uk"
   rr-db-name     = "govwifi_wifi"
 
@@ -329,8 +325,6 @@ module "api" {
 
   notify-api-key = var.notify-api-key
 
-  db-user                            = var.db-user
-  db-password                        = var.db-password
   db-hostname                        = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   db-read-replica-hostname           = "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   rack-env                           = "production"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -270,8 +270,6 @@ module "govwifi-admin" {
   sentry-dsn                 = var.admin-sentry-dsn
   public-google-api-key      = var.public-google-api-key
 
-  otp-secret-encryption-key = var.otp-secret-encryption-key
-
   logging-api-search-url = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
 
   zendesk-api-endpoint = "https://govuk.zendesk.com/api/v2/"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -243,7 +243,7 @@ module "govwifi-admin" {
 
   db-sg-list = []
 
-  admin-db-user     = var.admin-db-username
+  admin-db-user = var.admin-db-username
 
   db-instance-count        = 1
   db-instance-type         = "db.t2.large"
@@ -254,11 +254,11 @@ module "govwifi-admin" {
   db-backup-window         = "03:42-04:42"
   db-monitoring-interval   = 60
 
-  rr-db-host     = "rr.london.wifi.service.gov.uk"
-  rr-db-name     = "govwifi_wifi"
+  rr-db-host = "rr.london.wifi.service.gov.uk"
+  rr-db-name = "govwifi_wifi"
 
-  user-db-host     = var.user-rr-hostname
-  user-db-name     = "govwifi_production_users"
+  user-db-host = var.user-rr-hostname
+  user-db-name = "govwifi_production_users"
 
   critical-notifications-arn = module.critical-notifications.topic-arn
   capacity-notifications-arn = module.capacity-notifications.topic-arn
@@ -317,23 +317,23 @@ module "api" {
   safe-restart-docker-image     = format("%s/safe-restarter:production", local.docker_image_path)
   backup-rds-to-s3-docker-image = format("%s/database-backup:staging", local.docker_image_path)
 
-  db-hostname                        = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
-  db-read-replica-hostname           = "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
-  rack-env                           = "production"
-  radius-server-ips                  = split(",", var.frontend-radius-IPs)
-  authentication-sentry-dsn          = var.auth-sentry-dsn
-  safe-restart-sentry-dsn            = var.safe-restart-sentry-dsn
-  user-signup-sentry-dsn             = var.user-signup-sentry-dsn
-  logging-sentry-dsn                 = var.logging-sentry-dsn
-  subnet-ids                         = module.backend.backend-subnet-ids
-  ecs-instance-profile-id            = module.backend.ecs-instance-profile-id
-  ecs-service-role                   = module.backend.ecs-service-role
-  user-signup-api-base-url           = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443"
-  user-db-hostname                   = var.user-db-hostname
-  user-rr-hostname                   = var.user-rr-hostname
-  admin-bucket-name                  = "govwifi-production-admin"
-  background-jobs-enabled            = 1
-  user-signup-api-is-public          = 1
+  db-hostname               = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
+  db-read-replica-hostname  = "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
+  rack-env                  = "production"
+  radius-server-ips         = split(",", var.frontend-radius-IPs)
+  authentication-sentry-dsn = var.auth-sentry-dsn
+  safe-restart-sentry-dsn   = var.safe-restart-sentry-dsn
+  user-signup-sentry-dsn    = var.user-signup-sentry-dsn
+  logging-sentry-dsn        = var.logging-sentry-dsn
+  subnet-ids                = module.backend.backend-subnet-ids
+  ecs-instance-profile-id   = module.backend.ecs-instance-profile-id
+  ecs-service-role          = module.backend.ecs-service-role
+  user-signup-api-base-url  = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443"
+  user-db-hostname          = var.user-db-hostname
+  user-rr-hostname          = var.user-rr-hostname
+  admin-bucket-name         = "govwifi-production-admin"
+  background-jobs-enabled   = 1
+  user-signup-api-is-public = 1
 
   elb-sg-list = []
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -189,19 +189,12 @@ module "frontend" {
   users                 = var.users
   frontend-docker-image = format("%s/frontend:production", local.docker_image_path)
   raddb-docker-image    = format("%s/raddb:production", local.docker_image_path)
-  shared-key            = var.shared-key
 
   # admin bucket
   admin-bucket-name = "govwifi-production-admin"
 
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.london-api-base-url
-
-  # A site with this radkey must exist in the database for health checks to work
-  healthcheck-radius-key = var.hc-key
-  healthcheck-ssid       = var.hc-ssid
-  healthcheck-identity   = var.hc-identity
-  healthcheck-password   = var.hc-password
 
   # This must be based on us-east-1, as that's where the alarms go
   route53-critical-notifications-arn = module.route53-critical-notifications.topic-arn
@@ -340,29 +333,28 @@ module "api" {
 
   notify-api-key = var.notify-api-key
 
-  db-user                   = var.db-user
-  db-password               = var.db-password
-  db-hostname               = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
-  db-read-replica-hostname  = "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
-  rack-env                  = "production"
-  radius-server-ips         = split(",", var.frontend-radius-IPs)
-  authentication-sentry-dsn = var.auth-sentry-dsn
-  safe-restart-sentry-dsn   = var.safe-restart-sentry-dsn
-  user-signup-sentry-dsn    = var.user-signup-sentry-dsn
-  logging-sentry-dsn        = var.logging-sentry-dsn
-  shared-key                = var.shared-key
-  subnet-ids                = module.backend.backend-subnet-ids
-  ecs-instance-profile-id   = module.backend.ecs-instance-profile-id
-  ecs-service-role          = module.backend.ecs-service-role
-  user-signup-api-base-url  = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443"
-  user-db-username          = var.user-db-username
-  user-db-hostname          = var.user-db-hostname
-  user-db-password          = var.user-db-password
-  user-rr-hostname          = var.user-rr-hostname
-  admin-bucket-name         = "govwifi-production-admin"
-  background-jobs-enabled   = 1
-  govnotify-bearer-token    = var.govnotify-bearer-token
-  user-signup-api-is-public = 1
+  db-user                            = var.db-user
+  db-password                        = var.db-password
+  db-hostname                        = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
+  db-read-replica-hostname           = "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
+  rack-env                           = "production"
+  radius-server-ips                  = split(",", var.frontend-radius-IPs)
+  authentication-sentry-dsn          = var.auth-sentry-dsn
+  safe-restart-sentry-dsn            = var.safe-restart-sentry-dsn
+  user-signup-sentry-dsn             = var.user-signup-sentry-dsn
+  logging-sentry-dsn                 = var.logging-sentry-dsn
+  subnet-ids                         = module.backend.backend-subnet-ids
+  ecs-instance-profile-id            = module.backend.ecs-instance-profile-id
+  ecs-service-role                   = module.backend.ecs-service-role
+  user-signup-api-base-url           = "https://api-elb.london.${var.Env-Subdomain}.service.gov.uk:8443"
+  user-db-username                   = var.user-db-username
+  user-db-hostname                   = var.user-db-hostname
+  user-db-password                   = var.user-db-password
+  user-rr-hostname                   = var.user-rr-hostname
+  admin-bucket-name                  = "govwifi-production-admin"
+  background-jobs-enabled            = 1
+  govnotify-bearer-token             = var.govnotify-bearer-token
+  user-signup-api-is-public          = 1
 
   elb-sg-list = []
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -266,7 +266,6 @@ module "govwifi-admin" {
 
   rds-monitoring-role = module.backend.rds-monitoring-role
 
-  notify-api-key             = var.notify-api-key
   london-radius-ip-addresses = var.london-radius-ip-addresses
   dublin-radius-ip-addresses = var.dublin-radius-ip-addresses
   sentry-dsn                 = var.admin-sentry-dsn
@@ -321,8 +320,6 @@ module "api" {
   logging-docker-image          = format("%s/logging-api:production", local.docker_image_path)
   safe-restart-docker-image     = format("%s/safe-restarter:production", local.docker_image_path)
   backup-rds-to-s3-docker-image = format("%s/database-backup:staging", local.docker_image_path)
-
-  notify-api-key = var.notify-api-key
 
   db-hostname                        = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   db-read-replica-hostname           = "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -245,7 +245,6 @@ module "govwifi-admin" {
   db-sg-list = []
 
   admin-db-user     = var.admin-db-username
-  admin-db-password = var.admin-db-password
 
   db-instance-count        = 1
   db-instance-type         = "db.t2.large"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -232,7 +232,6 @@ module "govwifi-admin" {
 
   admin-docker-image      = format("%s/admin:production", local.docker_image_path)
   rack-env                = "production"
-  secret-key-base         = var.admin-secret-key-base
   ecs-instance-profile-id = module.backend.ecs-instance-profile-id
   ecs-service-role        = module.backend.ecs-service-role
 

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -142,31 +142,6 @@ variable "zendesk-api-token" {
   description = "Token for authenticating with Zendesk API"
 }
 
-variable "hc-key" {
-  type        = string
-  description = "Health check process shared secret"
-}
-
-variable "hc-ssid" {
-  type        = string
-  description = "Healt check simulated SSID"
-}
-
-variable "hc-identity" {
-  type        = string
-  description = "Healt check identity"
-}
-
-variable "hc-password" {
-  type        = string
-  description = "Healt check password"
-}
-
-variable "shared-key" {
-  type        = string
-  description = "A random key to be shared between the fronend and backend to retrieve initial client setup."
-}
-
 variable "notify-api-key" {
   type        = string
   description = "API key used to authenticate with GOV.UK Notify"

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -117,11 +117,6 @@ variable "zendesk-api-token" {
   description = "Token for authenticating with Zendesk API"
 }
 
-variable "notify-api-key" {
-  type        = string
-  description = "API key used to authenticate with GOV.UK Notify"
-}
-
 variable "aws-account-id" {
   type        = string
   description = "The ID of the AWS tenancy."

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -164,18 +164,6 @@ variable "administrator-IPs-list" {
   description = "Administrator allowed IPs (VPN IPs)"
 }
 
-variable "grafana-admin" {
-}
-
-variable "google-client-secret" {
-}
-
-variable "google-client-id" {
-}
-
-variable "grafana-server-root-url" {
-}
-
 variable "gds-slack-channel-id" {
 }
 

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -112,11 +112,6 @@ variable "zendesk-api-user" {
   description = "User for authenticating with Zendesk API"
 }
 
-variable "zendesk-api-token" {
-  type        = string
-  description = "Token for authenticating with Zendesk API"
-}
-
 variable "aws-account-id" {
   type        = string
   description = "The ID of the AWS tenancy."

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -107,11 +107,6 @@ variable "admin-db-username" {
   description = "Database main username for govwifi-admin"
 }
 
-variable "admin-db-password" {
-  type        = string
-  description = "Database main password for govwifi-admin"
-}
-
 variable "zendesk-api-user" {
   type        = string
   description = "User for authenticating with Zendesk API"

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -167,22 +167,6 @@ variable "administrator-IPs-list" {
 variable "gds-slack-channel-id" {
 }
 
-variable "metrics-aws-access-key" {
-  description = "Unused in this configuration"
-}
-
-variable "metrics-aws-secret-access-key" {
-  description = "Unused in this configuration"
-}
-
-variable "aws-parent-account-id" {
-  description = "Unused in this configuration"
-}
-
-variable "allowed-sites-api-elb-ssl-cert-arn" {
-  description = "Unused in this configuration"
-}
-
 variable "backend-subnet-IPs-list" {
   description = "Unused in this configuration"
 }

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -90,16 +90,6 @@ variable "admin-sentry-dsn" {
   type = string
 }
 
-variable "db-user" {
-  type        = string
-  description = "Database username"
-}
-
-variable "db-password" {
-  type        = string
-  description = "Database main password"
-}
-
 variable "user-db-hostname" {
   type        = string
   description = "User details database hostname"

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -73,11 +73,6 @@ variable "public-google-api-key" {
   default = "AIzaSyCz1cPYKamsA_ZJCygL9EY0Zq6stkazTco"
 }
 
-variable "otp-secret-encryption-key" {
-  type        = string
-  description = "Encryption key used to verify OTP authentication codes"
-}
-
 variable "user-signup-sentry-dsn" {
   type = string
 }

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -143,10 +143,6 @@ variable "london-api-base-url" {
   default     = "https://api-elb.london.wifi.service.gov.uk:8443"
 }
 
-variable "govnotify-bearer-token" {
-  type = string
-}
-
 variable "critical-notification-email" {
   type = string
 }

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -100,16 +100,6 @@ variable "db-password" {
   description = "Database main password"
 }
 
-variable "user-db-username" {
-  type        = string
-  description = "User details database username"
-}
-
-variable "user-db-password" {
-  type        = string
-  description = "User details database password"
-}
-
 variable "user-db-hostname" {
   type        = string
   description = "User details database hostname"

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -117,11 +117,6 @@ variable "aws-account-id" {
   description = "The ID of the AWS tenancy."
 }
 
-variable "admin-secret-key-base" {
-  type        = string
-  description = "Rails secret key base for the Admin platform"
-}
-
 variable "docker-image-path" {
   type        = string
   description = "ARN used to identify the common path element used for the docker image repositories in London."

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -107,21 +107,6 @@ variable "zendesk-api-user" {
   description = "User for authenticating with Zendesk API"
 }
 
-variable "aws-account-id" {
-  type        = string
-  description = "The ID of the AWS tenancy."
-}
-
-variable "docker-image-path" {
-  type        = string
-  description = "ARN used to identify the common path element used for the docker image repositories in London."
-}
-
-variable "route53-zone-id" {
-  type        = string
-  description = "Zone ID used by the Route53 DNS service."
-}
-
 variable "london-radius-ip-addresses" {
   type        = list(string)
   description = "Frontend RADIUS server IP addresses - London"

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -110,7 +110,6 @@ module "backend" {
 
   critical-notifications-arn = module.critical-notifications.topic-arn
   capacity-notifications-arn = module.capacity-notifications.topic-arn
-  rds-kms-key-id             = var.rds-kms-key-id
   user-replica-source-db     = "arn:aws:rds:eu-west-2:${local.aws_account_id}:db:wifi-production-user-db"
 
   # Seconds. Set to zero to disable monitoring

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -119,8 +119,6 @@ module "backend" {
   # Passed to application
   db-user               = var.db-user
   db-password           = var.db-password
-  user-db-password      = var.user-db-password
-  user-db-username      = var.user-db-username
   user-db-instance-type = "db.t2.medium"
   user-db-hostname      = var.user-db-hostname
   user-db-storage-gb    = 20
@@ -297,9 +295,7 @@ module "api" {
   ecs-instance-profile-id   = module.backend.ecs-instance-profile-id
   ecs-service-role          = module.backend.ecs-service-role
   user-signup-api-base-url  = ""
-  user-db-username          = var.user-db-username
   user-db-hostname          = var.user-db-hostname
-  user-db-password          = var.user-db-password
   user-rr-hostname          = var.user-rr-hostname
   background-jobs-enabled   = 0
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -218,19 +218,11 @@ module "frontend" {
   frontend-docker-image = format("%s/frontend:production", local.docker_image_path)
   raddb-docker-image    = format("%s/raddb:production", local.docker_image_path)
 
-  shared-key = var.shared-key
-
   # admin bucket
   admin-bucket-name = "govwifi-production-admin"
 
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.dublin-api-base-url
-
-  # A site with this radkey must exist in the database for health checks to work
-  healthcheck-radius-key = var.hc-key
-  healthcheck-ssid       = var.hc-ssid
-  healthcheck-identity   = var.hc-identity
-  healthcheck-password   = var.hc-password
 
   route53-critical-notifications-arn = module.route53-critical-notifications.topic-arn
   devops-notifications-arn           = module.devops-notifications.topic-arn
@@ -298,7 +290,6 @@ module "api" {
   radius-server-ips         = split(",", var.frontend-radius-IPs)
   authentication-sentry-dsn = var.auth-sentry-dsn
   safe-restart-sentry-dsn   = var.safe-restart-sentry-dsn
-  shared-key                = var.shared-key
   user-signup-docker-image  = ""
   logging-sentry-dsn        = ""
   user-signup-sentry-dsn    = ""

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -117,8 +117,6 @@ module "backend" {
   db-monitoring-interval = 60
 
   # Passed to application
-  db-user               = var.db-user
-  db-password           = var.db-password
   user-db-instance-type = "db.t2.medium"
   user-db-hostname      = var.user-db-hostname
   user-db-storage-gb    = 20
@@ -280,8 +278,6 @@ module "api" {
   safe-restart-docker-image     = format("%s/safe-restarter:production", local.docker_image_path)
   backup-rds-to-s3-docker-image = ""
 
-  db-user                   = var.db-user
-  db-password               = var.db-password
   db-hostname               = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   db-read-replica-hostname  = "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   rack-env                  = "production"

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -60,26 +60,6 @@ variable "ami" {
 
 # Secrets
 
-variable "aws-account-id" {
-  type        = string
-  description = "The ID of the AWS tenancy."
-}
-
-variable "aws-parent-account-id" {
-  type        = string
-  description = "The ID of the AWS parent account."
-}
-
-variable "docker-image-path" {
-  type        = string
-  description = "ARN used to identify the common path element used for the docker image repositories."
-}
-
-variable "route53-zone-id" {
-  type        = string
-  description = "Zone ID used by the Route53 DNS service."
-}
-
 variable "user-signup-sentry-dsn" {
   type    = string
   default = ""

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -69,31 +69,6 @@ variable "db-password" {
   description = "Database main password"
 }
 
-variable "hc-key" {
-  type        = string
-  description = "Health check process shared secret"
-}
-
-variable "hc-ssid" {
-  type        = string
-  description = "Healt check simulated SSID"
-}
-
-variable "hc-identity" {
-  type        = string
-  description = "Healt check identity"
-}
-
-variable "hc-password" {
-  type        = string
-  description = "Healt check password"
-}
-
-variable "shared-key" {
-  type        = string
-  description = "A random key to be shared between the fronend and backend to retrieve initial client setup."
-}
-
 variable "aws-account-id" {
   type        = string
   description = "The ID of the AWS tenancy."

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -59,15 +59,6 @@ variable "ami" {
 }
 
 # Secrets
-variable "db-user" {
-  type        = string
-  description = "Database username"
-}
-
-variable "db-password" {
-  type        = string
-  description = "Database main password"
-}
 
 variable "aws-account-id" {
   type        = string

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -129,16 +129,6 @@ variable "dublin-api-base-url" {
   default     = "https://api-elb.dublin.wifi.service.gov.uk:8443"
 }
 
-variable "user-db-username" {
-  type        = string
-  description = "User details database username"
-}
-
-variable "user-db-password" {
-  type        = string
-  description = "User details database password"
-}
-
 variable "user-db-hostname" {
   type        = string
   description = "User details database hostname"

--- a/scripts/unencrypt-secrets.sh
+++ b/scripts/unencrypt-secrets.sh
@@ -1,27 +1,57 @@
 #!/bin/bash
 set -euo pipefail
 
+# Command passed to the script from the Makefile (unencrypt-secrets or delete-secrets).
+# It will be either "unencrypt" or "delete"
 command="$1"
+
+# Find all file paths of .gpg files in the .private/passwords/secrets-to-copy directory
 files=$(find .private/passwords/secrets-to-copy -type f -name '*.gpg')
+
+# Iterate over the all the .gpg files in .private/passwords/secrets-to-copy
 for FILE in $files; do
+
+  # Remove the prepending file path (.private/passwords/secrets-to-copy/) from the file name
+  # Value will be e.g, govwifi/staging/secrets.auto.tfvars.gpg
   UNENCRYPTED_FILE_GPG=${FILE#.private/passwords/secrets-to-copy/}
+
+  # Remove the .gpg extension from the filename
+  # Value will be e.g., govwifi/staging/secrets.auto.tfvars
   UNENCRYPTED_FILE=${UNENCRYPTED_FILE_GPG%.gpg}
+
   echo $UNENCRYPTED_FILE
+
+  # If the command is "unencrypt"
   if [ "$command" == "unencrypt" ]; then
+  # Copy the contents of UNENCRYPTED_FILE into a new file with the same name but within the root project directory
   PASSWORD_STORE_DIR=.private/passwords pass "secrets-to-copy/${UNENCRYPTED_FILE}" > $UNENCRYPTED_FILE
+  # If the command is "delete"
   elif [ "$command" == "delete" ]; then
-    rm $UNENCRYPTED_FILE 
+    # Delete the UNENCRYPTED_FILE from the root project directory
+    rm $UNENCRYPTED_FILE
   fi
+
 done
 
+# If the filepath .private/non-encrypted/secrets-to-copy exists
 if [[ -d .private/non-encrypted/secrets-to-copy ]]; then
+
+  # Find all file paths of .gpg files in the .private/non-encrypted/secrets-to-copy directory
   files="$(find .private/non-encrypted/secrets-to-copy -type f)"
+
+  # For each file in the list of files
   for FILE in $files; do
+    # Remove the prepending file path (.private/non-encrypted/secrets-to-copy/) from the file name
+    # Value will be e.g, govwifi/staging/variables.auto.tfvars.gpg
     target_file="${FILE#.private/non-encrypted/secrets-to-copy/}"
     if [ "$command" == "unencrypt" ]; then
+      # Copy the variable.auto.tfvars file in the .private/non-encrypted/secrets-to-copy/* directories
+      # to the govwifi/<staging | staging-london | wifi | wifi-london> directories.
       cp "${FILE}" "${target_file}"
     elif [ "$command" == "delete" ]; then
+      # Delete the variable.auto.tfvars file in the .private/non-encrypted/secrets-to-copy/* directories
       rm "${target_file}"
     fi
   done
+
 fi

--- a/scripts/unencrypt-secrets.sh
+++ b/scripts/unencrypt-secrets.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-# This script is responsible for pulling in the encrypted and unencrypted values from the private `govwifi-build` repository.
+# This script pulls in the encrypted and unencrypted values from the private `govwifi-build` repository.
 
 # Command passed to the script from the Makefile (unencrypt-secrets or delete-secrets).
 # It will be either "unencrypt" or "delete"
 command="$1"
 
 # Find all file paths of .gpg files in the .private/passwords/secrets-to-copy directory
-files=$(find .private/passwords/secrets-to-copy -type f -name '*.gpg')
+# Exclude any filename secrets*.gpg since the values have been migrated to Secrets Manager
+files=$(find .private/passwords/secrets-to-copy -type f -name '*.gpg' ! -name '*secrets*.gpg')
 
 # Iterate over the all the .gpg files in .private/passwords/secrets-to-copy
 for FILE in $files; do
@@ -23,11 +24,9 @@ for FILE in $files; do
 
   echo $UNENCRYPTED_FILE
 
-  # If the command is "unencrypt"
   if [ "$command" == "unencrypt" ]; then
-  # Copy the contents of UNENCRYPTED_FILE into a new file with the same name but within the root project directory
-  PASSWORD_STORE_DIR=.private/passwords pass "secrets-to-copy/${UNENCRYPTED_FILE}" > $UNENCRYPTED_FILE
-  # If the command is "delete"
+    # Copy the contents of UNENCRYPTED_FILE into a new file with the same name but within the root project directory
+    PASSWORD_STORE_DIR=.private/passwords pass "secrets-to-copy/${UNENCRYPTED_FILE}" > $UNENCRYPTED_FILE
   elif [ "$command" == "delete" ]; then
     # Delete the UNENCRYPTED_FILE from the root project directory
     rm $UNENCRYPTED_FILE

--- a/scripts/unencrypt-secrets.sh
+++ b/scripts/unencrypt-secrets.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+# This script is responsible for pulling in the encrypted and unencrypted values from the private `govwifi-build` repository.
+
 # Command passed to the script from the Makefile (unencrypt-secrets or delete-secrets).
 # It will be either "unencrypt" or "delete"
 command="$1"


### PR DESCRIPTION
### What

Update the `unecrypt-secrets.sh` script to ignore any file named `secrets.auto.tfvars` in [govwifi-build](https://github.com/alphagov/govwifi-build/tree/master/passwords/secrets-to-copy/govwifi). These files are no longer relevant because the values are now stored in Secrets Manager. 

I have also added comments to the script because it was previously difficult to decipher. 

Remove references to the unused values from all `variables.tf` and `main.tf` files. 

Running `terraform plan` in each environment results in the following message:

```
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```

### Why

We have migrated to using Secrets Manager and need to update the relevant scripts to reflect this migration, as well as removing any stale code.