### PR TITLE
Update frontend AMIs

### DIFF
--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -78,26 +78,20 @@ log_group_name = ${var.Env-Name}/var/log/messages
 log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
 datetime_format = %b %d %H:%M:%S
 
-[/var/log/docker]
-file = /var/log/docker
-log_group_name = ${var.Env-Name}/var/log/docker
-log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
-datetime_format = %Y-%m-%dT%H:%M:%S.%f
-
 [/var/log/ecs/ecs-init.log]
-file = /var/log/ecs/ecs-init.log.*
+file = /var/log/ecs/ecs-init.log
 log_group_name = ${var.Env-Name}/var/log/ecs/ecs-init.log
 log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
 datetime_format = %Y-%m-%dT%H:%M:%SZ
 
 [/var/log/ecs/ecs-agent.log]
-file = /var/log/ecs/ecs-agent.log.*
+file = /var/log/ecs/ecs-agent.log
 log_group_name = ${var.Env-Name}/var/log/ecs/ecs-agent.log
 log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
 datetime_format = %Y-%m-%dT%H:%M:%SZ
 
 [/var/log/ecs/audit.log]
-file = /var/log/ecs/audit.log.*
+file = /var/log/ecs/audit.log
 log_group_name = ${var.Env-Name}/var/log/ecs/audit.log
 log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
 datetime_format = %Y-%m-%dT%H:%M:%SZ

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -33,73 +33,17 @@ repo_upgrade: all
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
-sudo yum install perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https -y
-sudo yum -y install perl-Digest-SHA perl-URI perl-libwww-perl perl-MIME-tools perl-Crypt-SSLeay perl-XML-LibXML unzip curl
-mkdir -p /home/ec2-user/scripts
-cd /home/ec2-user/scripts
-curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O
-unzip CloudWatchMonitoringScripts-1.2.2.zip
-rm CloudWatchMonitoringScripts-1.2.2.zip
-mv aws-scripts-mon /home/ec2-user/scripts/mon
-
---==BOUNDARY==
-MIME-Version: 1.0
-Content-Type: text/x-shellscript; charset="us-ascii"
-#!/bin/bash
-sudo yum install perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https -y
-sudo yum -y install perl-Digest-SHA perl-URI perl-libwww-perl perl-MIME-tools perl-Crypt-SSLeay perl-XML-LibXML unzip
-mkdir -p /home/ec2-user/scripts
-cd /home/ec2-user/scripts
-curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O
-unzip CloudWatchMonitoringScripts-1.2.2.zip
-rm CloudWatchMonitoringScripts-1.2.2.zip
-mv aws-scripts-mon /home/ec2-user/scripts/mon
-cd /home/ec2-user/scripts/mon
-
---==BOUNDARY==
-MIME-Version: 1.0
-Content-Type: text/x-shellscript; charset="us-ascii"
-#!/bin/bash
 # Set up daily security updates
-# Stagger restart time based on local IP (assigned randomly)
-# Restarting all backends before the frontends start their staggered nighly restarts
 
-IP=`hostname | sed -r 's/.*-([0-9]+)$/\1/'`
-MINS=$(( $IP % 59 ))
+yum install --assumeyes yum-cron
 
-cat <<EOF > ./crontab
-SHELL=/bin/bash
-PATH=/sbin:/bin:/usr/sbin:/usr/bin
-MAILTO=root
-HOME=/
+# The default is for all updates, switch to just security updates
+sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
 
-# For details see man 4 crontabs
+# Actually apply updates, rather than just downloading them
+sed -i 's/apply_updates = no/apply_updates = yes/' /etc/yum/yum-cron.conf
 
