### PR TITLE
Fix production prometheus instance logging

### DIFF
--- a/govwifi-prometheus/iam-roles.tf
+++ b/govwifi-prometheus/iam-roles.tf
@@ -1,10 +1,10 @@
 resource "aws_iam_instance_profile" "prometheus-instance-profile" {
-  name       = "${var.aws-region}-${var.Env-Name}-prometheus-instance-profile"
-  role       = aws_iam_role.prometheus-instance-role.name
+  name = "${var.aws-region}-${var.Env-Name}-prometheus-instance-profile"
+  role = aws_iam_role.prometheus-instance-role.name
 }
 
 resource "aws_iam_role" "prometheus-instance-role" {
-  name  = "${var.aws-region}-${var.Env-Name}-prometheus-instance-role"
+  name = "${var.aws-region}-${var.Env-Name}-prometheus-instance-role"
   path = "/"
 
   assume_role_policy = <<EOF
@@ -26,8 +26,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "prometheus-instance-policy" {
-  name       = "${var.aws-region}-${var.Env-Name}-prometheus-instance-policy"
-  role       = aws_iam_role.prometheus-instance-role.id
+  name = "${var.aws-region}-${var.Env-Name}-prometheus-instance-policy"
+  role = aws_iam_role.prometheus-instance-role.id
 
   policy = <<EOF
 {

--- a/govwifi-prometheus/iam-roles.tf
+++ b/govwifi-prometheus/iam-roles.tf
@@ -1,13 +1,9 @@
 resource "aws_iam_instance_profile" "prometheus-instance-profile" {
-  // count      = var.enable-bastion
   name       = "${var.aws-region}-${var.Env-Name}-prometheus-instance-profile"
   role       = aws_iam_role.prometheus-instance-role.name
-  // depends_on = [aws_iam_role.prometheus-instance-role]
 }
 
-
 resource "aws_iam_role" "prometheus-instance-role" {
-  // count = var.enable-prometheus
   name  = "${var.aws-region}-${var.Env-Name}-prometheus-instance-role"
   path = "/"
 
@@ -30,10 +26,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "prometheus-instance-policy" {
-  // count      = min(1 - var.save-pp-data, var.enable-bastion)  ???
   name       = "${var.aws-region}-${var.Env-Name}-prometheus-instance-policy"
   role       = aws_iam_role.prometheus-instance-role.id
-  // depends_on = [aws_iam_role.prometheus-instance-role]
 
   policy = <<EOF
 {

--- a/govwifi-prometheus/iam-roles.tf
+++ b/govwifi-prometheus/iam-roles.tf
@@ -1,0 +1,59 @@
+resource "aws_iam_instance_profile" "prometheus-instance-profile" {
+  // count      = var.enable-bastion
+  name       = "${var.aws-region}-${var.Env-Name}-prometheus-instance-profile"
+  role       = aws_iam_role.prometheus-instance-role.name
+  // depends_on = [aws_iam_role.prometheus-instance-role]
+}
+
+
+resource "aws_iam_role" "prometheus-instance-role" {
+  // count = var.enable-prometheus
+  name  = "${var.aws-region}-${var.Env-Name}-prometheus-instance-role"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy" "prometheus-instance-policy" {
+  // count      = min(1 - var.save-pp-data, var.enable-bastion)  ???
+  name       = "${var.aws-region}-${var.Env-Name}-prometheus-instance-policy"
+  role       = aws_iam_role.prometheus-instance-role.id
+  // depends_on = [aws_iam_role.prometheus-instance-role]
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ]
+    }
+  ]
+}
+EOF
+
+}
+

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -63,6 +63,8 @@ resource "aws_instance" "prometheus_instance" {
     aws_security_group.grafana-data-in.id,
   ]
 
+  iam_instance_profile = aws_iam_instance_profile.prometheus-instance-profile.id
+
   tags = {
     Name = "${title(var.Env-Name)} Prometheus-Server"
     Env  = title(var.Env-Name)


### PR DESCRIPTION
### What
* Add an IAM role, policy and instance attachment which will allow the production prometheus instance to create & write logs in Cloudwatch.
* Install awslogs to transport selected logs using the above role.
* awslogs has dependencies: python < 3.5, which requires a manual install / build from user_data.sh because there is no package in the repos for 3.4 / 3.5 or similar.
* python3.5 has many dependancies, this commit installs them in the correct sequence.

### Why
Prometheus instance has not been logging to cloudwatch since April 2021.


Link to Trello card (if applicable): https://trello.com/c/kSE54Yz9/1256-prometheus-server-is-not-logging

### Testing
Terminate the existing instance, log group and IAM role.
Run the terraform of destiny.
Wait 12.5 mins or make tea.
Check everything re-appears.