### PR TITLE
Make ECS task point to production ECR image for prod backup

### DIFF
--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -317,7 +317,7 @@ module "api" {
   user-signup-docker-image      = format("%s/user-signup-api:production", local.docker_image_path)
   logging-docker-image          = format("%s/logging-api:production", local.docker_image_path)
   safe-restart-docker-image     = format("%s/safe-restarter:production", local.docker_image_path)
-  backup-rds-to-s3-docker-image = format("%s/database-backup:staging", local.docker_image_path)
+  backup-rds-to-s3-docker-image = format("%s/database-backup:production", local.docker_image_path)
 
   db-hostname               = "db.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   db-read-replica-hostname  = "rr.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"


### PR DESCRIPTION
### What

Ensure database backup ECS task points to the relevant production ECR image for production backups. 

Backup task was pointing to staging ECR image instead of production. This looks like a copy/paste error which we didn't catch.

### Why

Our ECS task should point to the production ECR image. The typo isn't egregious, the production image is a promoted and relabelled version of the staging image output which we've thoroughly tested.

However, it's a typo and could be come a problematic red herring unless addressed.