-# Example of job definition:
-# .---------------- minute (0 - 59)
-# |  .------------- hour (0 - 23)
-# |  |  .---------- day of month (1 - 31)
-# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
-# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
-# |  |  |  |  |
-# *  *  *  *  * user-name command to be executed
-
-* * * * * root /home/ec2-user/scripts/mon/mon-put-instance-data.pl --mem-used --from-cron --mem-avail --swap-used --mem-used-incl-cache-buff
-42 * * * * root   run-parts /etc/cron.hourly
-$MINS 0 * * * root   run-parts /etc/cron.daily
-
-EOF
-
-sudo cp ./crontab /etc/crontab
-
-cat <<'EOF' > ./security-updates
-#!/bin/bash
-sudo yum update -y --security
-sudo yum update -y ecs-init
-EOF
-
-chmod +x ./security-updates
-sudo cp ./security-updates /etc/cron.daily
+chkconfig yum-cron on
 
 --==BOUNDARY==
 MIME-Version: 1.0
@@ -112,8 +56,11 @@ echo ECS_CLUSTER=${aws_ecs_cluster.frontend-cluster.name} >> /etc/ecs/ecs.config
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
-# Install awslogs and the jq JSON parser
-yum install -y awslogs jq
+
+yum install --assumeyes amazon-cloudwatch-agent awslogs
+
+# Send CloudWatch Logs data to the region where the instance is located
+sed -i -e "s/region = us-east-1/region = ${var.aws-region}/g" /etc/awslogs/awscli.conf
 
 # Inject the CloudWatch Logs configuration file contents
 cat > /etc/awslogs/awslogs.conf <<- EOF
@@ -123,86 +70,44 @@ state_file = /var/lib/awslogs/agent-state
 [/var/log/dmesg]
 file = /var/log/dmesg
 log_group_name = ${var.Env-Name}/var/log/dmesg
-log_stream_name = {cluster}/{container_instance_id}
+log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
 
 [/var/log/messages]
 file = /var/log/messages
 log_group_name = ${var.Env-Name}/var/log/messages
-log_stream_name = {cluster}/{container_instance_id}
+log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
 datetime_format = %b %d %H:%M:%S
 
 [/var/log/docker]
 file = /var/log/docker
 log_group_name = ${var.Env-Name}/var/log/docker
-log_stream_name = {cluster}/{container_instance_id}
+log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
 datetime_format = %Y-%m-%dT%H:%M:%S.%f
 
 [/var/log/ecs/ecs-init.log]
 file = /var/log/ecs/ecs-init.log.*
 log_group_name = ${var.Env-Name}/var/log/ecs/ecs-init.log
-log_stream_name = {cluster}/{container_instance_id}
+log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
 datetime_format = %Y-%m-%dT%H:%M:%SZ
 
 [/var/log/ecs/ecs-agent.log]
 file = /var/log/ecs/ecs-agent.log.*
 log_group_name = ${var.Env-Name}/var/log/ecs/ecs-agent.log
-log_stream_name = {cluster}/{container_instance_id}
+log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
 datetime_format = %Y-%m-%dT%H:%M:%SZ
 
 [/var/log/ecs/audit.log]
 file = /var/log/ecs/audit.log.*
 log_group_name = ${var.Env-Name}/var/log/ecs/audit.log
-log_stream_name = {cluster}/{container_instance_id}
+log_stream_name = ${aws_ecs_cluster.frontend-cluster.name}/{instance_id}
 datetime_format = %Y-%m-%dT%H:%M:%SZ
 
 EOF
 
---==BOUNDARY==
-MIME-Version: 1.0
-Content-Type: text/x-shellscript; charset="us-ascii"
-#!/bin/bash
-# Disable Anacron
-chmod a-x $(which anacron)
+systemctl enable awslogsd.service
+systemctl start awslogsd.service
 
 --==BOUNDARY==
