### PR TITLE
Remove unused RDS KMS key ID

### DIFF
--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -112,10 +112,6 @@ variable "user-rr-hostname" {
   default     = "users-rr.dublin.production.wifi.service.gov.uk"
 }
 
-variable "rds-kms-key-id" {
-  type = string
-}
-
 variable "critical-notification-email" {
   type = string
 }


### PR DESCRIPTION
### What

Remove unused RDS KMS key ID

### Why

This variable was previously refactored out of the codebase and should have been removed from this file.