### PR TITLE
enable grafana instances to send logs to cloudwatch

### DIFF
--- a/govwifi-grafana/iam.tf
+++ b/govwifi-grafana/iam.tf
@@ -16,12 +16,12 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
 }
 
 resource "aws_iam_instance_profile" "grafana-instance-profile" {
-  name       = "${var.aws-region}-${var.Env-Name}-grafana-instance-profile"
-  role       = aws_iam_role.grafana-instance-role.name
+  name = "${var.aws-region}-${var.Env-Name}-grafana-instance-profile"
+  role = aws_iam_role.grafana-instance-role.name
 }
 
 resource "aws_iam_role" "grafana-instance-role" {
-  name  = "${var.aws-region}-${var.Env-Name}-grafana-instance-role"
+  name = "${var.aws-region}-${var.Env-Name}-grafana-instance-role"
   path = "/"
 
   assume_role_policy = <<EOF
@@ -43,8 +43,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "grafana-instance-policy" {
-  name       = "${var.aws-region}-${var.Env-Name}-grafana-instance-policy"
-  role       = aws_iam_role.grafana-instance-role.id
+  name = "${var.aws-region}-${var.Env-Name}-grafana-instance-policy"
+  role = aws_iam_role.grafana-instance-role.id
 
   policy = <<EOF
 {

--- a/govwifi-grafana/iam.tf
+++ b/govwifi-grafana/iam.tf
@@ -14,3 +14,56 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
     }
   }
 }
+
+resource "aws_iam_instance_profile" "grafana-instance-profile" {
+  name       = "${var.aws-region}-${var.Env-Name}-grafana-instance-profile"
+  role       = aws_iam_role.grafana-instance-role.name
+}
+
+resource "aws_iam_role" "grafana-instance-role" {
+  name  = "${var.aws-region}-${var.Env-Name}-grafana-instance-role"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy" "grafana-instance-policy" {
+  name       = "${var.aws-region}-${var.Env-Name}-grafana-instance-policy"
+  role       = aws_iam_role.grafana-instance-role.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ]
+    }
+  ]
+}
+EOF
+
+}

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -32,6 +32,8 @@ resource "aws_instance" "grafana_instance" {
     aws_security_group.grafana-ec2-out.id,
   ]
 
+  iam_instance_profile = aws_iam_instance_profile.grafana-instance-profile.id
+
   tags = {
     Name = "${title(var.Env-Name)} Grafana-Server"
     Env  = title(var.Env-Name)
@@ -67,7 +69,7 @@ data "template_file" "grafana_user_data" {
   template = file("${path.module}/user_data.sh")
 
   vars = {
-    grafana_log_group       = "${var.Env-Name}-grafana-log-group"
+    grafana-log-group       = "${var.Env-Name}-grafana-log-group"
     grafana_admin           = local.grafana-admin
     google_client_secret    = local.google-client-secret
     google_client_id        = local.google-client-id

--- a/govwifi-grafana/user_data.sh
+++ b/govwifi-grafana/user_data.sh
@@ -51,6 +51,67 @@ echo "allow 127/8" >> /tmp/chrony.conf
 mv /tmp/chrony.conf /etc/chrony/chrony.conf
 systemctl restart chrony
 
+# Inject the CloudWatch Logs configuration file contents
+sudo cat <<'EOF' > ./initial-awslogs.conf
+[general]
+state_file = /var/awslogs/state/agent-state
+
+[/var/log/syslog]
+file = /var/log/syslog
+log_group_name = ${grafana-log-group}
+log_stream_name = {instance_id}/var/log/syslog
+datetime_format = %b %d %H:%M:%S
+
+[/var/log/auth.log]
+file = /var/log/auth.log
+log_group_name = ${grafana-log-group}
+log_stream_name = {instance_id}/var/log/auth.log
+datetime_format = %b %d %H:%M:%S
+
+[/var/log/dmesg]
+file = /var/log/dmesg
+log_group_name = ${grafana-log-group}
+log_stream_name = {instance_id}/var/log/dmesg
+
+[/var/log/unattended-upgrades/unattended-upgrades.log]
+file = /var/log/unattended-upgrades/unattended-upgrades.log
+log_group_name = ${grafana-log-group}
+log_stream_name = {instance_id}/var/log/unattended-upgrades/unattended-upgrades.log
+datetime_format = %Y-%m-%d %H:%M:%S
+
+[/var/log/cloud-init-output.log]
+file = /var/log/cloud-init-output.log
+log_group_name = ${grafana-log-group}
+log_stream_name = {instance_id}/var/log/cloud-init-output.log
+EOF
+
+# Install awslogs
+# Steps required are install pre-reqs for python 3.5.n, install & build python 3.5 cos awslogs script only supports python < 3.5
+# Legacy - instance has this already - The install script requires the issue file to start with the string "Ubuntu"
+# Legacy - default - sudo echo "Ubuntu Linux 20.04 LTS - Authorized uses only. All activity may be monitored and reported. \d \t @ \n" > /etc/issue
+
+# Install python 3.5 prerequisites
+run-until-success sudo apt-get install --yes build-essential checkinstall
+run-until-success sudo apt-get install --yes libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
+
+# Install python 3.5.n source
+cd /usr/src
+run-until-success sudo wget https://www.python.org/ftp/python/3.5.9/Python-3.5.9.tgz
+sudo tar xzf Python-3.5.9.tgz
+
+# Build python
+cd Python-3.5.9/
+sudo ./configure --enable-optimizations
+sudo make altinstall
+
+# Retrieve and run awslogs install script
+cd /
+run-until-success sudo curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
+
+# Legacy possibly - Try to circumvent pip install error with waiting for 10 seconds.
+# sleep 10
+sudo python3.5 ./awslogs-agent-setup.py -n -r eu-west-2 -c ./initial-awslogs.conf
+
 # Install Docker and Send Logs to CloudWatch
 logger 'Installing and configuring docker'
 mkdir -p /etc/systemd/system/docker.service.d
@@ -58,8 +119,7 @@ run-until-success apt-get install --yes docker.io
 cat <<EOF > /etc/systemd/system/docker.service.d/override.conf
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd --log-driver "local" 
-# ExecStart=/usr/bin/dockerd --log-driver awslogs --log-opt awslogs-region=eu-west-2 --log-opt awslogs-group=${grafana_log_group} --dns 10.0.0.2
+ExecStart=/usr/bin/dockerd --log-driver "local"
 EOF
 
 # Start and then stop systemctl daemon to do some housekeeping (mount folders etc)


### PR DESCRIPTION
### What
* Add an IAM role, policy and instance attachment which will allow the grafana instances to create & write logs in Cloudwatch.
* Install awslogs to transport selected logs using the above role.
* awslogs has dependencies: python < 3.5, which requires a manual install / build from user_data.sh because there is no package in the repos for 3.4 / 3.5 or similar.
* python3.5 has many dependancies, this commit installs them in the correct sequence.

### Why
Grafana instances have not been logging to cloudwatch since April 2021.
We need to send logs to cloudwatch, particularly in preparation for service assessment.

Link to Trello card (if applicable): https://trello.com/c/p8LL22jw/1359-fix-grafana-not-logging-to-cloudwatch

### Testing
Terminate the existing instance, log group and IAM role.
Run the terraform of destiny.
Wait 12.5 mins or make tea.
Check everything re-appears.