### PR TITLE
Fix EC2 key pair creation race condition

### DIFF
--- a/govwifi-keys/bastion-keys.tf
+++ b/govwifi-keys/bastion-keys.tf
@@ -9,6 +9,7 @@ resource "aws_key_pair" "govwifi-staging-bastion-key" {
 }
 
 resource "aws_key_pair" "govwifi-bastion-key" {
+  count      = 1
   key_name   = "govwifi-bastion-key-20210630"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDY/Q676Tp5CTpKWVksMPztERDdjWOrYFgVckF9IHGI2wC38ckWFiqawsEZBILUyNZgL/lnOtheN1UZtuGmUUkPxgtPw+YD6gMDcebhSX4wh9GM3JjXAIy9+V/WagQ84Pz10yIp+PlyzcQMu+RVRVzWyTYZUdgMsDt0tFdcgMgUc7FkC252CgtSZHpLXhnukG5KG69CoTO+kuak/k3vX5jwWjIgfMGZwIAq+F9XSIMAwylCmmdE5MetKl0Wx4EI/fm8WqSZXj+yeFRv9mQTus906AnNieOgOrgt4D24/JuRU1JTlZ35iNbOKcwlOTDSlTQrm4FA1sCllphhD/RQVYpMp6EV3xape626xwkucCC2gYnakxTZFHUIeWfC5aHGrqMOMtXRfW0xs+D+vzo3MCWepdIebWR5KVhqkbNUKHBG9e8oJbTYUkoyBZjC7LtI4fgB3+blXyFVuQoAzjf+poPzdPBfCC9eiUJrEHoOljO9yMcdkBfyW3c/o8Sd9PgNufc= bastion@govwifi"
 }

--- a/govwifi-keys/bastion-keys.tf
+++ b/govwifi-keys/bastion-keys.tf
@@ -9,7 +9,7 @@ resource "aws_key_pair" "govwifi-staging-bastion-key" {
 }
 
 resource "aws_key_pair" "govwifi-bastion-key" {
-  count      = 1
+  count      = var.create_production_bastion_key
   key_name   = "govwifi-bastion-key-20210630"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDY/Q676Tp5CTpKWVksMPztERDdjWOrYFgVckF9IHGI2wC38ckWFiqawsEZBILUyNZgL/lnOtheN1UZtuGmUUkPxgtPw+YD6gMDcebhSX4wh9GM3JjXAIy9+V/WagQ84Pz10yIp+PlyzcQMu+RVRVzWyTYZUdgMsDt0tFdcgMgUc7FkC252CgtSZHpLXhnukG5KG69CoTO+kuak/k3vX5jwWjIgfMGZwIAq+F9XSIMAwylCmmdE5MetKl0Wx4EI/fm8WqSZXj+yeFRv9mQTus906AnNieOgOrgt4D24/JuRU1JTlZ35iNbOKcwlOTDSlTQrm4FA1sCllphhD/RQVYpMp6EV3xape626xwkucCC2gYnakxTZFHUIeWfC5aHGrqMOMtXRfW0xs+D+vzo3MCWepdIebWR5KVhqkbNUKHBG9e8oJbTYUkoyBZjC7LtI4fgB3+blXyFVuQoAzjf+poPzdPBfCC9eiUJrEHoOljO9yMcdkBfyW3c/o8Sd9PgNufc= bastion@govwifi"
 }

--- a/govwifi-keys/variables.tf
+++ b/govwifi-keys/variables.tf
@@ -1,0 +1,4 @@
+variable "create_production_bastion_key" {
+  description = "Feature toggle key generation based on environment. Value should be 0 for staging and 1 for production."
+  type        = number
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -51,6 +51,9 @@ module "govwifi-keys" {
   }
 
   source = "../../govwifi-keys"
+
+
+  create_production_bastion_key = 0
 }
 
 # London Backend ==================================================================

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -52,7 +52,6 @@ module "govwifi-keys" {
 
   source = "../../govwifi-keys"
 
-
   create_production_bastion_key = 0
 }
 

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -152,6 +152,8 @@ module "govwifi-keys" {
   }
 
   source = "../../govwifi-keys"
+
+  create_production_bastion_key = 0
 }
 
 # Frontend ====================================================================

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -51,6 +51,8 @@ module "govwifi-keys" {
   }
 
   source = "../../govwifi-keys"
+
+  create_production_bastion_key = 1
 }
 
 # Global ====================================================================

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -51,6 +51,8 @@ module "govwifi-keys" {
   }
 
   source = "../../govwifi-keys"
+
+  create_production_bastion_key = 1
 }
 
 # Backend =====================================================================


### PR DESCRIPTION
### What

Feature toggle EC2 key creation based on environment. 

Add a count variable to the production EC2 instance key so it's only created when running the production apply (wifi and wifi-london).

### Why

Since the `govwifi-keys` module gets deployed on `make <ENV> apply`, `govwifi-bastion-key` is created when the module is deployed to production OR staging. 

If changes are applied to one environment but not the other, the next time someone runs `apply` Terraform will try to recreate the keys generating an AWS error:

```
Error: Error import KeyPair: InvalidKeyPair.Duplicate: The keypair '<key_name>' already exists.
	status code: 400, request id: <some ID>
```

Feature toggling which environment can create its respective EC2 key resolves this error. 

It also allows for more control over EC2 key pair creation and removes the risk of race conditions that block the main branch.