### PR TITLE
Disable FreeRADIUS verbose logging

### DIFF
--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -64,7 +64,7 @@ variable "enable-detailed-monitoring" {
 }
 
 variable "radiusd-params" {
-  default = "-X"
+  default = "-f"
 }
 
 variable "users" {


### PR DESCRIPTION
### What

Disable FreeRADIUS verbose logging by changing the `radiusd-params` from `-X` (verbose logging) to `-f` (normal logging).

### Why

* It was only enabled for the DigiCert rotation which is complete.
* The FreeRADIUS server are also intermittently failing which could be related to having the verbose logging enabled.
