### PR TITLE
Improve CloudWatch alert descriptions

### DIFF
--- a/govwifi-admin/alarms.tf
+++ b/govwifi-admin/alarms.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-no-healthy-hosts" {
     LoadBalancer = aws_lb.admin-alb.arn_suffix
   }
 
-  alarm_description = "Detect when there are no healthy admin targets"
+  alarm_description = "Load balancer detects no healthy admin targets"
 
   alarm_actions = compact([
     var.notification_arn,

--- a/govwifi-admin/alarms.tf
+++ b/govwifi-admin/alarms.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-no-healthy-hosts" {
     LoadBalancer = aws_lb.admin-alb.arn_suffix
   }
 
-  alarm_description = "Load balancer detects no healthy admin targets"
+  alarm_description = "Load balancer detects no healthy admin targets. Investigate admin-api ECS cluster and CloudWatch logs for root cause."
 
   alarm_actions = compact([
     var.notification_arn,

--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
     ServiceName = aws_ecs_service.logging-api-service[0].name
   }
 
-  alarm_description = "This alarm tells ECS to scale up based on high CPU - Logging"
+  alarm_description = "ECS cluster CPU is high, scaling up number of tasks. Investigate api cluster and CloudWatch logs for root cause."
 
   alarm_actions = [
     aws_appautoscaling_policy.ecs-policy-up-logging[0].arn,
@@ -40,26 +40,10 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
     ServiceName = aws_ecs_service.logging-api-service[0].name
   }
 
-  alarm_description = "Alarm scales down the number of ECS tasks in the cluster when CPU usage is low"
+  alarm_description = "ECS cluster CPU is low, scaling down number of tasks to save on cost."
 
   alarm_actions = [
     aws_appautoscaling_policy.ecs-policy-down-logging[0].arn,
   ]
 }
 
-#resource "aws_cloudwatch_metric_alarm" "radius-access-reject" {
-#  count               = "${var.alarm-count}"
-#  alarm_name          = "${var.Env-Name}-radius-access-reject"
-#  comparison_operator = "GreaterThanThreshold"
-#  evaluation_periods  = "3"
-#  period              = "60"
-#  threshold           = "1000"
-#  alarm_description   = "Access rejections has exceeded 1000"
-#  metric_name         = "${aws_cloudwatch_log_metric_filter.radius-access-reject.metric_transformation.0.name}"
-#  namespace           = "${local.logging_api_namespace}"
-#  statistic           = "Sum"
-#
-#  alarm_actions = [
-#    "${var.devops-notifications-arn}",
-#  ]
-#}

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-high" {
     ServiceName = aws_ecs_service.authorisation-api-service.name
   }
 
-  alarm_description = "This alarm tells ECS to scale up based on high CPU"
+  alarm_description = "ECS Cluster CPU is high, scaling up number of ECS tasks"
 
   alarm_actions = [
     aws_appautoscaling_policy.ecs-policy-up.arn,
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
     ServiceName = aws_ecs_service.authorisation-api-service.name
   }
 
