### PR TITLE
install python3.5 and run-until-success function to fix logging

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -177,8 +177,9 @@ EOF
 
 # Install awslogs
 # Steps required are install pre-reqs for python 3.5.n, install & build python 3.5 cos awslogs script only supports python < 3.5
-# Legacy - instance has this already - The install script requires the issue file to start with the string "Ubuntu"
-# Legacy - default - sudo echo "Ubuntu Linux 20.04 LTS - Authorized uses only. All activity may be monitored and reported. \d \t @ \n" > /etc/issue
+
+PYTHON_MAIN_VERSION=3.5
+PYTHON_VERSION=$PYTHON_MAIN_VERSION.9
 
 function run-until-success() {
   until $*
@@ -188,24 +189,24 @@ function run-until-success() {
   done
 }
 
-# Install python 3.5 prerequisites
+# Install python $PYTHON_VERSION prerequisites
 run-until-success sudo apt-get install --yes build-essential checkinstall
 run-until-success sudo apt-get install --yes libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
 
-# Install python 3.5.n source
+# Install python $PYTHON_VERSION source
 cd /usr/src
-run-until-success sudo wget https://www.python.org/ftp/python/3.5.9/Python-3.5.9.tgz
-sudo tar xzf Python-3.5.9.tgz
+run-until-success sudo wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz
+sudo tar xzf Python-$PYTHON_VERSION.tgz
 
 # Build python
-cd Python-3.5.9/
+cd Python-$PYTHON_VERSION/
 sudo ./configure --enable-optimizations
 sudo make altinstall
 
 # Retrieve and run awslogs install script
 cd /
 run-until-success sudo curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
-sudo python3.5 ./awslogs-agent-setup.py -n -r ${var.aws-region} -c ./initial-awslogs.conf
+sudo python$PYTHON_MAIN_VERSION ./awslogs-agent-setup.py -n -r ${var.aws-region} -c ./initial-awslogs.conf
 
 --==BOUNDARY==--
 DATA

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -179,7 +179,7 @@ EOF
 # Steps required are install pre-reqs for python 3.5.n, install & build python 3.5 cos awslogs script only supports python < 3.5
 
 PYTHON_MAIN_VERSION=3.5
-PYTHON_VERSION=$PYTHON_MAIN_VERSION.9
+PYTHON_VERSION=$PYTHON_MAIN_VERSION.10
 
 function run-until-success() {
   until $*

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -176,13 +176,36 @@ log_stream_name = {instance_id}
 EOF
 
 # Install awslogs
-# The install script requires the issue file to start with the string "Ubuntu"
-sudo echo "Ubuntu Linux 20.04 LTS - Authorized uses only. All activity may be monitored and reported. \d \t @ \n" > /etc/issue
-# Retrieve and run the install script
-curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
-# Try to circumvent pip install error with waiting for 10 seconds.
-sleep 10
-sudo python3 ./awslogs-agent-setup.py -n -r ${var.aws-region} -c ./initial-awslogs.conf
+# Steps required are install pre-reqs for python 3.5.n, install & build python 3.5 cos awslogs script only supports python < 3.5
+# Legacy - instance has this already - The install script requires the issue file to start with the string "Ubuntu"
+# Legacy - default - sudo echo "Ubuntu Linux 20.04 LTS - Authorized uses only. All activity may be monitored and reported. \d \t @ \n" > /etc/issue
+
+function run-until-success() {
+  until $*
+  do
+    logger "Executing $* failed. Sleeping..."
+    sleep 5
+  done
+}
+
+# Install python 3.5 prerequisites
+run-until-success sudo apt-get install --yes build-essential checkinstall
+run-until-success sudo apt-get install --yes libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
+
+# Install python 3.5.n source
+cd /usr/src
+run-until-success sudo wget https://www.python.org/ftp/python/3.5.9/Python-3.5.9.tgz
+sudo tar xzf Python-3.5.9.tgz
+
+# Build python
+cd Python-3.5.9/
+sudo ./configure --enable-optimizations
+sudo make altinstall
+
+# Retrieve and run awslogs install script
+cd /
+run-until-success sudo curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
+sudo python3.5 ./awslogs-agent-setup.py -n -r ${var.aws-region} -c ./initial-awslogs.conf
 
 --==BOUNDARY==--
 DATA


### PR DESCRIPTION
### What
1. Install python3.5

2. Add the function `run-until-success` and implement for python3.5 & awslogs

### Why
Overview
* Instances have not been logging to cloudwatch since April 2021 and logging is a priority on bastion instances

Cause
* The install script for awslogs does not support python3.8
* Note: python 3.8 is the default version installed on these instances.

Python3.5
* awslogs install script only supports python < 3.5
* python3.5 is a manual install / build from user_data.sh because there is no package in the repos for 3.4 / 3.5 or similar.
* python3.5 has many dependancies, this change installs them in the correct sequence.

Function: run-until-success
* This pattern is used in prometheus and grafana modules.
* A decision has been made to replace the 'until : do : done' structure because run-until-success includes logging and can be abstracted (as a piece of tech debt).

### To Test
Terminate the existing instance, log group and IAM role.
Run the terraform of destiny.
Wait 12.5 mins or make tea.
Check everything re-appears.

Link to Trello card (if applicable): https://trello.com/c/7ZkhOWta/1316-apply-prometheus-logging-fix-to-bastion
