### PR TITLE
Fix pagerduty alarm actions

### DIFF
--- a/govwifi-admin/alarms.tf
+++ b/govwifi-admin/alarms.tf
@@ -16,6 +16,6 @@ resource "aws_cloudwatch_metric_alarm" "admin-no-healthy-hosts" {
   alarm_description = "Detect when there are no healthy admin targets"
 
   alarm_actions = compact([
-    var.pagerduty_notification_arn,
+    var.notification_arn,
   ])
 }

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -84,7 +84,8 @@ variable "critical-notifications-arn" {
 variable "capacity-notifications-arn" {
 }
 
-variable "pagerduty_notification_arn" {
+variable "notification_arn" {
+  description = "Notification ARN for alerts. In production alerts are sent to PagerDuty, but in staging alerts are sent to an email group."
   type = string
 }
 

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -86,7 +86,7 @@ variable "capacity-notifications-arn" {
 
 variable "notification_arn" {
   description = "Notification ARN for alerts. In production alerts are sent to PagerDuty, but in staging alerts are sent to an email group."
-  type = string
+  type        = string
 }
 
 variable "db-instance-count" {

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "authentication-api-no-healthy-hosts" {
   alarm_description = "Detect when there are no healthy API targets"
 
   alarm_actions = compact([
-    var.pagerduty_notification_arn,
+    var.notification_arn,
   ])
 }
 
@@ -92,6 +92,6 @@ resource "aws_cloudwatch_metric_alarm" "user-signup-api-no-healthy-hosts" {
   alarm_description = "Detect when there are no healthy user signup API targets"
 
   alarm_actions = compact([
-    var.pagerduty_notification_arn,
+    var.notification_arn,
   ])
 }

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -117,7 +117,7 @@ variable "devops-notifications-arn" {
 
 variable "notification_arn" {
   description = "Notification ARN for alerts. In production alerts are sent to PagerDuty, but in staging alerts are sent to an email group."
-  type = string
+  type        = string
 }
 
 variable "users" {

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -115,7 +115,8 @@ variable "capacity-notifications-arn" {
 variable "devops-notifications-arn" {
 }
 
-variable "pagerduty_notification_arn" {
+variable "notification_arn" {
+  description = "Notification ARN for alerts. In production alerts are sent to PagerDuty, but in staging alerts are sent to an email group."
   type = string
 }
 

--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -24,7 +24,10 @@ resource "aws_cloudwatch_metric_alarm" "radius-hc" {
 }
 
 # TODO: This requires a more up to date version of the AWS provider to work
-#
+# We will also need to feature toggle the alarm actions so the notification ARN points to PagerDuty for production
+# and an appropriate email group for staging. See implementation of `notification_arn` in govwifi/staging-london/main.tf
+# and govwifi/wifi-london/main.tf
+
 # https://trello.com/c/Jsis2ZR1/1042-5-upgrade-the-terraform-aws-provider-to-a-more-recent-version
 #
 # resource "aws_cloudwatch_composite_alarm" "all_radius_servers_down" {

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -94,10 +94,6 @@ variable "devops-notifications-arn" {
   type = string
 }
 
-variable "pagerduty_notification_arn" {
-  type = string
-}
-
 variable "admin-bucket-name" {
   type = string
 }

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -267,6 +267,8 @@ module "govwifi-admin" {
   )
 
   use_env_prefix = true
+
+  notification_arn = module.notifications.topic-arn
 }
 
 module "api" {
@@ -297,6 +299,7 @@ module "api" {
   critical-notifications-arn = module.notifications.topic-arn
   capacity-notifications-arn = module.notifications.topic-arn
   devops-notifications-arn   = module.notifications.topic-arn
+  notification_arn           = module.notifications.topic-arn
 
   auth-docker-image             = format("%s/authorisation-api:staging", local.docker_image_path)
   user-signup-docker-image      = format("%s/user-signup-api:staging", local.docker_image_path)

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -255,6 +255,7 @@ module "api" {
   critical-notifications-arn = module.notifications.topic-arn
   capacity-notifications-arn = module.notifications.topic-arn
   devops-notifications-arn   = module.notifications.topic-arn
+  notification_arn           = module.notifications.topic-arn
 
   auth-docker-image             = format("%s/authorisation-api:staging", local.docker_image_path)
   user-signup-docker-image      = ""

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -196,7 +196,6 @@ module "frontend" {
   # This must be based on us-east-1, as that's where the alarms go
   route53-critical-notifications-arn = module.route53-critical-notifications.topic-arn
   devops-notifications-arn           = module.devops-notifications.topic-arn
-  pagerduty_notification_arn         = module.region_pagerduty.topic_arn
 
   # Security groups ---------------------------------------
   radius-instance-sg-ids = []
@@ -313,7 +312,7 @@ module "api" {
   critical-notifications-arn = module.critical-notifications.topic-arn
   capacity-notifications-arn = module.capacity-notifications.topic-arn
   devops-notifications-arn   = module.devops-notifications.topic-arn
-  notification_arn = module.region_pagerduty.topic_arn
+  notification_arn           = module.region_pagerduty.topic_arn
 
   auth-docker-image             = format("%s/authorisation-api:production", local.docker_image_path)
   user-signup-docker-image      = format("%s/user-signup-api:production", local.docker_image_path)

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -264,7 +264,7 @@ module "govwifi-admin" {
 
   critical-notifications-arn = module.critical-notifications.topic-arn
   capacity-notifications-arn = module.capacity-notifications.topic-arn
-  pagerduty_notification_arn = module.region_pagerduty.topic_arn
+  notification_arn           = module.region_pagerduty.topic_arn
 
   rds-monitoring-role = module.backend.rds-monitoring-role
 
@@ -313,7 +313,7 @@ module "api" {
   critical-notifications-arn = module.critical-notifications.topic-arn
   capacity-notifications-arn = module.capacity-notifications.topic-arn
   devops-notifications-arn   = module.devops-notifications.topic-arn
-  pagerduty_notification_arn = module.region_pagerduty.topic_arn
+  notification_arn = module.region_pagerduty.topic_arn
 
   auth-docker-image             = format("%s/authorisation-api:production", local.docker_image_path)
   user-signup-docker-image      = format("%s/user-signup-api:production", local.docker_image_path)

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -276,7 +276,7 @@ module "api" {
   critical-notifications-arn = module.critical-notifications.topic-arn
   capacity-notifications-arn = module.capacity-notifications.topic-arn
   devops-notifications-arn   = module.devops-notifications.topic-arn
-  pagerduty_notification_arn = module.region_pagerduty.topic_arn
+  notification_arn           = module.region_pagerduty.topic_arn
 
   auth-docker-image             = format("%s/authorisation-api:production", local.docker_image_path)
   logging-docker-image          = format("%s/logging-api:production", local.docker_image_path)

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -225,7 +225,6 @@ module "frontend" {
 
   route53-critical-notifications-arn = module.route53-critical-notifications.topic-arn
   devops-notifications-arn           = module.devops-notifications.topic-arn
-  pagerduty_notification_arn         = module.us_east_1_pagerduty.topic_arn
 
   # Security groups ---------------------------------------
   radius-instance-sg-ids = []


### PR DESCRIPTION
### What

* Remove unused `pagerduty_notification_arn` variable
* Remove "pagerduty" prefix from variable name to make alert action agnostic to notification destination.
* Feature toggle `alarm_action`: in production alerts should be sent to PagerDuty, but in staging they should go to an appropriate email group since we don't need to alert the out of hours team for issues in staging.
* Add description to `notification_arn` explaining feature toggle and purpose
* Add missing `notification_arn` variables to module declarations in staging and staging-london. This was causing Terraform validation errors.

#### How to test

1. Check out the branch
2. Ensure you can run `terraform plan` without errors in each of the environments

### Why

We want to feature toggle this alert functionality: production alerts should be sent to PagerDuty and staging alerts should be sent to the relevant email group. In order to do that we abstract the variable name, pointing it to the appropriate notification ARN depending on the environment.

Our Terraform module declarations require variables added to `variables.tf` files in the module directories are also declared within the module.

If we create variables for new resources to use, like `pagerduty_notification_arn`, they not only have to be added to the production `main.tf` files but also the staging `main.tf` files.

Link to [Trello card](https://trello.com/c/HIPp6IyG/1466-create-and-configure-cloudwatch-alarms-to-alert-pagerduty).
