### PR TITLE
Enable FreeRADIUS verbose logging

### DIFF
--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -64,7 +64,7 @@ variable "enable-detailed-monitoring" {
 }
 
 variable "radiusd-params" {
-  default = "-f"
+  default = "-X"
 }
 
 variable "users" {


### PR DESCRIPTION
### What

**Do not merge until 2 July**

Enabling verbose logging while we rotate the DigiCert certificates. This flag should be disabled after two days.

### Why

This is to have a log of any potential issues users may face, especially a potential drop-off in users authenticating.


[Link to Trello card](https://trello.com/c/dZotS9Mf/800-sub-task-enable-freeradius-debug-logging-for-timeboxed-period).
