### PR TITLE
Update FreeStorage alarm threshold on staging RDS databases

### DIFF
--- a/govwifi-backend/db-alarms.tf
+++ b/govwifi-backend/db-alarms.tf
@@ -38,16 +38,16 @@ resource "aws_cloudwatch_metric_alarm" "db_memoryalarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "db_storagealarm" {
+resource "aws_cloudwatch_metric_alarm" "sessions_db_storage_alarm" {
   count               = var.db-instance-count
-  alarm_name          = "${var.Env-Name}-db-storage-alarm"
+  alarm_name          = "${var.Env-Name}-sessions-db-storage-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "FreeStorageSpace"
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Minimum"
-  threshold           = "32212254720"
+  threshold           = var.db-storage-alarm-threshold
 
   dimensions = {
     DBInstanceIdentifier = aws_db_instance.db[0].identifier

--- a/govwifi-backend/user-db-alarms.tf
+++ b/govwifi-backend/user-db-alarms.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "user_db_memoryalarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "user_db_storagealarm" {
+resource "aws_cloudwatch_metric_alarm" "user_db_storage_alarm" {
   count               = var.db-instance-count
   alarm_name          = "${var.env}-user-db-storage-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
@@ -47,7 +47,7 @@ resource "aws_cloudwatch_metric_alarm" "user_db_storagealarm" {
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Minimum"
-  threshold           = "32212254720"
+  threshold           = var.db-storage-alarm-threshold
   datapoints_to_alarm = "1"
 
   dimensions = {

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -154,3 +154,7 @@ variable "backup_mysql_rds" {
   type        = bool
 }
 
+variable "db-storage-alarm-threshold" {
+  description = "DB storage threshold used for alarms. Value varies based on environment and storage average."
+  type        = number
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -124,6 +124,8 @@ module "backend" {
 
   use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
+
+  db-storage-alarm-threshold = 19327342936
 }
 
 # London Frontend ==================================================================

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -122,6 +122,8 @@ module "backend" {
   grafana-IP            = "${var.grafana-IP}/32"
 
   use_env_prefix = var.use_env_prefix
+
+  db-storage-alarm-threshold = 19327342936
 }
 
 # Emails ======================================================================

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -140,6 +140,8 @@ module "backend" {
 
   use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
+
+  db-storage-alarm-threshold = 32212254720
 }
 
 # London Frontend ======DIFFERENT AWS REGION===================================
@@ -344,6 +346,8 @@ module "api" {
 
   use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
+
+  low_cpu_threshold = 1
 }
 
 module "critical-notifications" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -127,6 +127,8 @@ module "backend" {
   grafana-IP            = "${var.grafana-IP}/32"
 
   use_env_prefix = var.use_env_prefix
+
+  db-storage-alarm-threshold = 32212254720
 }
 
 # Emails ======================================================================


### PR DESCRIPTION
### What

* Feature toggle the FreeStorage alarm threshold based on staging and production needs.
* Set the staging threshold to 18GB since the overall database storage is 20GB (we could even go lower).
* Keep the production threshold to 32GB since the overall database storage is 1TB.

### Why

* The alarms were created with a default threshold of 32GB which is fine for the production databases where storage is set to 1TB.
* However, the staging databases storage is set to 20GB therefore the staging alarm will always be in alert state since the free storage always less than the overall storage (20GB) which is less than the default 32GB threshold.


[Link to Trello card](https://trello.com/c/XowCI6x0/298-address-cloudwatch-alerts-in-alarm-state)
