### PR TITLE
Update low CPU alarm on ECS tasks

### DIFF
--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
 
 resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
   count               = var.alarm-count
-  alarm_name          = "${var.Env-Name}-logging-ecs-cpu-alarm-low"
+  alarm_name          = "${var.Env-Name}-downscale-logging-ecs-cpu-low-alarm"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "2"
   metric_name         = "CPUUtilization"
@@ -40,7 +40,7 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
     ServiceName = aws_ecs_service.logging-api-service[0].name
   }
 
-  alarm_description = "This alarm tells ECS to scale in based on low CPU usage - Logging"
+  alarm_description = "Alarm scales down the number of ECS tasks in the cluster when CPU usage is low"
 
   alarm_actions = [
     aws_appautoscaling_policy.ecs-policy-down-logging[0].arn,

--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
   namespace           = "AWS/ECS"
   period              = "300"
   statistic           = "Average"
-  threshold           = "1"
+  threshold           = "0.3"
   datapoints_to_alarm = "2"
 
   dimensions = {

--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
   namespace           = "AWS/ECS"
   period              = "300"
   statistic           = "Average"
-  threshold           = "0.3"
+  threshold           = var.low_cpu_threshold
   datapoints_to_alarm = "2"
 
   dimensions = {

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
   namespace           = "AWS/ECS"
   period              = "300"
   statistic           = "Average"
-  threshold           = "1"
+  threshold           = "0.3"
   datapoints_to_alarm = "1"
 
   dimensions = {

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
   namespace           = "AWS/ECS"
   period              = "300"
   statistic           = "Average"
-  threshold           = "0.3"
+  threshold           = var.low_cpu_threshold
   datapoints_to_alarm = "1"
 
   dimensions = {

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -26,7 +26,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-high" {
 
 resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
   count               = var.alarm-count
-  alarm_name          = "${var.Env-Name}-auth-ecs-cpu-alarm-low"
+  alarm_name          = "${var.Env-Name}-downscale-auth-ecs-cpu-low-alarm"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
     ServiceName = aws_ecs_service.authorisation-api-service.name
   }
 
-  alarm_description = "This alarm tells ECS to scale in based on low CPU usage"
+  alarm_description = "Alarm scales down the number of ECS tasks in the cluster when CPU usage is low"
 
   alarm_actions = [
     aws_appautoscaling_policy.ecs-policy-down.arn,

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -211,3 +211,8 @@ variable "backup_mysql_rds" {
   default     = false
   type        = bool
 }
+
+variable "low_cpu_threshold" {
+  description = "Low CPU threshold for ECS task alarms. This value is higher (1%) for production but lower (0.3%) for staging and is based on average CPU."
+  type        = number
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -338,6 +338,8 @@ module "api" {
 
   use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
+
+  low_cpu_threshold = 0.3
 }
 
 module "notifications" {

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -287,6 +287,8 @@ module "api" {
   ]
 
   use_env_prefix = var.use_env_prefix
+
+  low_cpu_threshold = 0.3
 }
 
 module "notifications" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -344,6 +344,8 @@ module "api" {
 
   use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
+
+  low_cpu_threshold = 1
 }
 
 module "critical-notifications" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -303,6 +303,8 @@ module "api" {
   ]
 
   use_env_prefix = var.use_env_prefix
+
+  low_cpu_threshold = 1
 }
 
 module "critical-notifications" {


### PR DESCRIPTION
### What

* Reduce low CPU alarm threshold to 0.3% on staging Auth API and Logging API ECS task alarms.
* Toggle CPU threshold value to adjust for different CPU averages between staging and production.
* Update alarm name and description for clarity

### Why

* The average CPU for both staging ECS tasks is always below 1% (even the max CPU rarely exceeds 1%) therefore these alerts will always go off. The minimum low CPU hovers around 0.3%, in which case we do want to downscale the number of ECS tasks for efficiency and cost savings.
* Production is slightly different. The CPU average rarely dips below 1% so it's sensible to keep the threshold for production at 1%.

[Link to Trello card](https://trello.com/c/XowCI6x0/298-address-cloudwatch-alerts-in-alarm-state).