-MIME-Version: 1.0
-Content-Type: text/x-shellscript; charset="us-ascii"
-#!/bin/bash
-# Set the region to send CloudWatch Logs data to (the region where the container instance is located)
-# region=$(curl 169.254.169.254/latest/meta-data/placement/availability-zone | sed s'/.$//')
-region=${var.aws-region}
-sed -i -e "s/region = us-east-1/region = $region/g" /etc/awslogs/awscli.conf
-
---==BOUNDARY==
-MIME-Version: 1.0
-Content-Type: text/upstart-job; charset="us-ascii"
-
-#upstart-job
-description "Configure and start CloudWatch Logs agent on Amazon ECS container instance"
-author "Amazon Web Services"
-start on started ecs
-
-script
-	exec 2>>/var/log/ecs/cloudwatch-logs-start.log
-	set -x
-
-	until curl -s http://localhost:51678/v1/metadata
-	do
-		sleep 1
-	done
-
-	# Grab the cluster and container instance ARN from instance metadata
-	cluster=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .Cluster')
-	container_instance_id=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .ContainerInstanceArn' | awk -F/ '{print $2}' )
-
-	# Replace the cluster name and container instance ID placeholders with the actual values
-	sed -i -e "s/{cluster}/$cluster/g" /etc/awslogs/awslogs.conf
-	sed -i -e "s/{container_instance_id}/$container_instance_id/g" /etc/awslogs/awslogs.conf
-
-	service awslogs start
-	chkconfig awslogs on
-end script
---==BOUNDARY==--
 
 DATA
 

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -214,8 +214,6 @@ DATA
 
   lifecycle {
     create_before_destroy = true
-
-    ignore_changes = [user_data]
   }
 }
 

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -53,8 +53,8 @@ variable "zone-names" {
 }
 
 variable "ami" {
-  # eu-west-2, Amazon Linux AMI 2017.09.l x86_64 ECS HVM GP2
-  default     = "ami-2218f945"
+  # eu-west-2, Amazon Linux AMI 2.0.20210819 x86_64 ECS HVM GP2
+  default     = "ami-0820c1f2c6fc9dff1"
   description = "AMI id to launch, must be in the region specified by the region variable"
 }
 

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -54,8 +54,8 @@ variable "zone-names" {
 }
 
 variable "ami" {
-  # eu-west-1, Amazon Linux AMI 2017.09.l x86_64 ECS HVM GP2
-  default     = "ami-2d386654"
+  # eu-west-1, Amazon Linux AMI 2.0.20210819 x86_64 ECS HVM GP2
+  default     = "ami-0edfed61b9e44e914"
   description = "AMI id to launch, must be in the region specified by the region variable"
 }
 

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -53,8 +53,8 @@ variable "zone-names" {
 }
 
 variable "ami" {
-  # eu-west-2, Amazon Linux AMI 2017.09.l x86_64 ECS HVM GP2
-  default     = "ami-2218f945"
+  # eu-west-2, Amazon Linux AMI 2.0.20210819 x86_64 ECS HVM GP2
+  default     = "ami-0820c1f2c6fc9dff1"
   description = "AMI id to launch, must be in the region specified by the region variable"
 }
 

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -53,8 +53,8 @@ variable "zone-names" {
 }
 
 variable "ami" {
-  # eu-west-1, Amazon Linux AMI 2017.09.l x86_64 ECS HVM GP2
-  default     = "ami-2d386654"
+  # eu-west-1, Amazon Linux AMI 2.0.20210819 x86_64 ECS HVM GP2
+  default     = "ami-0edfed61b9e44e914"
   description = "AMI id to launch, must be in the region specified by the region variable"
 }
 


### PR DESCRIPTION
### What
Update the AMIs used in govwifi-frontend

Switch from using the Amazon Linux AMI to Amazon Linux 2, this changes
a few things, like switching to systemd as the init system for
example.

As part of this, update and try to simplify the user data. Remove the
CloudWatchMonitoringScripts as they're deprecated, and I'm not sure
what they do. Switch to using yum-cron to provide security
updates. Remove the upstart service for starting the awslogs service,
just set the configuration correctly and then start it with the
script.

### Why
The old AMIs are old.


Link to Trello card (if applicable): https://trello.com/c/lNOuXm9b/1444-story-update-amis-in-staging
