### PR TITLE
Send request statistics to Elasticsearch every hour.

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -38,6 +38,14 @@ resource "aws_cloudwatch_event_rule" "daily_gdpr_set_user_last_login" {
   is_enabled          = true
 }
 
+resource "aws_cloudwatch_event_rule" "hourly_request_statistics_event" {
+  count               = var.event-rule-count
+  name                = "${var.Env-Name}-hourly_request_statistics"
+  description         = "Triggers hourly"
+  schedule_expression = "cron(0 * * * ? *)"
+  is_enabled          = true
+}
+
 # new daily, weekly and monthly metrics published to S3
 resource "aws_cloudwatch_event_rule" "daily_metrics_logging_event" {
   count               = var.event-rule-count


### PR DESCRIPTION
### What
Call a rake task in the logging API that sends request stats to Elasticsearch every hour.
### Why
So we can visualise the data in Grafana.


Link to Trello card (if applicable): https://trello.com/c/iuIWfaxw/1502-super-admin-time-series-of-org-traffic-3
