### PR TITLE
Create KMS key for secrets CloudTrail logs

### DIFF
--- a/govwifi-account/kms.tf
+++ b/govwifi-account/kms.tf
@@ -1,0 +1,12 @@
+// Only applied  in wifi-london so it can be used govwifi-backend/secrets-manager-alarms.tf
+// We only need one KMS key for the CloudTrail logs
+resource "aws_kms_key" "kms_cloudtrail_logs_manangement_events" {
+  description             = "This key is used to encrypt Secrets Management CloudTrail logs"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+}
+
+resource "aws_kms_alias" "cloudtrail_secrets_management_alias" {
+  name          = "alias/kms-cloudtrail-logs-manangement-events"
+  target_key_id = aws_kms_key.kms_cloudtrail_logs_manangement_events.key_id
+}

--- a/govwifi-admin/new_alarms.tf--
+++ b/govwifi-admin/new_alarms.tf--
@@ -1,3 +1,6 @@
+# These alerts were created in the console and will need to be imported using Terraform.
+# A few will also need descriptions
+
 resource "aws_cloudwatch_metric_alarm" "EAP-Outer-and-inner-identities-are-the-same" {
     alarm_name          = "EAP Outer and inner identities are the same"
     comparison_operator = "GreaterThanOrEqualToThreshold"


### PR DESCRIPTION
### What

Create KMS key for encrypting Secrets Manager CloudTrail logs

Add documentation to `new-alerts.tf--` to clarify the contents are in AWS but not fully integrated into Terraform.

### Why

We're creating CloudWatch alarms which need to read from an encrypted CloudTrail log group and alert on changes in Secrets Manager. This log group needs to be encrypted and therefore needs a KMS key.

For now, we only need a single key for encrypting the logs. 

We will add the configuration for the CloudTrail and CloudWatch alarms in a subsequent PR.

[Link to Trello card](https://trello.com/c/qspTsoBf/1259-sub-task-add-security-alerting-to-secrets-manager).
