### PR TITLE
Add missing "endpoint_auto_confirms = true" argument

### DIFF
--- a/govwifi-pagerduty-integration/main.tf
+++ b/govwifi-pagerduty-integration/main.tf
@@ -3,7 +3,8 @@ resource "aws_sns_topic" "pagerduty" {
 }
 
 resource "aws_sns_topic_subscription" "pagerduty_subscription" {
-  topic_arn = aws_sns_topic.pagerduty.arn
-  protocol  = "https"
-  endpoint  = var.sns_topic_subscription_https_endpoint
+  topic_arn              = aws_sns_topic.pagerduty.arn
+  protocol               = "https"
+  endpoint               = var.sns_topic_subscription_https_endpoint
+  endpoint_auto_confirms = true
 }


### PR DESCRIPTION
### What
Add missing "endpoint_auto_confirms = true" argument.

### Why
Otherwise you get an error:

  Error: Protocol http/https is only supported for endpoints which auto confirms!


Link to Trello card (if applicable): https://trello.com/c/HIPp6IyG/1466-create-and-configure-cloudwatch-alarms-to-alert-pagerduty