-  alarm_description = "Alarm scales down the number of ECS tasks in the cluster when CPU usage is low"
+  alarm_description = "ECS Cluster CPU is low, scaling down number of ECS tasks"
 
   alarm_actions = [
     aws_appautoscaling_policy.ecs-policy-down.arn,
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "authentication-api-no-healthy-hosts" {
     LoadBalancer = aws_lb.api-alb[0].arn_suffix
   }
 
-  alarm_description = "Detect when there are no healthy API targets"
+  alarm_description = "Load balancer detects no healthy API targets"
 
   alarm_actions = compact([
     var.notification_arn,
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_metric_alarm" "user-signup-api-no-healthy-hosts" {
     LoadBalancer = aws_lb.user-signup-api[0].arn_suffix
   }
 
-  alarm_description = "Detect when there are no healthy user signup API targets"
+  alarm_description = "Load balancer detects no healthy user signup API targets"
 
   alarm_actions = compact([
     var.notification_arn,

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-high" {
     ServiceName = aws_ecs_service.authorisation-api-service.name
   }
 
-  alarm_description = "ECS Cluster CPU is high, scaling up number of ECS tasks"
+  alarm_description = "ECS cluster CPU is high, scaling up number of tasks. Investigate api cluster and CloudWatch logs for root cause."
 
   alarm_actions = [
     aws_appautoscaling_policy.ecs-policy-up.arn,
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
     ServiceName = aws_ecs_service.authorisation-api-service.name
   }
 
-  alarm_description = "ECS Cluster CPU is low, scaling down number of ECS tasks"
+  alarm_description = "ECS cluster CPU is low, scaling down number of ECS tasks to save on cost."
 
   alarm_actions = [
     aws_appautoscaling_policy.ecs-policy-down.arn,
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "authentication-api-no-healthy-hosts" {
     LoadBalancer = aws_lb.api-alb[0].arn_suffix
   }
 
-  alarm_description = "Load balancer detects no healthy API targets"
+  alarm_description = "Load balancer detects no healthy authentication API targets. Investigate api cluster and CloudWatch logs for root cause."
 
   alarm_actions = compact([
     var.notification_arn,
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_metric_alarm" "user-signup-api-no-healthy-hosts" {
     LoadBalancer = aws_lb.user-signup-api[0].arn_suffix
   }
 
-  alarm_description = "Load balancer detects no healthy user signup API targets"
+  alarm_description = "Load balancer detects no healthy user signup API targets. Investigate api ECS cluster and CloudWatch logs for root cause."
 
   alarm_actions = compact([
     var.notification_arn,

--- a/govwifi-backend/db-alarms.tf
+++ b/govwifi-backend/db-alarms.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_metric_alarm" "db_cpu_alarm" {
     DBInstanceIdentifier = aws_db_instance.db[0].identifier
   }
 
-  alarm_description  = "This metric monitors the cpu utilization of the DB."
+  alarm_description  = "Database CPU utilization exceeding threshold. Investigate database logs for root cause."
   alarm_actions      = [var.critical-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "db_memory_alarm" {
     DBInstanceIdentifier = aws_db_instance.db[0].identifier
   }
 
-  alarm_description  = "This metric monitors the freeable memory available for the DB."
+  alarm_description  = "Database is running low on free memory. Investigate database logs for root cause."
   alarm_actions      = [var.critical-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -53,7 +53,7 @@ resource "aws_cloudwatch_metric_alarm" "sessions_db_storage_alarm" {
     DBInstanceIdentifier = aws_db_instance.db[0].identifier
   }
 
-  alarm_description  = "This metric monitors the storage space available for the DB."
+  alarm_description  = "Database is running low on free storage space. Investigate database logs for root cause."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -73,7 +73,7 @@ resource "aws_cloudwatch_metric_alarm" "db_burst_balance_alarm" {
     DBInstanceIdentifier = aws_db_instance.db[0].identifier
   }
 
-  alarm_description  = "This metric monitors the IOPS burst balance available for the DB."
+  alarm_description  = "Database's available IOPS burst balance is running low. Investigate disk usage on the RDS instance."
   alarm_actions      = [var.critical-notifications-arn]
   treat_missing_data = "missing"
 }
@@ -93,7 +93,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_burst_balance_alarm" {
     DBInstanceIdentifier = aws_db_instance.read_replica[0].identifier
   }
 
-  alarm_description  = "This metric monitors the IOPS burst balance available for the DB read replica."
+  alarm_description  = "Read replica database's available IOPS burst balance is running low. Investigate disk usage on the RDS instance."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "missing"
 }
@@ -113,7 +113,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_lagging_alarm" {
     DBInstanceIdentifier = aws_db_instance.read_replica[0].identifier
   }
 
-  alarm_description  = "This metric monitors the Replication Lag for the DB read replica."
+  alarm_description  = "Read replica database replication lag exceeding threshold. Investigate connections to the primary database."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -133,7 +133,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_cpu_alarm" {
     DBInstanceIdentifier = aws_db_instance.read_replica[0].identifier
   }
 
-  alarm_description  = "This metric monitors the cpu utilization of the DB read replica."
+  alarm_description  = "Read replica database CPU utilization exceeding threshold. Investigate database logs for root cause."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -153,7 +153,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_memory_alarm" {
     DBInstanceIdentifier = aws_db_instance.read_replica[0].identifier
   }
 
-  alarm_description  = "This metric monitors the freeable memory available for the DB read replica."
+  alarm_description  = "Read replica database is running low on free memory. Investigate database logs for root cause."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -174,7 +174,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_storage_alarm" {
     DBInstanceIdentifier = aws_db_instance.read_replica[0].identifier
   }
 
-  alarm_description  = "This metric monitors the storage space available for the DB read replica."
+  alarm_description  = "Read replica database is running low on free storage space. Investigate database logs for root cause."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "breaching"
 }

