### PR TITLE
Switch to administrator-IPs as a list

### DIFF
--- a/govwifi-account/variables.tf
+++ b/govwifi-account/variables.tf
@@ -3,8 +3,3 @@ variable "aws-account-id" {
 
 variable "administrator-IPs" {
 }
-
-variable "administrator-IPs-list" {
-  type = list(string)
-}
-

--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -92,7 +92,7 @@ resource "aws_security_group" "be-vpn-in" {
     protocol  = "tcp"
 
     # Temporarily add ITHC IPs. Remove when ITHC complete.
-    cidr_blocks = distinct(split(",", var.administrator-IPs))
+    cidr_blocks = var.administrator-IPs
   }
 }
 

--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "grafana-alb-in" {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = distinct(split(",", var.administrator-IPs))
+    cidr_blocks = var.administrator-IPs
   }
 }
 

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -139,10 +139,6 @@ variable "backend-subnet-IPs-list" {
   description = "Unused in this configuration"
 }
 
-variable "administrator-IPs-list" {
-  description = "Unused in this configuration"
-}
-
 variable "use_env_prefix" {
   default     = true
   type        = bool

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -105,10 +105,6 @@ variable "prometheus-IP-ireland" {
 variable "grafana-IP" {
 }
 
-variable "administrator-IPs-list" {
-  description = "Unused in this configuration"
-}
-
 variable "backend-subnet-IPs-list" {
   description = "Unused in this configuration"
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -62,10 +62,9 @@ module "govwifi-account" {
     aws = aws.AWS-main
   }
 
-  source                 = "../../govwifi-account"
-  aws-account-id         = local.aws_account_id
-  administrator-IPs      = var.administrator-IPs
-  administrator-IPs-list = split(",", var.administrator-IPs)
+  source            = "../../govwifi-account"
+  aws-account-id    = local.aws_account_id
+  administrator-IPs = var.administrator-IPs
 }
 
 # ====================================================================

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -144,11 +144,6 @@ variable "prometheus-IP-ireland" {
 variable "grafana-IP" {
 }
 
-variable "administrator-IPs-list" {
-  type        = list(string)
-  description = "Administrator allowed IPs (VPN IPs)"
-}
-
 variable "gds-slack-channel-id" {
 }
 

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -133,10 +133,6 @@ variable "prometheus-IP-ireland" {
 variable "grafana-IP" {
 }
 
-variable "administrator-IPs-list" {
-  description = "Unused in this configuration"
-}
-
 variable "backend-subnet-IPs-list" {
   description = "Unused in this configuration"
 }


### PR DESCRIPTION
### What
Switch to administrator-IPs as a list

### Why
Since it is a list, it's easier to define as one, rather than a comma
separated string.