### PR TITLE
Change the user for the amazon-cloudwatch-agent on frontend machines

### DIFF
--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -63,8 +63,7 @@ yum install --assumeyes amazon-cloudwatch-agent
 cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json << EOF
 {
   "agent": {
-    "metrics_collection_interval": 60,
-    "run_as_user": "cwagent"
+    "metrics_collection_interval": 60
   },
   "logs": {
     "logs_collected": {


### PR DESCRIPTION
### What
I just picked the cwagent user in the wizard, but it doesn't have
permission to read the relevant logs. So change the behaviour to the
default, which is the root user.

### Why
So that the amazon-cloudwatch-agent can read the log files.