### PR TITLE
Provide admin API access to google backup credentials

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -123,6 +123,9 @@ resource "aws_ecs_task_definition" "admin-task" {
           "name": "DEVISE_SECRET_KEY",
           "valueFrom": "${data.aws_secretsmanager_secret_version.key_base.arn}:secret-key-base::"
         },{
+          "name": "GOOGLE_SERVICE_ACCOUNT_BACKUP_CREDENTIALS",
+          "valueFrom": "${data.aws_secretsmanager_secret_version.google_service_account_backup_credentials.arn}:credentials::"
+        },{
           "name": "NOTIFY_API_KEY",
           "valueFrom": "${data.aws_secretsmanager_secret_version.notify_api_key.arn}:notify-api-key::"
         },{

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -137,7 +137,8 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret_version.otp_encryption_key.arn,
       data.aws_secretsmanager_secret_version.session_db.arn,
       data.aws_secretsmanager_secret_version.users_db.arn,
-      data.aws_secretsmanager_secret_version.admin_db.arn
+      data.aws_secretsmanager_secret_version.admin_db.arn,
+      data.aws_secretsmanager_secret_version.google_service_account_backup_credentials.arn,
     ]
   }
 }

--- a/govwifi-admin/secrets-manager.tf
+++ b/govwifi-admin/secrets-manager.tf
@@ -53,3 +53,12 @@ data "aws_secretsmanager_secret_version" "admin_db" {
 data "aws_secretsmanager_secret" "admin_db" {
   name = var.use_env_prefix ? "staging/rds/admin-db/credentials" : "rds/admin-db/credentials"
 }
+
+data "aws_secretsmanager_secret_version" "google_service_account_backup_credentials" {
+  secret_id = data.aws_secretsmanager_secret.google_service_account_backup_credentials.id
+}
+
+data "aws_secretsmanager_secret" "google_service_account_backup_credentials" {
+  name = "admin/google-service-account-backup-credentials"
+}
+


### PR DESCRIPTION
### What

* Allow Admin ECS task to access google-service-account-backup-credentials secret in Secrets Manager
* Fix typo: comma was omitted

### Why

This is part of a larger piece of work to backup service emails in case of a catastrophic AWS failure/disaster.

[Link to Trello card](https://trello.com/c/cofhRdNA/1517-admin-back-up-list) 
