### PR TITLE
Use underscores for resource names in govwifi-frontend

### DIFF
--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_metric_alarm" "radius-healthcheck" {
+resource "aws_cloudwatch_metric_alarm" "radius_healthcheck" {
   provider = aws.route53-alarms
   count    = var.radius-instance-count
   alarm_name = "${element(
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "radius-healthcheck" {
 #   alarm_rule = join(" AND ", formatlist("ALARM(\"%s\")", aws_cloudwatch_metric_alarm.radius-hc[*].alarm_name))
 # }
 
-resource "aws_cloudwatch_metric_alarm" "radius-latency" {
+resource "aws_cloudwatch_metric_alarm" "radius_latency" {
   provider = aws.route53-alarms
   count    = var.radius-instance-count
   alarm_name = "${element(
@@ -67,7 +67,7 @@ resource "aws_cloudwatch_metric_alarm" "radius-latency" {
   alarm_description = "FreeRADIUS response rate is slow (greater than 1s). Investigate CloudWatch logs for root cause."
 }
 
-resource "aws_cloudwatch_metric_alarm" "radius-cannot-connect-to-api" {
+resource "aws_cloudwatch_metric_alarm" "radius_cannot_connect_to_api" {
   alarm_name          = "${var.Env-Name}-radius-cannot-connect-to-api"
   comparison_operator = "GreaterThanThreshold"
   threshold           = 0
@@ -75,8 +75,8 @@ resource "aws_cloudwatch_metric_alarm" "radius-cannot-connect-to-api" {
   period              = "60"
   statistic           = "Sum"
   treat_missing_data  = "breaching"
-  metric_name         = aws_cloudwatch_log_metric_filter.radius-cannot-connect-to-api.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.radius-cannot-connect-to-api.metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.radius_cannot_connect_to_api.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.radius_cannot_connect_to_api.metric_transformation[0].namespace
 
   alarm_actions = [
     var.devops-notifications-arn,

--- a/govwifi-frontend/certs.tf
+++ b/govwifi-frontend/certs.tf
@@ -1,4 +1,4 @@
-resource "aws_s3_bucket" "frontend-cert-bucket" {
+resource "aws_s3_bucket" "frontend_cert_bucket" {
   count  = 1
   bucket = var.is_production_aws_account ? "govwifi-${var.rack-env}-${lower(var.aws-region-name)}-frontend-cert" : "govwifi-${var.Env-Subdomain}-${lower(var.aws-region-name)}-frontend-cert"
   acl    = "private"

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -1,33 +1,33 @@
 # Create ECS Cluster
 
-resource "aws_ecs_cluster" "frontend-cluster" {
+resource "aws_ecs_cluster" "frontend_cluster" {
   name = "${var.Env-Name}-frontend-cluster"
 }
 
-resource "aws_cloudwatch_log_group" "frontend-log-group" {
+resource "aws_cloudwatch_log_group" "frontend_log_group" {
   name = "${var.Env-Name}-frontend-docker-log-group"
 
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "govwifi-frontend-ecr" {
+resource "aws_ecr_repository" "govwifi_frontend_ecr" {
   count = var.create-ecr
   name  = "govwifi/frontend"
 }
 
-resource "aws_ecr_repository" "govwifi-frontend-base-ecr" {
+resource "aws_ecr_repository" "govwifi_frontend_base_ecr" {
   count = var.create-ecr
   name  = "govwifi/frontend-base"
 }
 
-resource "aws_ecr_repository" "govwifi-raddb-ecr" {
+resource "aws_ecr_repository" "govwifi_raddb_ecr" {
   count = var.create-ecr
   name  = "govwifi/raddb"
 }
 
-resource "aws_ecs_task_definition" "radius-task" {
+resource "aws_ecs_task_definition" "radius_task" {
   family             = "radius-task-${var.Env-Name}"
-  task_role_arn      = aws_iam_role.ecs-task-role.arn
+  task_role_arn      = aws_iam_role.ecs_task_role.arn
   execution_role_arn = aws_iam_role.ecsTaskExecutionRole.arn
 
   volume {
@@ -116,7 +116,7 @@ resource "aws_ecs_task_definition" "radius-task" {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "${aws_cloudwatch_log_group.frontend-log-group.name}",
+        "awslogs-group": "${aws_cloudwatch_log_group.frontend_log_group.name}",
         "awslogs-region": "${var.aws-region}",
         "awslogs-stream-prefix": "${var.Env-Name}-docker-logs"
       }
@@ -145,14 +145,14 @@ resource "aws_ecs_task_definition" "radius-task" {
         "value": "s3://${var.admin-bucket-name}"
       },{
         "name": "CERT_STORE_BUCKET",
-        "value": "s3://${aws_s3_bucket.frontend-cert-bucket[0].bucket}"
+        "value": "s3://${aws_s3_bucket.frontend_cert_bucket[0].bucket}"
       }
     ],
     "image": "${var.raddb-docker-image}",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "${aws_cloudwatch_log_group.frontend-log-group.name}",
+        "awslogs-group": "${aws_cloudwatch_log_group.frontend_log_group.name}",
         "awslogs-region": "${var.aws-region}",
         "awslogs-stream-prefix": "${var.Env-Name}-docker-logs"
       }
@@ -166,10 +166,10 @@ EOF
 
 }
 
-resource "aws_ecs_service" "frontend-service" {
+resource "aws_ecs_service" "frontend_service" {
   name            = "frontend-service-${var.Env-Name}"
-  cluster         = aws_ecs_cluster.frontend-cluster.id
-  task_definition = aws_ecs_task_definition.radius-task.arn
+  cluster         = aws_ecs_cluster.frontend_cluster.id
+  task_definition = aws_ecs_task_definition.radius_task.arn
   desired_count   = var.radius-instance-count
 
   ordered_placement_strategy {

--- a/govwifi-frontend/eips.tf
+++ b/govwifi-frontend/eips.tf
@@ -1,4 +1,4 @@
-resource "aws_eip" "radius-eips" {
+resource "aws_eip" "radius_eips" {
   count = var.radius-instance-count
   vpc   = true
 

--- a/govwifi-frontend/frontend.tf
+++ b/govwifi-frontend/frontend.tf
@@ -1,7 +1,7 @@
 # AWS Configuration
 # CREATE VPC
 
-resource "aws_vpc" "wifi-frontend" {
+resource "aws_vpc" "wifi_frontend" {
   cidr_block           = var.vpc-cidr-block
   enable_dns_hostnames = true
 
@@ -12,8 +12,8 @@ resource "aws_vpc" "wifi-frontend" {
 
 # CREATE GATEWAY AND DEFAULT ROUTE
 
-resource "aws_internet_gateway" "wifi-frontend" {
-  vpc_id = aws_vpc.wifi-frontend.id
+resource "aws_internet_gateway" "wifi_frontend" {
+  vpc_id = aws_vpc.wifi_frontend.id
 
   tags = {
     Name = "Frontend Internet GW - ${var.Env-Name}"
@@ -21,16 +21,16 @@ resource "aws_internet_gateway" "wifi-frontend" {
 }
 
 resource "aws_route" "internet_access" {
-  route_table_id         = aws_vpc.wifi-frontend.main_route_table_id
+  route_table_id         = aws_vpc.wifi_frontend.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.wifi-frontend.id
+  gateway_id             = aws_internet_gateway.wifi_frontend.id
 }
 
 # CREATE SUBNET IN EACH AZ
 
-resource "aws_subnet" "wifi-frontend-subnet" {
+resource "aws_subnet" "wifi_frontend_subnet" {
   count                   = var.zone-count
-  vpc_id                  = aws_vpc.wifi-frontend.id
+  vpc_id                  = aws_vpc.wifi_frontend.id
   availability_zone       = var.zone-names[format("zone%d", count.index)]
   cidr_block              = var.zone-subnets[format("zone%d", count.index)]
   map_public_ip_on_launch = true

--- a/govwifi-frontend/iam-roles.tf
+++ b/govwifi-frontend/iam-roles.tf
@@ -2,9 +2,9 @@ locals {
   admin-bucket-arn = "arn:aws:s3:::${var.admin-bucket-name}"
 }
 
-resource "aws_iam_role_policy" "ecs-instance-policy" {
+resource "aws_iam_role_policy" "ecs_instance_policy" {
   name = "${var.aws-region-name}-frontend-ecs-instance-policy-${var.Env-Name}"
-  role = aws_iam_role.ecs-instance-role.id
+  role = aws_iam_role.ecs_instance_role.id
 
   policy = <<EOF
 {
@@ -55,7 +55,7 @@ EOF
 
 }
 
-resource "aws_iam_role" "ecs-instance-role" {
+resource "aws_iam_role" "ecs_instance_role" {
   name = "${var.aws-region-name}-frontend-ecs-instance-role-${var.Env-Name}"
 
   assume_role_policy = <<EOF
@@ -76,15 +76,15 @@ EOF
 
 }
 
-resource "aws_iam_instance_profile" "ecs-instance-profile" {
+resource "aws_iam_instance_profile" "ecs_instance_profile" {
   name = "${var.aws-region-name}-frontend-ecs-instance-profile-${var.Env-Name}"
-  role = aws_iam_role.ecs-instance-role.name
+  role = aws_iam_role.ecs_instance_role.name
 }
 
 # Unused until a loadbalancer is set up
-resource "aws_iam_role_policy" "ecs-service-policy" {
+resource "aws_iam_role_policy" "ecs_service_policy" {
   name = "${var.aws-region-name}-frontend-ecs-service-policy-${var.Env-Name}"
-  role = aws_iam_role.ecs-task-role.id
+  role = aws_iam_role.ecs_task_role.id
 
   policy = <<EOF
 {
@@ -104,7 +104,7 @@ EOF
 
 }
 
-resource "aws_iam_role" "ecs-task-role" {
+resource "aws_iam_role" "ecs_task_role" {
   name = "${var.aws-region-name}-frontend-ecs-task-role-${var.Env-Name}"
 
   assume_role_policy = <<EOF
@@ -127,7 +127,7 @@ EOF
 
 resource "aws_iam_role_policy" "cert_bucket_policy" {
   name   = "${var.aws-region-name}-frontend-cert-bucket-${var.Env-Name}"
-  role   = aws_iam_role.ecs-task-role.id
+  role   = aws_iam_role.ecs_task_role.id
   policy = data.aws_iam_policy_document.cert_bucket_policy.json
 }
 
@@ -139,15 +139,15 @@ data "aws_iam_policy_document" "cert_bucket_policy" {
     ]
 
     resources = [
-      aws_s3_bucket.frontend-cert-bucket[0].arn,
-      "${aws_s3_bucket.frontend-cert-bucket[0].arn}/*",
+      aws_s3_bucket.frontend_cert_bucket[0].arn,
+      "${aws_s3_bucket.frontend_cert_bucket[0].arn}/*",
     ]
   }
 }
 
 resource "aws_iam_role_policy" "admin_bucket_policy" {
   name   = "${var.aws-region-name}-frontend-admin-bucket-${var.Env-Name}"
-  role   = aws_iam_role.ecs-task-role.id
+  role   = aws_iam_role.ecs_task_role.id
   policy = data.aws_iam_policy_document.admin_bucket_policy.json
 }
 

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -5,17 +5,17 @@ resource "aws_instance" "radius" {
   ami           = var.ami
   instance_type = "t2.medium"
   key_name      = var.ssh-key-name
-  subnet_id     = element(aws_subnet.wifi-frontend-subnet.*.id, count.index)
+  subnet_id     = element(aws_subnet.wifi_frontend_subnet.*.id, count.index)
 
   vpc_security_group_ids = [
-    aws_security_group.fe-ecs-out.id,
-    aws_security_group.fe-admin-in.id,
-    aws_security_group.fe-radius-out.id,
-    aws_security_group.fe-radius-in.id,
-    aws_security_group.fe-prometheus-in.id
+    aws_security_group.fe_ecs_out.id,
+    aws_security_group.fe_admin_in.id,
+    aws_security_group.fe_radius_out.id,
+    aws_security_group.fe_radius_in.id,
+    aws_security_group.fe_prometheus_in.id
   ]
 
-  iam_instance_profile = aws_iam_instance_profile.ecs-instance-profile.id
+  iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.id
   monitoring           = var.enable-detailed-monitoring
 
   user_data = <<DATA
@@ -50,7 +50,7 @@ MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
 # Set cluster name
-echo ECS_CLUSTER=${aws_ecs_cluster.frontend-cluster.name} >> /etc/ecs/ecs.config
+echo ECS_CLUSTER=${aws_ecs_cluster.frontend_cluster.name} >> /etc/ecs/ecs.config
 
 --==BOUNDARY==
 MIME-Version: 1.0

--- a/govwifi-frontend/metrics.tf
+++ b/govwifi-frontend/metrics.tf
@@ -1,8 +1,8 @@
-resource "aws_cloudwatch_log_metric_filter" "auth-shared-secret-incorrect" {
+resource "aws_cloudwatch_log_metric_filter" "auth_shared_secret_incorrect" {
   name = "${var.Env-Name}-auth-shared-secret-incorrect"
 
   pattern        = "\"Shared secret is incorrect\" \"Received packet\""
-  log_group_name = aws_cloudwatch_log_group.frontend-log-group.name
+  log_group_name = aws_cloudwatch_log_group.frontend_log_group.name
 
   metric_transformation {
     name          = "auth-shared-secret-incorrect-count"
@@ -12,11 +12,11 @@ resource "aws_cloudwatch_log_metric_filter" "auth-shared-secret-incorrect" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "accounting-shared-secret-incorrect" {
+resource "aws_cloudwatch_log_metric_filter" "accounting_shared_secret_incorrect" {
   name = "${var.Env-Name}-accounting-shared-secret-incorrect"
 
   pattern        = "\"Shared secret is incorrect\" \"Received Accounting-Request packet\""
-  log_group_name = aws_cloudwatch_log_group.frontend-log-group.name
+  log_group_name = aws_cloudwatch_log_group.frontend_log_group.name
 
   metric_transformation {
     name          = "accounting-shared-secret-incorrect-count"
@@ -26,11 +26,11 @@ resource "aws_cloudwatch_log_metric_filter" "accounting-shared-secret-incorrect"
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "outer-and-inner-identities-same" {
+resource "aws_cloudwatch_log_metric_filter" "outer_and_inner_identities_same" {
   name = "${var.Env-Name}-outer-and-inner-identities-same"
 
   pattern        = "\"Outer and inner identities are the same\""
-  log_group_name = aws_cloudwatch_log_group.frontend-log-group.name
+  log_group_name = aws_cloudwatch_log_group.frontend_log_group.name
 
   metric_transformation {
     name          = "outer-and-inner-identities-same-count"
@@ -40,11 +40,11 @@ resource "aws_cloudwatch_log_metric_filter" "outer-and-inner-identities-same" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "unknown-client" {
+resource "aws_cloudwatch_log_metric_filter" "unknown_client" {
   name = "${var.Env-Name}-unknown-client"
 
   pattern        = "\"unknown client\""
-  log_group_name = aws_cloudwatch_log_group.frontend-log-group.name
+  log_group_name = aws_cloudwatch_log_group.frontend_log_group.name
 
   metric_transformation {
     name          = "unknown-client"
@@ -54,11 +54,11 @@ resource "aws_cloudwatch_log_metric_filter" "unknown-client" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "radius-cannot-connect-to-api" {
+resource "aws_cloudwatch_log_metric_filter" "radius_cannot_connect_to_api" {
   name = "${var.Env-Name}-radius-cannot-connect-to-api"
 
   pattern        = "\"ERROR: Server returned no data\""
-  log_group_name = aws_cloudwatch_log_group.frontend-log-group.name
+  log_group_name = aws_cloudwatch_log_group.frontend_log_group.name
 
   metric_transformation {
     name          = "radius-cannot-connect-to-api"

--- a/govwifi-frontend/outputs.tf
+++ b/govwifi-frontend/outputs.tf
@@ -1,32 +1,32 @@
 output "frontend-vpc-id" {
-  value = aws_vpc.wifi-frontend.id
+  value = aws_vpc.wifi_frontend.id
 }
 
 output "frontend-subnet-id" {
-  value = aws_subnet.wifi-frontend-subnet.*.id
+  value = aws_subnet.wifi_frontend_subnet.*.id
 }
 
 output "fe-admin-in" {
-  value = aws_security_group.fe-admin-in.id
+  value = aws_security_group.fe_admin_in.id
 }
 
 output "fe-ecs-out" {
-  value = aws_security_group.fe-ecs-out.id
+  value = aws_security_group.fe_ecs_out.id
 }
 
 output "fe-radius-in" {
-  value = aws_security_group.fe-radius-in.id
+  value = aws_security_group.fe_radius_in.id
 }
 
 output "fe-radius-out" {
-  value = aws_security_group.fe-radius-out.id
+  value = aws_security_group.fe_radius_out.id
 }
 
 output "ecs-instance-profile" {
-  value = aws_iam_instance_profile.ecs-instance-profile.id
+  value = aws_iam_instance_profile.ecs_instance_profile.id
 }
 
 output "wifi-frontend-subnet" {
-  value = aws_subnet.wifi-frontend-subnet.*.id
+  value = aws_subnet.wifi_frontend_subnet.*.id
 }
 

--- a/govwifi-frontend/security_groups.tf
+++ b/govwifi-frontend/security_groups.tf
@@ -1,9 +1,9 @@
 # ECS Endpoint addresses
 
-resource "aws_security_group" "fe-ecs-out" {
+resource "aws_security_group" "fe_ecs_out" {
   name        = "fe-ecs-out"
   description = "Allow the ECS agent to talk to the ECS endpoints"
-  vpc_id      = aws_vpc.wifi-frontend.id
+  vpc_id      = aws_vpc.wifi_frontend.id
 
   tags = {
     Name = "${title(var.Env-Name)} Frontend ECS out"
@@ -34,10 +34,10 @@ resource "aws_security_group" "fe-ecs-out" {
 
 # Traffic from administrators
 
-resource "aws_security_group" "fe-admin-in" {
+resource "aws_security_group" "fe_admin_in" {
   name        = "fe-admin-in"
   description = "Allow inbound traffic from administrators"
-  vpc_id      = aws_vpc.wifi-frontend.id
+  vpc_id      = aws_vpc.wifi_frontend.id
 
   tags = {
     Name = "${title(var.Env-Name)} Frontend Admin in"
@@ -53,10 +53,10 @@ resource "aws_security_group" "fe-admin-in" {
 
 # Traffic from Prometheus server in London
 
-resource "aws_security_group" "fe-prometheus-in" {
+resource "aws_security_group" "fe_prometheus_in" {
   name        = "fe-prometheus-in"
   description = "Allow inbound traffic from Prometheus server in London"
-  vpc_id      = aws_vpc.wifi-frontend.id
+  vpc_id      = aws_vpc.wifi_frontend.id
 
   tags = {
     Name = "${title(var.Env-Name)} Frontend Prometheus in"
@@ -76,10 +76,10 @@ resource "aws_security_group" "fe-prometheus-in" {
 
 # API access from the RADIUS servers
 
-resource "aws_security_group" "fe-radius-out" {
+resource "aws_security_group" "fe_radius_out" {
   name        = "fe-radius-out"
   description = "Allow outbound API calls from the RADIUS servers"
-  vpc_id      = aws_vpc.wifi-frontend.id
+  vpc_id      = aws_vpc.wifi_frontend.id
 
   tags = {
     Name = "${title(var.Env-Name)} Frontend RADIUS out"
@@ -120,10 +120,10 @@ resource "aws_security_group" "fe-radius-out" {
 
 # RADIUS traffic to the RADIUS servers
 
-resource "aws_security_group" "fe-radius-in" {
+resource "aws_security_group" "fe_radius_in" {
   name        = "fe-radius-in"
   description = "Allow inbound API calls to the RADIUS servers"
-  vpc_id      = aws_vpc.wifi-frontend.id
+  vpc_id      = aws_vpc.wifi_frontend.id
 
   tags = {
     Name = "${title(var.Env-Name)} Frontend RADIUS in"


### PR DESCRIPTION
### What
Try to move towards using underscores rather than dashes, as this is
more consistent with Terraform itself. Just change the resources
within the govwifi-frontend module.

This shouldn't have any effects beyond the names used in Terraform
changing. Unfortunately, when applying this change, either the
existing resources will need to be moved (using the state mv command
for example), or need destroying and re-creating through running
terraform apply.

### Why
This is more consistent with Terraform itself.
