### PR TITLE
Make make lint and make format work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,13 @@ delete-secrets: .private
 lint: lint-terraform
 format: format-terraform
 
+.PHONY: lint-terraform
 lint-terraform:
-	terraform fmt -check=true -diff=true
+	terraform fmt -recursive -diff -check .
 
+.PHONY: format-terraform
 format-terraform:
-	terraform fmt
+	terraform fmt -recursive -diff .
 
 .private:
 	git clone git@github.com:alphagov/govwifi-build.git .private


### PR DESCRIPTION
### What
Make make lint and make format work. Also mark the targets as PHONY, because they are.

### Why
I'm not sure if I'm just using the Makefile incorrectly, but with
these changes, both make lint and make format actually do things.
