### PR TITLE
Remove references to the Performance Platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ govwifi/staging-london/backend.config
 govwifi/staging/backend.config
 govwifi/wifi-london/backend.config
 govwifi/wifi/backend.config
-govwifi/performance-london/backend.config
-govwifi/performance/backend.config
 .terraform
 terraform.tfstate
 terraform.tfstate.*.backup

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,6 @@ staging:
 	$(eval export DEPLOY_ENV=staging)
 	$(eval export REPO=staging)
 	$(eval export AWS_REGION=eu-west-1)
-performance-london:
-	$(eval export DEPLOY_ENV=performance-london)
-	$(eval export REPO=latest)
-	$(eval export AWS_REGION=eu-west-2)
-performance:
-	$(eval export DEPLOY_ENV=performance)
-	$(eval export REPO=latest)
-	$(eval export AWS_REGION=eu-west-1)
 wifi-london:
 	$(eval export DEPLOY_ENV=wifi-london)
 	$(eval export REPO=latest)

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ This repository contains instructions on how to build GovWifi end-to-end - the s
 - [Running terraform](#running-terraform)
 - [Bootstrapping terraform](#bootstrapping-terraform)
 - [Rotating ELB Certificates](#rotating-ELB-certificates)
-- [Performance Testing](#performance-testing)
-  - [Infrastructure](#infrastructure)
-  - [Testing](#testing)
-    - [Caveat](#caveat)
-  - [Testing scripts](#testing-scripts)
-  - [Running the tests](#running-the-tests)
 
 ## Overview
 Our public-facing websites are:

--- a/govwifi-account/iam-roles.tf
+++ b/govwifi-account/iam-roles.tf
@@ -3098,13 +3098,6 @@ resource "aws_iam_role_policy" "London-staging-backend-bastion-instance-role_Lon
       "Resource": [
         "arn:aws:logs:*:*:*"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Resource": "arn:aws:s3:::staging-london-pp-data/*"
     }
   ]
 }
@@ -3169,13 +3162,6 @@ resource "aws_iam_role_policy" "London-wifi-backend-bastion-instance-role_London
       "Resource": [
         "arn:aws:logs:*:*:*"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Resource": "arn:aws:s3:::wifi-london-pp-data/*"
     }
   ]
 }

--- a/govwifi-backend/s3.tf
+++ b/govwifi-backend/s3.tf
@@ -1,22 +1,3 @@
-# Bucket to store previously generated stats in Performance Platform JSON format for safekeeping.
-resource "aws_s3_bucket" "pp-data-bucket" {
-  count         = var.save-pp-data
-  bucket        = "${var.Env-Name}-${lower(var.aws-region-name)}-pp-data"
-  force_destroy = true
-  acl           = "private"
-
-  tags = {
-    Name   = "${title(var.Env-Name)} Performance Platform data backup"
-    Region = title(var.aws-region-name)
-    # Product     = "${var.product-name}"
-    Environment = title(var.Env-Name)
-    Category    = "Statistics data / backup"
-  }
-  versioning {
-    enabled = true
-  }
-}
-
 # Bucket to store MySQL RDS backups
 resource "aws_s3_bucket" "rds-mysql-backup-bucket" {
   count         = var.backup_mysql_rds ? 1 : 0

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -131,15 +131,6 @@ variable "users" {
   type = list(string)
 }
 
-variable "save-pp-data" {
-  description = "Whether or not to save Performance Platform backup data. Value must be 0 or 1."
-  default     = "0"
-}
-
-variable "pp-domain-name" {
-  default = ""
-}
-
 variable "user-replica-source-db" {
   type    = string
   default = ""

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -116,9 +116,6 @@ module "backend" {
   user-db-instance-type = "db.t2.small"
   user-db-storage-gb    = 20
 
-  # Whether or not to save Performance Platform backup data
-  save-pp-data          = 1
-  pp-domain-name        = "www.performance.service.gov.uk"
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
   grafana-IP            = "${var.grafana-IP}/32"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -132,9 +132,6 @@ module "backend" {
   user-db-storage-gb    = 1000
   user-db-replica-count = 1
 
-  # Whether or not to save Performance Platform backup data
-  save-pp-data          = 1
-  pp-domain-name        = "www.performance.service.gov.uk"
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"
   grafana-IP            = "${var.grafana-IP}/32"


### PR DESCRIPTION
### What
All references to the Performance Platform have been removed.

### Why
The Performance Platform has been retired and this is dead code.

Link to Trello card (if applicable): https://trello.com/c/qhxg3z58/1333-zendesk-govwifi-support10041-re-govwifi-update-new-security-certificate
