### PR TITLE
Setup out of hours alerting via Cloudwatch/PagerDuty

### DIFF
--- a/govwifi-admin/alarms.tf
+++ b/govwifi-admin/alarms.tf
@@ -1,0 +1,21 @@
+resource "aws_cloudwatch_metric_alarm" "admin-no-healthy-hosts" {
+  alarm_name          = "${var.Env-Name} admin no healthy hosts"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "1"
+  datapoints_to_alarm = "1"
+
+  dimensions = {
+    LoadBalancer = aws_lb.admin-alb.arn_suffix
+  }
+
+  alarm_description = "Detect when there are no healthy admin targets"
+
+  alarm_actions = compact([
+    var.pagerduty_notification_arn,
+  ])
+}

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -84,6 +84,10 @@ variable "critical-notifications-arn" {
 variable "capacity-notifications-arn" {
 }
 
+variable "pagerduty_notification_arn" {
+  type = string
+}
+
 variable "db-instance-count" {
 }
 

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -50,3 +50,48 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
   treat_missing_data = "breaching"
 }
 
+resource "aws_cloudwatch_metric_alarm" "authentication-api-no-healthy-hosts" {
+  alarm_name          = "${var.Env-Name} authentication API no healthy hosts"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "1"
+  datapoints_to_alarm = "1"
+
+  dimensions = {
+    LoadBalancer = aws_lb.api-alb[0].arn_suffix
+  }
+
+  alarm_description = "Detect when there are no healthy API targets"
+
+  alarm_actions = compact([
+    var.pagerduty_notification_arn,
+  ])
+}
+
+resource "aws_cloudwatch_metric_alarm" "user-signup-api-no-healthy-hosts" {
+  count = var.user-signup-enabled
+
+  alarm_name          = "${var.Env-Name} user signup API no healthy hosts"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "1"
+  datapoints_to_alarm = "1"
+
+  dimensions = {
+    LoadBalancer = aws_lb.user-signup-api[0].arn_suffix
+  }
+
+  alarm_description = "Detect when there are no healthy user signup API targets"
+
+  alarm_actions = compact([
+    var.pagerduty_notification_arn,
+  ])
+}

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -115,6 +115,10 @@ variable "capacity-notifications-arn" {
 variable "devops-notifications-arn" {
 }
 
+variable "pagerduty_notification_arn" {
+  type = string
+}
+
 variable "users" {
   type = list(string)
 }

--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -23,6 +23,19 @@ resource "aws_cloudwatch_metric_alarm" "radius-hc" {
   ]
 }
 