--- a/govwifi-backend/db-alarms.tf
+++ b/govwifi-backend/db-alarms.tf
@@ -1,6 +1,6 @@
-resource "aws_cloudwatch_metric_alarm" "db_cpu_alarm" {
+resource "aws_cloudwatch_metric_alarm" "sessions_db_cpu_alarm" {
   count               = var.db-instance-count
-  alarm_name          = "${var.Env-Name}-db-cpu-alarm"
+  alarm_name          = "${var.Env-Name}-session-db-cpu-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
@@ -18,9 +18,9 @@ resource "aws_cloudwatch_metric_alarm" "db_cpu_alarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "db_memory_alarm" {
+resource "aws_cloudwatch_metric_alarm" "sessions_db_memory_alarm" {
   count               = var.db-instance-count
-  alarm_name          = "${var.Env-Name}-db-memory-alarm"
+  alarm_name          = "${var.Env-Name}-sessions-db-memory-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "FreeableMemory"
@@ -58,9 +58,9 @@ resource "aws_cloudwatch_metric_alarm" "sessions_db_storage_alarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "db_burst_balance_alarm" {
+resource "aws_cloudwatch_metric_alarm" "sessions_db_burst_balance_alarm" {
   count               = var.db-instance-count
-  alarm_name          = "${var.Env-Name}-db-burstbalanace-alarm"
+  alarm_name          = "${var.Env-Name}-sessions-db-burstbalanace-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "BurstBalance"
@@ -78,9 +78,9 @@ resource "aws_cloudwatch_metric_alarm" "db_burst_balance_alarm" {
   treat_missing_data = "missing"
 }
 
-resource "aws_cloudwatch_metric_alarm" "rr_burst_balance_alarm" {
+resource "aws_cloudwatch_metric_alarm" "sessions_rr_burst_balance_alarm" {
   count               = var.db-replica-count
-  alarm_name          = "${var.Env-Name}-rr-burstbalanace-alarm"
+  alarm_name          = "${var.Env-Name}-sessions-rr-burstbalanace-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "BurstBalance"
@@ -98,9 +98,9 @@ resource "aws_cloudwatch_metric_alarm" "rr_burst_balance_alarm" {
   treat_missing_data = "missing"
 }
 
-resource "aws_cloudwatch_metric_alarm" "rr_lagging_alarm" {
+resource "aws_cloudwatch_metric_alarm" "sessions_rr_lagging_alarm" {
   count               = var.db-replica-count
-  alarm_name          = "${var.Env-Name}-rr-lagging-alarm"
+  alarm_name          = "${var.Env-Name}-sessions-rr-lagging-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "ReplicaLag"
@@ -118,9 +118,9 @@ resource "aws_cloudwatch_metric_alarm" "rr_lagging_alarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "rr_cpu_alarm" {
+resource "aws_cloudwatch_metric_alarm" "sessions_rr_cpu_alarm" {
   count               = var.db-replica-count
-  alarm_name          = "${var.Env-Name}-rr-cpu-alarm"
+  alarm_name          = "${var.Env-Name}-sessions-rr-cpu-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
@@ -138,9 +138,9 @@ resource "aws_cloudwatch_metric_alarm" "rr_cpu_alarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "rr_memory_alarm" {
+resource "aws_cloudwatch_metric_alarm" "sessions_rr_memory_alarm" {
   count               = var.db-replica-count
-  alarm_name          = "${var.Env-Name}-rr-memory-alarm"
+  alarm_name          = "${var.Env-Name}-sessions-rr-memory-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "FreeableMemory"
@@ -158,9 +158,9 @@ resource "aws_cloudwatch_metric_alarm" "rr_memory_alarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "rr_storage_alarm" {
+resource "aws_cloudwatch_metric_alarm" "sessions_rr_storage_alarm" {
   count               = var.db-replica-count
-  alarm_name          = "${var.Env-Name}-rr-storage-alarm"
+  alarm_name          = "${var.Env-Name}-sessions-rr-storage-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "FreeStorageSpace"

--- a/govwifi-backend/db-alarms.tf
+++ b/govwifi-backend/db-alarms.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_metric_alarm" "db_cpualarm" {
+resource "aws_cloudwatch_metric_alarm" "db_cpu_alarm" {
   count               = var.db-instance-count
   alarm_name          = "${var.Env-Name}-db-cpu-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -18,7 +18,7 @@ resource "aws_cloudwatch_metric_alarm" "db_cpualarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "db_memoryalarm" {
+resource "aws_cloudwatch_metric_alarm" "db_memory_alarm" {
   count               = var.db-instance-count
   alarm_name          = "${var.Env-Name}-db-memory-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "sessions_db_storage_alarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "db_burstbalancealarm" {
+resource "aws_cloudwatch_metric_alarm" "db_burst_balance_alarm" {
   count               = var.db-instance-count
   alarm_name          = "${var.Env-Name}-db-burstbalanace-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
@@ -78,7 +78,7 @@ resource "aws_cloudwatch_metric_alarm" "db_burstbalancealarm" {
   treat_missing_data = "missing"
 }
 
-resource "aws_cloudwatch_metric_alarm" "rr_burstbalancealarm" {
+resource "aws_cloudwatch_metric_alarm" "rr_burst_balance_alarm" {
   count               = var.db-replica-count
   alarm_name          = "${var.Env-Name}-rr-burstbalanace-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
@@ -98,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_burstbalancealarm" {
   treat_missing_data = "missing"
 }
 
-resource "aws_cloudwatch_metric_alarm" "rr_laggingalarm" {
+resource "aws_cloudwatch_metric_alarm" "rr_lagging_alarm" {
   count               = var.db-replica-count
   alarm_name          = "${var.Env-Name}-rr-lagging-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_laggingalarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "rr_cpualarm" {
+resource "aws_cloudwatch_metric_alarm" "rr_cpu_alarm" {
   count               = var.db-replica-count
   alarm_name          = "${var.Env-Name}-rr-cpu-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -138,7 +138,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_cpualarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "rr_memoryalarm" {
+resource "aws_cloudwatch_metric_alarm" "rr_memory_alarm" {
   count               = var.db-replica-count
   alarm_name          = "${var.Env-Name}-rr-memory-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
@@ -158,7 +158,7 @@ resource "aws_cloudwatch_metric_alarm" "rr_memoryalarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "rr_storagealarm" {
+resource "aws_cloudwatch_metric_alarm" "rr_storage_alarm" {
   count               = var.db-replica-count
   alarm_name          = "${var.Env-Name}-rr-storage-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"

--- a/govwifi-backend/user-db-alarms.tf
+++ b/govwifi-backend/user-db-alarms.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_metric_alarm" "user_db_cpu_alarm" {
   count               = var.db-instance-count
-  alarm_name          = "${var.env}-user--db-cpu-alarm"
+  alarm_name          = "${var.env}-user-db-cpu-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"

--- a/govwifi-backend/user-db-alarms.tf
+++ b/govwifi-backend/user-db-alarms.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_metric_alarm" "user_db_cpu_alarm" {
     DBInstanceIdentifier = aws_db_instance.users_db[0].identifier
   }
 
-  alarm_description  = "This metric monitors the cpu utilization of the User DB."
+  alarm_description  = "Database CPU utilization exceeding threshold. Investigate database logs for root cause."
   alarm_actions      = [var.critical-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "user_db_memory_alarm" {
     DBInstanceIdentifier = aws_db_instance.users_db[0].identifier
   }
 
-  alarm_description  = "This metric monitors the freeable memory available for the DB."
+  alarm_description  = "Database is running low on free memory. Investigate database logs for root cause."
   alarm_actions      = [var.critical-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_metric_alarm" "user_db_storage_alarm" {
     DBInstanceIdentifier = aws_db_instance.users_db[0].identifier
   }
 
-  alarm_description  = "This metric monitors the storage space available for the DB."
+  alarm_description  = "Database is running low on free storage space. Investigate database logs for root cause."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -74,7 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_burst_balance_alarm" {
     DBInstanceIdentifier = aws_db_instance.users_read_replica[0].identifier
   }
 
-  alarm_description  = "This metric monitors the IOPS burst balance available for the DB read replica."
+  alarm_description  = "Read replica database's available IOPS burst balance is running low. Investigate disk usage on the RDS instance."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "missing"
 }
@@ -94,7 +94,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_lagging_alarm" {
     DBInstanceIdentifier = aws_db_instance.users_read_replica[0].identifier
   }
 
-  alarm_description  = "This metric monitors the Replication Lag for the DB read replica."
+  alarm_description  = "Read replica database replication lag exceeding threshold. Investigate connections to the primary database."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -114,7 +114,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_cpu_alarm" {
     DBInstanceIdentifier = aws_db_instance.users_read_replica[0].identifier
   }
 
-  alarm_description  = "This metric monitors the cpu utilization of the DB read replica."
+  alarm_description  = "Read replica database CPU utilization exceeding threshold. Investigate database logs for root cause."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -134,7 +134,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_memory_alarm" {
     DBInstanceIdentifier = aws_db_instance.users_read_replica[0].identifier
   }
 
-  alarm_description  = "This metric monitors the freeable memory available for the DB read replica."
+  alarm_description  = "Read replica database is running low on free memory. Investigate database logs for root cause."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "breaching"
 }
@@ -155,7 +155,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_storage_alarm" {
     DBInstanceIdentifier = aws_db_instance.users_read_replica[0].identifier
   }
 
-  alarm_description  = "This metric monitors the storage space available for the DB read replica."
+  alarm_description  = "Read replica database is running low on free storage space. Investigate database logs for root cause."
   alarm_actions      = [var.capacity-notifications-arn]
   treat_missing_data = "breaching"
 }

--- a/govwifi-backend/user-db-alarms.tf
+++ b/govwifi-backend/user-db-alarms.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_metric_alarm" "user_db_cpualarm" {
+resource "aws_cloudwatch_metric_alarm" "user_db_cpu_alarm" {
   count               = var.db-instance-count
   alarm_name          = "${var.env}-user--db-cpu-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -18,7 +18,7 @@ resource "aws_cloudwatch_metric_alarm" "user_db_cpualarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "user_db_memoryalarm" {
+resource "aws_cloudwatch_metric_alarm" "user_db_memory_alarm" {
   count               = var.db-instance-count
   alarm_name          = "${var.env}-user-db-memory-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_metric_alarm" "user_db_storage_alarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "user_rr_burstbalancealarm" {
+resource "aws_cloudwatch_metric_alarm" "user_rr_burst_balance_alarm" {
   count               = var.user-db-replica-count
   alarm_name          = "${var.env}-user-rr-burstbalanace-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_burstbalancealarm" {
   treat_missing_data = "missing"
 }
 
-resource "aws_cloudwatch_metric_alarm" "user_rr_laggingalarm" {
+resource "aws_cloudwatch_metric_alarm" "user_rr_lagging_alarm" {
   count               = var.user-db-replica-count
   alarm_name          = "${var.env}-user-rr-lagging-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -99,7 +99,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_laggingalarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "user_rr_cpualarm" {
+resource "aws_cloudwatch_metric_alarm" "user_rr_cpu_alarm" {
   count               = var.user-db-replica-count
   alarm_name          = "${var.env}-user-rr-cpu-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -119,7 +119,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_cpualarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "user_rr_memoryalarm" {
+resource "aws_cloudwatch_metric_alarm" "user_rr_memory_alarm" {
   count               = var.user-db-replica-count
   alarm_name          = "${var.env}-user-rr-memory-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
@@ -139,7 +139,7 @@ resource "aws_cloudwatch_metric_alarm" "user_rr_memoryalarm" {
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "user_rr_storagealarm" {
+resource "aws_cloudwatch_metric_alarm" "user_rr_storage_alarm" {
   count               = var.user-db-replica-count
   alarm_name          = "${var.env}-user-rr-storage-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"

--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_metric_alarm" "radius-healthcheck" {
     var.route53-critical-notifications-arn,
   ]
 
-  alarm_description = "Route53 healthcheck request failed to authenticate via FreeRADIUS and Authentication API."
+  alarm_description = "Route53 healthcheck request failed to authenticate via FreeRADIUS and Authentication API. Investigate CloudWatch logs for root cause."
 }
 
 # TODO: This requires a more up to date version of the AWS provider to work
@@ -64,7 +64,7 @@ resource "aws_cloudwatch_metric_alarm" "radius-latency" {
     var.route53-critical-notifications-arn,
   ]
 
-  alarm_description = "FreeRADIUS response rate is slow (greater than 1s)."
+  alarm_description = "FreeRADIUS response rate is slow (greater than 1s). Investigate CloudWatch logs for root cause."
 }
 
 resource "aws_cloudwatch_metric_alarm" "radius-cannot-connect-to-api" {
@@ -82,6 +82,6 @@ resource "aws_cloudwatch_metric_alarm" "radius-cannot-connect-to-api" {
     var.devops-notifications-arn,
   ]
 
-  alarm_description = "FreeRADIUS cannot connect to the Logging and/or Authentication API."
+  alarm_description = "FreeRADIUS cannot connect to the Logging and/or Authentication API. Investigate CloudWatch logs for root cause."
 }
 

--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_metric_alarm" "radius-hc" {
+resource "aws_cloudwatch_metric_alarm" "radius-healthcheck" {
   provider = aws.route53-alarms
   count    = var.radius-instance-count
   alarm_name = "${element(
@@ -21,6 +21,8 @@ resource "aws_cloudwatch_metric_alarm" "radius-hc" {
   alarm_actions = [
     var.route53-critical-notifications-arn,
   ]
+
+  alarm_description = "Route53 healthcheck request failed to authenticate via FreeRADIUS and Authentication API."
 }
 
 # TODO: This requires a more up to date version of the AWS provider to work
@@ -61,6 +63,8 @@ resource "aws_cloudwatch_metric_alarm" "radius-latency" {
   alarm_actions = [
     var.route53-critical-notifications-arn,
   ]
+
+  alarm_description = "FreeRADIUS response rate is slow (greater than 1s)."
 }
 
 resource "aws_cloudwatch_metric_alarm" "radius-cannot-connect-to-api" {
@@ -77,5 +81,7 @@ resource "aws_cloudwatch_metric_alarm" "radius-cannot-connect-to-api" {
   alarm_actions = [
     var.devops-notifications-arn,
   ]
+
+  alarm_description = "FreeRADIUS cannot connect to the Logging and/or Authentication API."
 }
 

--- a/govwifi-grafana/alarms.tf
+++ b/govwifi-grafana/alarms.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_metric_alarm" "grafana-instance-status" {
 
   alarm_name         = "${var.Env-Name}-grafana-instance-status"
-  alarm_description  = "Alert in event of ${var.Env-Name}-granfana EC2 on instance Status Check failure"
+  alarm_description  = "Alert in event of ${var.Env-Name}-grafana EC2 on instance Status Check failure. Investigate Grafana CloudWatch logs for root cause."
   alarm_actions      = [var.critical-notifications-arn]
   treat_missing_data = "breaching"
 
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_metric_alarm" "grafana-instance-status" {
 resource "aws_cloudwatch_metric_alarm" "grafana-system-status" {
 
   alarm_name         = "${var.Env-Name}-grafana-system-status"
-  alarm_description  = "Alert in event of ${var.Env-Name}-granfana EC2 on system Status Check failure"
+  alarm_description  = "Alert in event of ${var.Env-Name}-grafana EC2 on system Status Check failure. Investigate Grafana CloudWatch logs for root cause."
   alarm_actions      = [var.critical-notifications-arn]
   treat_missing_data = "breaching"
 
@@ -43,7 +43,7 @@ resource "aws_cloudwatch_metric_alarm" "grafana-system-status" {
 resource "aws_cloudwatch_metric_alarm" "grafana-service-status" {
 
   alarm_name         = "${var.Env-Name}-grafana-service-status"
-  alarm_description  = "Alert in event of ${var.Env-Name}-granfana can not load the login page. This likely indicates the Grafana service is not running"
+  alarm_description  = "Alert in event of ${var.Env-Name}-grafana can not load the login page. This likely indicates the Grafana service is not running."
   alarm_actions      = [var.critical-notifications-arn]
   treat_missing_data = "breaching"
 


### PR DESCRIPTION
### What

* Add missing descriptions from alerts.
* Refactor alert descriptions to describe the scenario causing the alert to go off and include a diagnostic action.
* Fix typos in a few alerts.
* Add Sessions DB name to relevant alerts.

**The changes have been applied to the staging components.**

### Why

Alert descriptions should provide enough context for an RE/dev to quickly identify what the symptom is and how to begin to diagnose it. This makes it easier when an alert goes off to get to the root cause, potentially saving time.

I've tried to include a diagnostic action on all the alerts even if they're a bit generic (i.e., look in CloudWatch logs). For a new joiner that could be helpful information even thought it may seem obvious to experienced GovWifi REs/devs.


[Link to Trello card](https://trello.com/c/mFSTl7cn/1531-add-descriptions-to-cloudwatch-alerts).