+# TODO: This requires a more up to date version of the AWS provider to work
+#
+# https://trello.com/c/Jsis2ZR1/1042-5-upgrade-the-terraform-aws-provider-to-a-more-recent-version
+#
+# resource "aws_cloudwatch_composite_alarm" "all_radius_servers_down" {
+#   provider = aws.route53-alarms
+#   alarm_name = "${var.Env-Name} ${var.aws-region} All Radius servers down"
+
+#   alarm_actions = [var.pagerduty_notification_arn]
+
+#   alarm_rule = join(" AND ", formatlist("ALARM(\"%s\")", aws_cloudwatch_metric_alarm.radius-hc[*].alarm_name))
+# }
+
 resource "aws_cloudwatch_metric_alarm" "radius-latency" {
   provider = aws.route53-alarms
   count    = var.radius-instance-count

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -94,6 +94,10 @@ variable "devops-notifications-arn" {
   type = string
 }
 
+variable "pagerduty_notification_arn" {
+  type = string
+}
+
 variable "admin-bucket-name" {
   type = string
 }

--- a/govwifi-pagerduty-integration/README.md
+++ b/govwifi-pagerduty-integration/README.md
@@ -1,0 +1,4 @@
+# GovWifi PagerDuty
+
+This module creates an SNS topic and subscription for sending events
+to PagerDuty. Cloudwatch alarms can be hooked up to the topic.

--- a/govwifi-pagerduty-integration/main.tf
+++ b/govwifi-pagerduty-integration/main.tf
@@ -1,0 +1,9 @@
+resource "aws_sns_topic" "pagerduty" {
+  name = "alarms-for-pagerduty"
+}
+
+resource "aws_sns_topic_subscription" "pagerduty_subscription" {
+  topic_arn = aws_sns_topic.pagerduty.arn
+  protocol  = "https"
+  endpoint  = var.sns_topic_subscription_https_endpoint
+}

--- a/govwifi-pagerduty-integration/outputs.tf
+++ b/govwifi-pagerduty-integration/outputs.tf
@@ -1,0 +1,3 @@
+output "topic_arn" {
+  value = aws_sns_topic.pagerduty.arn
+}

--- a/govwifi-pagerduty-integration/variables.tf
+++ b/govwifi-pagerduty-integration/variables.tf
@@ -1,0 +1,1 @@
+variable "sns_topic_subscription_https_endpoint" {}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -196,6 +196,7 @@ module "frontend" {
   # This must be based on us-east-1, as that's where the alarms go
   route53-critical-notifications-arn = module.route53-critical-notifications.topic-arn
   devops-notifications-arn           = module.devops-notifications.topic-arn
+  pagerduty_notification_arn         = module.region_pagerduty.topic_arn
 
   # Security groups ---------------------------------------
   radius-instance-sg-ids = []

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -398,6 +398,20 @@ module "route53-critical-notifications" {
   emails     = [var.critical-notification-email]
 }
 
+locals {
+  pagerduty_https_endpoint = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_config.secret_string)["integration-url"]
+}
+
+module "region_pagerduty" {
+  providers = {
+    aws = aws.AWS-main
+  }
+
+  source = "../../govwifi-pagerduty-integration"
+
+  sns_topic_subscription_https_endpoint = local.pagerduty_https_endpoint
+}
+
 module "govwifi-dashboard" {
   providers = {
     aws = aws.AWS-main

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -264,6 +264,7 @@ module "govwifi-admin" {
 
   critical-notifications-arn = module.critical-notifications.topic-arn
   capacity-notifications-arn = module.capacity-notifications.topic-arn
+  pagerduty_notification_arn = module.region_pagerduty.topic_arn
 
   rds-monitoring-role = module.backend.rds-monitoring-role
 
@@ -312,6 +313,7 @@ module "api" {
   critical-notifications-arn = module.critical-notifications.topic-arn
   capacity-notifications-arn = module.capacity-notifications.topic-arn
   devops-notifications-arn   = module.devops-notifications.topic-arn
+  pagerduty_notification_arn = module.region_pagerduty.topic_arn
 
   auth-docker-image             = format("%s/authorisation-api:production", local.docker_image_path)
   user-signup-docker-image      = format("%s/user-signup-api:production", local.docker_image_path)

--- a/govwifi/wifi-london/secrets-manager.tf
+++ b/govwifi/wifi-london/secrets-manager.tf
@@ -21,3 +21,11 @@ data "aws_secretsmanager_secret_version" "route53_zone_id" {
 data "aws_secretsmanager_secret" "route53_zone_id" {
   name = "aws/route53/zone-id"
 }
+
+data "aws_secretsmanager_secret" "pagerduty_config" {
+  name = "pagerduty/config"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_config" {
+  secret_id = data.aws_secretsmanager_secret.pagerduty_config.id
+}

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -9,3 +9,7 @@ locals {
 locals {
   route53_zone_id = jsondecode(data.aws_secretsmanager_secret_version.route53_zone_id.secret_string)["route53-zone-id"]
 }
+
+locals {
+  pagerduty_https_endpoint = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_config.secret_string)["integration-url"]
+}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -225,6 +225,7 @@ module "frontend" {
 
   route53-critical-notifications-arn = module.route53-critical-notifications.topic-arn
   devops-notifications-arn           = module.devops-notifications.topic-arn
+  pagerduty_notification_arn         = module.us_east_1_pagerduty.topic_arn
 
   # Security groups ---------------------------------------
   radius-instance-sg-ids = []
@@ -275,6 +276,7 @@ module "api" {
   critical-notifications-arn = module.critical-notifications.topic-arn
   capacity-notifications-arn = module.capacity-notifications.topic-arn
   devops-notifications-arn   = module.devops-notifications.topic-arn
+  pagerduty_notification_arn = module.region_pagerduty.topic_arn
 
   auth-docker-image             = format("%s/authorisation-api:production", local.docker_image_path)
   logging-docker-image          = format("%s/logging-api:production", local.docker_image_path)

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -357,6 +357,28 @@ module "route53-critical-notifications" {
   emails     = [var.critical-notification-email]
 }
 
+module "region_pagerduty" {
+  providers = {
+    aws = aws.AWS-main
+  }
+
+  source = "../../govwifi-pagerduty-integration"
+
+  sns_topic_subscription_https_endpoint = local.pagerduty_https_endpoint
+}
+
+# This is used for the alarms connected to the Route 53 healthchecks
+# in this region
+module "us_east_1_pagerduty" {
+  providers = {
+    aws = aws.route53-alarms
+  }
+
+  source = "../../govwifi-pagerduty-integration"
+
+  sns_topic_subscription_https_endpoint = local.pagerduty_https_endpoint
+}
+
 module "govwifi-prometheus" {
   providers = {
     aws = aws.AWS-main

--- a/govwifi/wifi/secrets-manager.tf
+++ b/govwifi/wifi/secrets-manager.tf
@@ -21,3 +21,11 @@ data "aws_secretsmanager_secret_version" "route53_zone_id" {
 data "aws_secretsmanager_secret" "route53_zone_id" {
   name = "aws/route53/zone-id"
 }
+
+data "aws_secretsmanager_secret" "pagerduty_config" {
+  name = "pagerduty/config"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_config" {
+  secret_id = data.aws_secretsmanager_secret.pagerduty_config.id
+}


### PR DESCRIPTION
### What
Setup out of hours alerting via Cloudwatch/PagerDuty.

### Why
So that Unboxed can find out when things break, and then hopefully fix things.


Link to Trello card (if applicable): https://trello.com/c/HIPp6IyG/1466-create-and-configure-cloudwatch-alarms-to-alert-pagerduty

## TODO

 - [x] Work out how to manage the secret containing the PagerDuty endpoint for the SNS topic subscription, should this be replicated cross region, or just looked up in one region?
   - The secret is now replicated to the Ireland region
 - [x] Discuss upgrading the AWS provider, so that the composite alarms can be managed through Terraform
   - Some discussion has happened, I'll go with adding the Terraform for the two composite alarms now, but commented out.
 - [x] Document the `govwifi-pagerduty-integration` module
 - [x] Should a new SNS topic be used? There's already quite a lot of topics, but from a brief inspection, the "critical" topics are very sensitive, connected to alerts (like database CPU usage) that could fire when the service is still functioning.
   - Going to go with a new one, then consider trying to refactor later
