### PR TITLE
Use underscores for resource names in govwifi-api module

### DIFF
--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
+resource "aws_cloudwatch_metric_alarm" "logging_ecs_cpu_alarm_high" {
   count               = var.alarm-count
   alarm_name          = "${var.Env-Name}-logging-ecs-cpu-alarm-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -10,20 +10,20 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-high" {
   threshold           = "50"
 
   dimensions = {
-    ClusterName = aws_ecs_cluster.api-cluster.name
-    ServiceName = aws_ecs_service.logging-api-service[0].name
+    ClusterName = aws_ecs_cluster.api_cluster.name
+    ServiceName = aws_ecs_service.logging_api_service[0].name
   }
 
   alarm_description = "ECS cluster CPU is high, scaling up number of tasks. Investigate api cluster and CloudWatch logs for root cause."
 
   alarm_actions = [
-    aws_appautoscaling_policy.ecs-policy-up-logging[0].arn,
+    aws_appautoscaling_policy.ecs_policy_up_logging[0].arn,
   ]
 
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
+resource "aws_cloudwatch_metric_alarm" "logging_ecs_cpu_alarm_low" {
   count               = var.alarm-count
   alarm_name          = "${var.Env-Name}-downscale-logging-ecs-cpu-low-alarm"
   comparison_operator = "LessThanThreshold"
@@ -36,14 +36,14 @@ resource "aws_cloudwatch_metric_alarm" "logging-ecs-cpu-alarm-low" {
   datapoints_to_alarm = "2"
 
   dimensions = {
-    ClusterName = aws_ecs_cluster.api-cluster.name
-    ServiceName = aws_ecs_service.logging-api-service[0].name
+    ClusterName = aws_ecs_cluster.api_cluster.name
+    ServiceName = aws_ecs_service.logging_api_service[0].name
   }
 
   alarm_description = "ECS cluster CPU is low, scaling down number of tasks to save on cost."
 
   alarm_actions = [
-    aws_appautoscaling_policy.ecs-policy-down-logging[0].arn,
+    aws_appautoscaling_policy.ecs_policy_down_logging[0].arn,
   ]
 }
 

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-high" {
+resource "aws_cloudwatch_metric_alarm" "auth_ecs_cpu_alarm_high" {
   count               = var.alarm-count
   alarm_name          = "${var.Env-Name}-auth-ecs-cpu-alarm-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -10,21 +10,21 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-high" {
   threshold           = "50"
 
   dimensions = {
-    ClusterName = aws_ecs_cluster.api-cluster.name
-    ServiceName = aws_ecs_service.authorisation-api-service.name
+    ClusterName = aws_ecs_cluster.api_cluster.name
+    ServiceName = aws_ecs_service.authorisation_api_service.name
   }
 
   alarm_description = "ECS cluster CPU is high, scaling up number of tasks. Investigate api cluster and CloudWatch logs for root cause."
 
   alarm_actions = [
-    aws_appautoscaling_policy.ecs-policy-up.arn,
+    aws_appautoscaling_policy.ecs_policy_up.arn,
     var.devops-notifications-arn,
   ]
 
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
+resource "aws_cloudwatch_metric_alarm" "auth_ecs_cpu_alarm_low" {
   count               = var.alarm-count
   alarm_name          = "${var.Env-Name}-downscale-auth-ecs-cpu-low-alarm"
   comparison_operator = "LessThanThreshold"
@@ -37,20 +37,20 @@ resource "aws_cloudwatch_metric_alarm" "auth-ecs-cpu-alarm-low" {
   datapoints_to_alarm = "1"
 
   dimensions = {
-    ClusterName = aws_ecs_cluster.api-cluster.name
-    ServiceName = aws_ecs_service.authorisation-api-service.name
+    ClusterName = aws_ecs_cluster.api_cluster.name
+    ServiceName = aws_ecs_service.authorisation_api_service.name
   }
 
   alarm_description = "ECS cluster CPU is low, scaling down number of ECS tasks to save on cost."
 
   alarm_actions = [
-    aws_appautoscaling_policy.ecs-policy-down.arn,
+    aws_appautoscaling_policy.ecs_policy_down.arn,
   ]
 
   treat_missing_data = "breaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "authentication-api-no-healthy-hosts" {
+resource "aws_cloudwatch_metric_alarm" "authentication_api_no_healthy_hosts" {
   alarm_name          = "${var.Env-Name} authentication API no healthy hosts"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -62,7 +62,7 @@ resource "aws_cloudwatch_metric_alarm" "authentication-api-no-healthy-hosts" {
   datapoints_to_alarm = "1"
 
   dimensions = {
-    LoadBalancer = aws_lb.api-alb[0].arn_suffix
+    LoadBalancer = aws_lb.api_alb[0].arn_suffix
   }
 
   alarm_description = "Load balancer detects no healthy authentication API targets. Investigate api cluster and CloudWatch logs for root cause."
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "authentication-api-no-healthy-hosts" {
   ])
 }
 
-resource "aws_cloudwatch_metric_alarm" "user-signup-api-no-healthy-hosts" {
+resource "aws_cloudwatch_metric_alarm" "user_signup_api_no_healthy_hosts" {
   count = var.user-signup-enabled
 
   alarm_name          = "${var.Env-Name} user signup API no healthy hosts"
@@ -86,7 +86,7 @@ resource "aws_cloudwatch_metric_alarm" "user-signup-api-no-healthy-hosts" {
   datapoints_to_alarm = "1"
 
   dimensions = {
-    LoadBalancer = aws_lb.user-signup-api[0].arn_suffix
+    LoadBalancer = aws_lb.user_signup_api[0].arn_suffix
   }
 
   alarm_description = "Load balancer detects no healthy user signup API targets. Investigate api ECS cluster and CloudWatch logs for root cause."

--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -1,15 +1,15 @@
-resource "aws_cloudwatch_log_group" "authorisation-api-log-group" {
+resource "aws_cloudwatch_log_group" "authorisation_api_log_group" {
   name = "${var.Env-Name}-authorisation-api-docker-log-group"
 
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "authorisation-api-ecr" {
+resource "aws_ecr_repository" "authorisation_api_ecr" {
   count = var.ecr-repository-count
   name  = "govwifi/authorisation-api"
 }
 
-resource "aws_ecs_task_definition" "authorisation-api-task" {
+resource "aws_ecs_task_definition" "authorisation_api_task" {
   family                   = "authorisation-api-task-${var.Env-Name}"
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
@@ -78,7 +78,7 @@ resource "aws_ecs_task_definition" "authorisation-api-task" {
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "${aws_cloudwatch_log_group.authorisation-api-log-group.name}",
+          "awslogs-group": "${aws_cloudwatch_log_group.authorisation_api_log_group.name}",
           "awslogs-region": "${var.aws-region}",
           "awslogs-stream-prefix": "${var.Env-Name}-authorisation-api-docker-logs"
         }
@@ -92,10 +92,10 @@ EOF
 
 }
 
-resource "aws_ecs_service" "authorisation-api-service" {
+resource "aws_ecs_service" "authorisation_api_service" {
   name             = "authorisation-api-service-${var.Env-Name}"
-  cluster          = aws_ecs_cluster.api-cluster.id
-  task_definition  = aws_ecs_task_definition.authorisation-api-task.arn
+  cluster          = aws_ecs_cluster.api_cluster.id
+  task_definition  = aws_ecs_task_definition.authorisation_api_task.arn
   desired_count    = var.authorisation-api-count
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
@@ -103,8 +103,8 @@ resource "aws_ecs_service" "authorisation-api-service" {
   network_configuration {
     security_groups = concat(
       var.backend-sg-list,
-      [aws_security_group.api-in.id],
-      [aws_security_group.api-out.id],
+      [aws_security_group.api_in.id],
+      [aws_security_group.api_out.id],
     )
 
     subnets          = var.subnet-ids
@@ -135,7 +135,7 @@ resource "aws_alb_listener_rule" "static" {
 }
 
 resource "aws_alb_target_group" "alb_target_group" {
-  depends_on  = [aws_lb.api-alb]
+  depends_on  = [aws_lb.api_alb]
   name        = "api-lb-tg-${var.Env-Name}"
   port        = "8080"
   protocol    = "HTTP"

--- a/govwifi-api/authorisation-metrics.tf
+++ b/govwifi-api/authorisation-metrics.tf
@@ -1,9 +1,9 @@
-resource "aws_cloudwatch_log_metric_filter" "response-status-ok" {
+resource "aws_cloudwatch_log_metric_filter" "response_status_ok" {
   count = 1
   name  = "${var.Env-Name}-response-status-ok"
 
   pattern        = "\"status=200\" -\"user/HEALTH\""
-  log_group_name = aws_cloudwatch_log_group.authorisation-api-log-group.name
+  log_group_name = aws_cloudwatch_log_group.authorisation_api_log_group.name
 
   metric_transformation {
     name          = "${var.Env-Name}-response-status-ok-count"

--- a/govwifi-api/certs.tf
+++ b/govwifi-api/certs.tf
@@ -1,4 +1,4 @@
-resource "aws_acm_certificate" "api-elb-global" {
+resource "aws_acm_certificate" "api_elb_global" {
   count             = var.backend-elb-count
   domain_name       = aws_route53_record.elb_global[0].fqdn
   validation_method = "DNS"
@@ -8,13 +8,13 @@ resource "aws_acm_certificate" "api-elb-global" {
   }
 }
 
-resource "aws_acm_certificate_validation" "api-elb-global" {
+resource "aws_acm_certificate_validation" "api_elb_global" {
   count                   = var.backend-elb-count
-  certificate_arn         = aws_acm_certificate.api-elb-global[0].arn
+  certificate_arn         = aws_acm_certificate.api_elb_global[0].arn
   validation_record_fqdns = [aws_route53_record.elb_global_cert_validation[0].fqdn]
 }
 
-resource "aws_acm_certificate" "api-elb-regional" {
+resource "aws_acm_certificate" "api_elb_regional" {
   count             = var.backend-elb-count
   domain_name       = aws_route53_record.elb[0].fqdn
   validation_method = "DNS"
@@ -24,9 +24,9 @@ resource "aws_acm_certificate" "api-elb-regional" {
   }
 }
 
-resource "aws_acm_certificate_validation" "api-elb-regional" {
+resource "aws_acm_certificate_validation" "api_elb_regional" {
   count                   = var.backend-elb-count
-  certificate_arn         = aws_acm_certificate.api-elb-regional[0].arn
+  certificate_arn         = aws_acm_certificate.api_elb_regional[0].arn
   validation_record_fqdns = [aws_route53_record.elb_regional_cert_validation[0].fqdn]
 }
 

--- a/govwifi-api/cluster.tf
+++ b/govwifi-api/cluster.tf
@@ -1,4 +1,4 @@
-resource "aws_ecs_cluster" "api-cluster" {
+resource "aws_ecs_cluster" "api_cluster" {
   name = "${var.Env-Name}-api-cluster"
 }
 

--- a/govwifi-api/database-backup-task.tf
+++ b/govwifi-api/database-backup-task.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_event_rule" "backup-rds-to-s3" {
+resource "aws_cloudwatch_event_rule" "backup_rds_to_s3" {
   count               = var.backup_mysql_rds ? 1 : 0
   name                = "${var.Env-Name}-backup-rds-to-s3"
   description         = "Triggers at 00:30 UTC Daily"
@@ -6,22 +6,22 @@ resource "aws_cloudwatch_event_rule" "backup-rds-to-s3" {
   is_enabled          = true
 }
 
-resource "aws_cloudwatch_log_group" "backup-rds-to-s3-log-group" {
+resource "aws_cloudwatch_log_group" "backup_rds_to_s3_log_group" {
   count = var.backup_mysql_rds ? 1 : 0
   name  = "${var.Env-Name}-backup-rds-to-s3-docker-log-group"
 
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "database-backup-ecr" {
+resource "aws_ecr_repository" "database_backup_ecr" {
   count = var.ecr-repository-count
   name  = "govwifi/database-backup"
 }
 
-resource "aws_ecs_task_definition" "backup-rds-to-s3-task-definition" {
+resource "aws_ecs_task_definition" "backup_rds_to_s3_task_definition" {
   count                    = var.backup_mysql_rds ? 1 : 0
   family                   = "backup-rds-to-s3-task-${var.Env-Name}"
-  task_role_arn            = aws_iam_role.backup-rds-to-s3-task-role[0].arn
+  task_role_arn            = aws_iam_role.backup_rds_to_s3_task_role[0].arn
   execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
   requires_compatibilities = ["FARGATE"]
   cpu                      = 2048
@@ -112,7 +112,7 @@ resource "aws_ecs_task_definition" "backup-rds-to-s3-task-definition" {
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "${aws_cloudwatch_log_group.backup-rds-to-s3-log-group[0].name}",
+          "awslogs-group": "${aws_cloudwatch_log_group.backup_rds_to_s3_log_group[0].name}",
           "awslogs-region": "${var.aws-region}",
           "awslogs-stream-prefix": "${var.Env-Name}-backup-rds-to-s3-docker-logs"
         }
@@ -126,7 +126,7 @@ EOF
 
 }
 
-resource "aws_iam_role" "backup-rds-to-s3-task-role" {
+resource "aws_iam_role" "backup_rds_to_s3_task_role" {
   count = var.backup_mysql_rds ? 1 : 0
   name  = "${var.Env-Name}-backup-rds-to-s3-task-role"
 
@@ -148,7 +148,7 @@ EOF
 
 }
 
-resource "aws_iam_role" "backup-rds-to-s3-scheduled-task-role" {
+resource "aws_iam_role" "backup_rds_to_s3_scheduled_task_role" {
   count = var.backup_mysql_rds ? 1 : 0
   name  = "${var.Env-Name}-backup-rds-to-s3-scheduled-task-role"
 
@@ -170,11 +170,11 @@ DOC
 
 }
 
-resource "aws_iam_role_policy" "backup-rds-to-s3-task-policy" {
+resource "aws_iam_role_policy" "backup_rds_to_s3_task_policy" {
   count      = var.backup_mysql_rds ? 1 : 0
   name       = "${var.Env-Name}-backup-rds-to-s3-task-policy"
-  role       = aws_iam_role.backup-rds-to-s3-task-role[0].id
-  depends_on = [aws_iam_role.backup-rds-to-s3-task-role]
+  role       = aws_iam_role.backup_rds_to_s3_task_role[0].id
+  depends_on = [aws_iam_role.backup_rds_to_s3_task_role]
 
   policy = <<EOF
 {
@@ -236,10 +236,10 @@ EOF
 
 }
 
-resource "aws_iam_role_policy" "backup-rds-to-s3-scheduled-task-policy" {
+resource "aws_iam_role_policy" "backup_rds_to_s3_scheduled_task_policy" {
   count = var.backup_mysql_rds ? 1 : 0
   name  = "${var.Env-Name}-backup-rds-to-s3-scheduled-task-policy"
-  role  = aws_iam_role.backup-rds-to-s3-scheduled-task-role[0].id
+  role  = aws_iam_role.backup_rds_to_s3_scheduled_task_role[0].id
 
   policy = <<DOC
 {
@@ -249,7 +249,7 @@ resource "aws_iam_role_policy" "backup-rds-to-s3-scheduled-task-policy" {
       "Sid": "sid0",
           "Effect": "Allow",
           "Action": "ecs:RunTask",
-          "Resource": "${replace(aws_ecs_task_definition.backup-rds-to-s3-task-definition[0].arn, "/:\\d+$/", ":*", )}"
+          "Resource": "${replace(aws_ecs_task_definition.backup_rds_to_s3_task_definition[0].arn, "/:\\d+$/", ":*", )}"
     },{
       "Sid": "sid1",
       "Effect": "Allow",
@@ -269,16 +269,16 @@ DOC
 
 }
 
-resource "aws_cloudwatch_event_target" "backup-rds-to-s3" {
+resource "aws_cloudwatch_event_target" "backup_rds_to_s3" {
   count     = var.backup_mysql_rds ? 1 : 0
   target_id = "${var.Env-Name}-backup-rds-to-s3"
-  arn       = aws_ecs_cluster.api-cluster.arn
-  rule      = aws_cloudwatch_event_rule.backup-rds-to-s3[0].name
-  role_arn  = aws_iam_role.backup-rds-to-s3-scheduled-task-role[0].arn
+  arn       = aws_ecs_cluster.api_cluster.arn
+  rule      = aws_cloudwatch_event_rule.backup_rds_to_s3[0].name
+  role_arn  = aws_iam_role.backup_rds_to_s3_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.backup-rds-to-s3-task-definition[0].arn
+    task_definition_arn = aws_ecs_task_definition.backup_rds_to_s3_task_definition[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -287,8 +287,8 @@ resource "aws_cloudwatch_event_target" "backup-rds-to-s3" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id],
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id],
       )
 
       assign_public_ip = true

--- a/govwifi-api/elb.tf
+++ b/govwifi-api/elb.tf
@@ -1,12 +1,12 @@
-resource "aws_lb" "api-alb" {
+resource "aws_lb" "api_alb" {
   name     = "api-alb-${var.Env-Name}"
   internal = false
   count    = var.backend-elb-count
   subnets  = var.subnet-ids
 
   security_groups = [
-    aws_security_group.api-alb-in.id,
-    aws_security_group.api-alb-out.id,
+    aws_security_group.api_alb_in.id,
+    aws_security_group.api_alb_out.id,
   ]
 
   load_balancer_type = "application"
@@ -17,10 +17,10 @@ resource "aws_lb" "api-alb" {
 }
 
 resource "aws_alb_listener" "alb_listener" {
-  load_balancer_arn = aws_lb.api-alb[0].arn
+  load_balancer_arn = aws_lb.api_alb[0].arn
   port              = "8443"
   protocol          = "HTTPS"
-  certificate_arn   = aws_acm_certificate.api-elb-regional[0].arn
+  certificate_arn   = aws_acm_certificate.api_elb_regional[0].arn
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
 
   default_action {
@@ -29,15 +29,15 @@ resource "aws_alb_listener" "alb_listener" {
   }
 }
 
-resource "aws_lb_listener_certificate" "api-elb-global" {
+resource "aws_lb_listener_certificate" "api_elb_global" {
   count           = var.backend-elb-count
   listener_arn    = aws_alb_listener.alb_listener.arn
-  certificate_arn = aws_acm_certificate.api-elb-global[0].arn
+  certificate_arn = aws_acm_certificate.api_elb_global[0].arn
 
-  depends_on = [aws_acm_certificate_validation.api-elb-global]
+  depends_on = [aws_acm_certificate_validation.api_elb_global]
 }
 
-resource "aws_security_group" "api-alb-in" {
+resource "aws_security_group" "api_alb_in" {
   name        = "loadbalancer-in"
   description = "Allow Inbound Traffic To The ALB"
   vpc_id      = var.vpc-id
@@ -54,7 +54,7 @@ resource "aws_security_group" "api-alb-in" {
   }
 }
 
-resource "aws_security_group" "api-alb-out" {
+resource "aws_security_group" "api_alb_out" {
   name        = "loadbalancer-out"
   description = "Allow Outbound Traffic To The ALB"
   vpc_id      = var.vpc-id

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -1,19 +1,19 @@
-resource "aws_cloudwatch_log_group" "logging-api-log-group" {
+resource "aws_cloudwatch_log_group" "logging_api_log_group" {
   count = var.logging-enabled
   name  = "${var.Env-Name}-logging-api-docker-log-group"
 
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "logging-api-ecr" {
+resource "aws_ecr_repository" "logging_api_ecr" {
   count = var.ecr-repository-count
   name  = "govwifi/logging-api"
 }
 
-resource "aws_ecs_task_definition" "logging-api-task" {
+resource "aws_ecs_task_definition" "logging_api_task" {
   count                    = var.logging-enabled
   family                   = "logging-api-task-${var.Env-Name}"
-  task_role_arn            = aws_iam_role.logging-api-task-role[0].arn
+  task_role_arn            = aws_iam_role.logging_api_task_role[0].arn
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
   memory                   = 512
@@ -103,7 +103,7 @@ resource "aws_ecs_task_definition" "logging-api-task" {
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "${aws_cloudwatch_log_group.logging-api-log-group[0].name}",
+          "awslogs-group": "${aws_cloudwatch_log_group.logging_api_log_group[0].name}",
           "awslogs-region": "${var.aws-region}",
           "awslogs-stream-prefix": "${var.Env-Name}-logging-api-docker-logs"
         }
@@ -117,11 +117,11 @@ EOF
 
 }
 
-resource "aws_ecs_service" "logging-api-service" {
+resource "aws_ecs_service" "logging_api_service" {
   count            = var.logging-enabled
   name             = "logging-api-service-${var.Env-Name}"
-  cluster          = aws_ecs_cluster.api-cluster.id
-  task_definition  = aws_ecs_task_definition.logging-api-task[0].arn
+  cluster          = aws_ecs_cluster.api_cluster.id
+  task_definition  = aws_ecs_task_definition.logging_api_task[0].arn
   desired_count    = var.backend-instance-count
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
@@ -129,8 +129,8 @@ resource "aws_ecs_service" "logging-api-service" {
   network_configuration {
     security_groups = concat(
       var.backend-sg-list,
-      [aws_security_group.api-in.id],
-      [aws_security_group.api-out.id]
+      [aws_security_group.api_in.id],
+      [aws_security_group.api_out.id]
     )
 
     subnets          = var.subnet-ids
@@ -138,15 +138,15 @@ resource "aws_ecs_service" "logging-api-service" {
   }
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.logging-api-tg[0].arn
+    target_group_arn = aws_alb_target_group.logging_api_tg[0].arn
     container_name   = "logging"
     container_port   = "8080"
   }
 }
 
-resource "aws_alb_target_group" "logging-api-tg" {
+resource "aws_alb_target_group" "logging_api_tg" {
   count       = var.logging-enabled
-  depends_on  = [aws_lb.api-alb]
+  depends_on  = [aws_lb.api_alb]
   name        = "logging-api-${var.Env-Name}"
   port        = "8080"
   protocol    = "HTTP"
@@ -166,15 +166,15 @@ resource "aws_alb_target_group" "logging-api-tg" {
   }
 }
 
-resource "aws_alb_listener_rule" "logging-api-lr" {
+resource "aws_alb_listener_rule" "logging_api_lr" {
   count        = var.logging-enabled
-  depends_on   = [aws_alb_target_group.logging-api-tg]
+  depends_on   = [aws_alb_target_group.logging_api_tg]
   listener_arn = aws_alb_listener.alb_listener.arn
   priority     = 3
 
   action {
     type             = "forward"
-    target_group_arn = aws_alb_target_group.logging-api-tg[0].id
+    target_group_arn = aws_alb_target_group.logging_api_tg[0].id
   }
 
   condition {
@@ -183,7 +183,7 @@ resource "aws_alb_listener_rule" "logging-api-lr" {
   }
 }
 
-resource "aws_iam_role" "logging-api-task-role" {
+resource "aws_iam_role" "logging_api_task_role" {
   count = var.logging-enabled
   name  = "${var.Env-Name}-logging-api-task-role"
 
@@ -205,11 +205,11 @@ EOF
 
 }
 
-resource "aws_iam_role_policy" "logging-api-task-policy" {
+resource "aws_iam_role_policy" "logging_api_task_policy" {
   count      = var.logging-enabled
   name       = "${var.Env-Name}-logging-api-task-policy"
-  role       = aws_iam_role.logging-api-task-role[0].id
-  depends_on = [aws_iam_role.logging-api-task-role]
+  role       = aws_iam_role.logging_api_task_role[0].id
+  depends_on = [aws_iam_role.logging_api_task_role]
 
   policy = <<EOF
 {

--- a/govwifi-api/logging-metrics.tf
+++ b/govwifi-api/logging-metrics.tf
@@ -1,8 +1,8 @@
-resource "aws_cloudwatch_log_metric_filter" "radius-access-reject" {
+resource "aws_cloudwatch_log_metric_filter" "radius_access_reject" {
   count          = var.logging-enabled
   name           = "${var.Env-Name}-radius-access-reject"
   pattern        = "\"\\\"authentication_result\\\": \\\"Access-Reject\\\"\""
-  log_group_name = aws_cloudwatch_log_group.logging-api-log-group[0].name
+  log_group_name = aws_cloudwatch_log_group.logging_api_log_group[0].name
 
   metric_transformation {
     name          = "${var.Env-Name}-radius-access-reject-count"
@@ -12,13 +12,13 @@ resource "aws_cloudwatch_log_metric_filter" "radius-access-reject" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "radius-access-accept" {
+resource "aws_cloudwatch_log_metric_filter" "radius_access_accept" {
   count = var.logging-enabled
   name  = "${var.Env-Name}-radius-access-accept"
 
   # match all accepts, but not the healthchecks
   pattern        = "\"\\\"authentication_result\\\": \\\"Access-Accept\\\"\" -\"\\\"username\\\": \\\"HEALTH\\\"\""
-  log_group_name = aws_cloudwatch_log_group.logging-api-log-group[0].name
+  log_group_name = aws_cloudwatch_log_group.logging_api_log_group[0].name
 
   metric_transformation {
     name          = "${var.Env-Name}-radius-access-accept-count"
@@ -28,12 +28,12 @@ resource "aws_cloudwatch_log_metric_filter" "radius-access-accept" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "response-status-no-content" {
+resource "aws_cloudwatch_log_metric_filter" "response_status_no_content" {
   count = var.logging-enabled
   name  = "${var.Env-Name}-response-status-no-content"
 
   pattern        = "\"status=204\" -\"\\\"username\\\": \\\"HEALTH\\\"\""
-  log_group_name = aws_cloudwatch_log_group.logging-api-log-group[0].name
+  log_group_name = aws_cloudwatch_log_group.logging_api_log_group[0].name
 
   metric_transformation {
     name          = "${var.Env-Name}-response-status-no-content-count"

--- a/govwifi-api/logging-scaling-policy.tf
+++ b/govwifi-api/logging-scaling-policy.tf
@@ -1,19 +1,19 @@
-resource "aws_appautoscaling_target" "logging-ecs-target" {
+resource "aws_appautoscaling_target" "logging_ecs_target" {
   count              = var.logging-enabled
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.logging-api-service[0].name}"
+  resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.logging_api_service[0].name}"
   max_capacity       = 20
   min_capacity       = 3
   scalable_dimension = "ecs:service:DesiredCount"
 }
 
-resource "aws_appautoscaling_policy" "ecs-policy-up-logging" {
+resource "aws_appautoscaling_policy" "ecs_policy_up_logging" {
   count              = var.logging-enabled
   name               = "ECS Scale Up Logging"
-  service_namespace  = aws_appautoscaling_target.logging-ecs-target[0].service_namespace
+  service_namespace  = aws_appautoscaling_target.logging_ecs_target[0].service_namespace
   policy_type        = "StepScaling"
-  resource_id        = aws_appautoscaling_target.logging-ecs-target[0].resource_id
-  scalable_dimension = aws_appautoscaling_target.logging-ecs-target[0].scalable_dimension
+  resource_id        = aws_appautoscaling_target.logging_ecs_target[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.logging_ecs_target[0].scalable_dimension
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
@@ -25,16 +25,16 @@ resource "aws_appautoscaling_policy" "ecs-policy-up-logging" {
     }
   }
 
-  depends_on = [aws_appautoscaling_target.logging-ecs-target]
+  depends_on = [aws_appautoscaling_target.logging_ecs_target]
 }
 
-resource "aws_appautoscaling_policy" "ecs-policy-down-logging" {
+resource "aws_appautoscaling_policy" "ecs_policy_down_logging" {
   count              = var.logging-enabled
   name               = "ECS Scale Down"
-  service_namespace  = aws_appautoscaling_target.logging-ecs-target[0].service_namespace
-  resource_id        = aws_appautoscaling_target.logging-ecs-target[0].resource_id
+  service_namespace  = aws_appautoscaling_target.logging_ecs_target[0].service_namespace
+  resource_id        = aws_appautoscaling_target.logging_ecs_target[0].resource_id
   policy_type        = "StepScaling"
-  scalable_dimension = aws_appautoscaling_target.logging-ecs-target[0].scalable_dimension
+  scalable_dimension = aws_appautoscaling_target.logging_ecs_target[0].scalable_dimension
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
@@ -46,6 +46,6 @@ resource "aws_appautoscaling_policy" "ecs-policy-down-logging" {
     }
   }
 
-  depends_on = [aws_appautoscaling_target.logging-ecs-target]
+  depends_on = [aws_appautoscaling_target.logging_ecs_target]
 }
 

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -1,4 +1,4 @@
-resource "aws_iam_role" "logging-scheduled-task-role" {
+resource "aws_iam_role" "logging_scheduled_task_role" {
   count = var.logging-enabled
   name  = "${var.Env-Name}-logging-scheduled-task-role"
 
@@ -20,10 +20,10 @@ DOC
 
 }
 
-resource "aws_iam_role_policy" "logging-scheduled-task-policy" {
+resource "aws_iam_role_policy" "logging_scheduled_task_policy" {
   count = var.logging-enabled
   name  = "${var.Env-Name}-logging-scheduled-task-policy"
-  role  = aws_iam_role.logging-scheduled-task-role[0].id
+  role  = aws_iam_role.logging_scheduled_task_role[0].id
 
   policy = <<DOC
 {
@@ -33,7 +33,7 @@ resource "aws_iam_role_policy" "logging-scheduled-task-policy" {
             "Effect": "Allow",
             "Action": "ecs:RunTask",
             "Resource": "${replace(
-  aws_ecs_task_definition.logging-api-scheduled-task[0].arn,
+  aws_ecs_task_definition.logging_api_scheduled_task[0].arn,
   "/:\\d+$/",
   ":*",
 )}"
@@ -56,16 +56,16 @@ DOC
 
 }
 
-resource "aws_cloudwatch_event_target" "logging-daily-session-deletion" {
+resource "aws_cloudwatch_event_target" "logging_daily_session_deletion" {
   count     = var.logging-enabled
   target_id = "${var.Env-Name}-logging-daily-session-deletion"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.daily_session_deletion_event[0].name
-  role_arn  = aws_iam_role.logging-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -74,8 +74,8 @@ resource "aws_cloudwatch_event_target" "logging-daily-session-deletion" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -95,16 +95,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "gdpr-set-user-last-login" {
+resource "aws_cloudwatch_event_target" "gdpr_set_user_last_login" {
   count     = var.logging-enabled
   target_id = "${var.Env-Name}-gdpr-user-set-last-login"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.daily_gdpr_set_user_last_login[0].name
-  role_arn  = aws_iam_role.logging-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -113,8 +113,8 @@ resource "aws_cloudwatch_event_target" "gdpr-set-user-last-login" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -134,16 +134,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "hourly-request-statistics" {
+resource "aws_cloudwatch_event_target" "hourly_request_statistics" {
   count     = var.logging-enabled
   target_id = "${var.Env-Name}-publish-hourly-request-statistics"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.hourly_request_statistics_event[0].name
-  role_arn  = aws_iam_role.logging-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -152,8 +152,8 @@ resource "aws_cloudwatch_event_target" "hourly-request-statistics" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -174,16 +174,16 @@ EOF
 }
 
 # new metrics
-resource "aws_cloudwatch_event_target" "publish-monthly-metrics-logging" {
+resource "aws_cloudwatch_event_target" "publish_monthly_metrics_logging" {
   count     = var.logging-enabled
   target_id = "${var.Env-Name}-logging-monthly-metrics"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.monthly_metrics_logging_event[0].name
-  role_arn  = aws_iam_role.logging-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -192,8 +192,8 @@ resource "aws_cloudwatch_event_target" "publish-monthly-metrics-logging" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -213,16 +213,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "publish-weekly-metrics-logging" {
+resource "aws_cloudwatch_event_target" "publish_weekly_metrics_logging" {
   count     = var.logging-enabled
   target_id = "${var.Env-Name}-logging-weekly-metrics"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.weekly_metrics_logging_event[0].name
-  role_arn  = aws_iam_role.logging-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -231,8 +231,8 @@ resource "aws_cloudwatch_event_target" "publish-weekly-metrics-logging" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -252,16 +252,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "publish-daily-metrics-logging" {
+resource "aws_cloudwatch_event_target" "publish_daily_metrics_logging" {
   count     = var.logging-enabled
   target_id = "${var.Env-Name}-logging-daily-metrics"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.daily_metrics_logging_event[0].name
-  role_arn  = aws_iam_role.logging-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -270,8 +270,8 @@ resource "aws_cloudwatch_event_target" "publish-daily-metrics-logging" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -291,16 +291,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "publish-monthly-metrics-to-elasticsearch" {
+resource "aws_cloudwatch_event_target" "publish_monthly_metrics_to_elasticsearch" {
   count     = var.logging-enabled
   target_id = "${var.Env-Name}-logging-monthly-metrics-to-elasticsearch"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.monthly_metrics_logging_event[0].name
-  role_arn  = aws_iam_role.logging-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -309,8 +309,8 @@ resource "aws_cloudwatch_event_target" "publish-monthly-metrics-to-elasticsearch
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -330,16 +330,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "publish-weekly-metrics-to-elasticsearch" {
+resource "aws_cloudwatch_event_target" "publish_weekly_metrics_to_elasticsearch" {
   count     = var.logging-enabled
   target_id = "${var.Env-Name}-logging-weekly-metrics-to-elasticsearch"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.weekly_metrics_logging_event[0].name
-  role_arn  = aws_iam_role.logging-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -348,8 +348,8 @@ resource "aws_cloudwatch_event_target" "publish-weekly-metrics-to-elasticsearch"
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -369,16 +369,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "publish-daily-metrics-to-elasticsearch" {
+resource "aws_cloudwatch_event_target" "publish_daily_metrics_to_elasticsearch" {
   count     = var.logging-enabled
   target_id = "${var.Env-Name}-logging-daily-metrics-to-elasticsearch"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.daily_metrics_logging_event[0].name
-  role_arn  = aws_iam_role.logging-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -387,8 +387,8 @@ resource "aws_cloudwatch_event_target" "publish-daily-metrics-to-elasticsearch" 
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -408,10 +408,10 @@ EOF
 
 }
 
-resource "aws_ecs_task_definition" "logging-api-scheduled-task" {
+resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
   count                    = var.logging-enabled
   family                   = "logging-api-scheduled-task-${var.Env-Name}"
-  task_role_arn            = aws_iam_role.logging-api-task-role[0].arn
+  task_role_arn            = aws_iam_role.logging_api_task_role[0].arn
   execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
   requires_compatibilities = ["FARGATE"]
   cpu                      = 512
@@ -505,7 +505,7 @@ resource "aws_ecs_task_definition" "logging-api-scheduled-task" {
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "${aws_cloudwatch_log_group.logging-api-log-group[0].name}",
+          "awslogs-group": "${aws_cloudwatch_log_group.logging_api_log_group[0].name}",
           "awslogs-region": "${var.aws-region}",
           "awslogs-stream-prefix": "${var.Env-Name}-logging-api-docker-logs"
         }
@@ -519,16 +519,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "sync-s3-to-elasticsearch" {
+resource "aws_cloudwatch_event_target" "sync_s3_to_elasticsearch" {
   count     = var.logging-enabled
   target_id = "${var.Env-Name}-sync-s3-to-elasticsearch"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.sync_s3_to_elasticsearch_event[0].name
-  role_arn  = aws_iam_role.logging-api-task-role[0].arn
+  role_arn  = aws_iam_role.logging_api_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.logging-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -537,8 +537,8 @@ resource "aws_cloudwatch_event_target" "sync-s3-to-elasticsearch" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true

--- a/govwifi-api/route53.tf
+++ b/govwifi-api/route53.tf
@@ -5,8 +5,8 @@ resource "aws_route53_record" "elb" {
   type    = "A"
 
   alias {
-    name                   = aws_lb.api-alb[0].dns_name
-    zone_id                = aws_lb.api-alb[0].zone_id
+    name                   = aws_lb.api_alb[0].dns_name
+    zone_id                = aws_lb.api_alb[0].zone_id
     evaluate_target_health = true
   }
 }
@@ -31,19 +31,19 @@ resource "aws_route53_record" "elb_global" {
 
 resource "aws_route53_record" "elb_global_cert_validation" {
   count   = var.backend-elb-count
-  name    = aws_acm_certificate.api-elb-global[0].domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.api-elb-global[0].domain_validation_options[0].resource_record_type
+  name    = aws_acm_certificate.api_elb_global[0].domain_validation_options[0].resource_record_name
+  type    = aws_acm_certificate.api_elb_global[0].domain_validation_options[0].resource_record_type
   zone_id = var.route53-zone-id
-  records = [aws_acm_certificate.api-elb-global[0].domain_validation_options[0].resource_record_value]
+  records = [aws_acm_certificate.api_elb_global[0].domain_validation_options[0].resource_record_value]
   ttl     = 60
 }
 
 resource "aws_route53_record" "elb_regional_cert_validation" {
   count   = var.backend-elb-count
-  name    = aws_acm_certificate.api-elb-regional[0].domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.api-elb-regional[0].domain_validation_options[0].resource_record_type
+  name    = aws_acm_certificate.api_elb_regional[0].domain_validation_options[0].resource_record_name
+  type    = aws_acm_certificate.api_elb_regional[0].domain_validation_options[0].resource_record_type
   zone_id = var.route53-zone-id
-  records = [aws_acm_certificate.api-elb-regional[0].domain_validation_options[0].resource_record_value]
+  records = [aws_acm_certificate.api_elb_regional[0].domain_validation_options[0].resource_record_value]
   ttl     = 60
 }
 

--- a/govwifi-api/safe-restart-scheduled-task.tf
+++ b/govwifi-api/safe-restart-scheduled-task.tf
@@ -6,23 +6,23 @@ resource "aws_cloudwatch_event_rule" "daily_safe_restart" {
   is_enabled          = true
 }
 
-resource "aws_cloudwatch_log_group" "safe-restart-log-group" {
+resource "aws_cloudwatch_log_group" "safe_restart_log_group" {
   count = var.safe-restart-enabled
   name  = "${var.Env-Name}-safe-restart-docker-log-group"
 
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "safe-restarter-ecr" {
+resource "aws_ecr_repository" "safe_restarter_ecr" {
   count = var.ecr-repository-count
   name  = "govwifi/safe-restarter"
 }
 
-resource "aws_ecs_task_definition" "safe-restart-task-definition" {
+resource "aws_ecs_task_definition" "safe_restart_task_definition" {
   count                    = var.safe-restart-enabled
   family                   = "safe-restart-task-${var.Env-Name}"
   execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
-  task_role_arn            = aws_iam_role.safe-restart-task-role[0].arn
+  task_role_arn            = aws_iam_role.safe_restart_task_role[0].arn
   requires_compatibilities = ["FARGATE"]
   cpu                      = 256
   memory                   = 1024
@@ -73,7 +73,7 @@ resource "aws_ecs_task_definition" "safe-restart-task-definition" {
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "${aws_cloudwatch_log_group.safe-restart-log-group[0].name}",
+          "awslogs-group": "${aws_cloudwatch_log_group.safe_restart_log_group[0].name}",
           "awslogs-region": "${var.aws-region}",
           "awslogs-stream-prefix": "${var.Env-Name}-safe-restart-docker-logs"
         }
@@ -87,7 +87,7 @@ EOF
 
 }
 
-resource "aws_iam_role" "safe-restart-task-role" {
+resource "aws_iam_role" "safe_restart_task_role" {
   count = var.safe-restart-enabled
   name  = "${var.Env-Name}-safe-restart-task-role"
 
@@ -109,7 +109,7 @@ EOF
 
 }
 
-resource "aws_iam_role" "safe-restart-scheduled-task-role" {
+resource "aws_iam_role" "safe_restart_scheduled_task_role" {
   count = var.safe-restart-enabled
   name  = "${var.Env-Name}-safe-restart-scheduled-task-role"
 
@@ -131,11 +131,11 @@ DOC
 
 }
 
-resource "aws_iam_role_policy" "safe-restart-task-policy" {
+resource "aws_iam_role_policy" "safe_restart_task_policy" {
   count      = var.safe-restart-enabled
   name       = "${var.Env-Name}-safe-restart-task-policy"
-  role       = aws_iam_role.safe-restart-task-role[0].id
-  depends_on = [aws_iam_role.safe-restart-task-role]
+  role       = aws_iam_role.safe_restart_task_role[0].id
+  depends_on = [aws_iam_role.safe_restart_task_role]
 
   policy = <<EOF
 {
@@ -158,10 +158,10 @@ EOF
 
 }
 
-resource "aws_iam_role_policy" "safe-restart-scheduled-task-policy" {
+resource "aws_iam_role_policy" "safe_restart_scheduled_task_policy" {
   count = var.safe-restart-enabled
   name  = "${var.Env-Name}-safe-restart-scheduled-task-policy"
-  role  = aws_iam_role.safe-restart-scheduled-task-role[0].id
+  role  = aws_iam_role.safe_restart_scheduled_task_role[0].id
 
   policy = <<DOC
 {
@@ -171,7 +171,7 @@ resource "aws_iam_role_policy" "safe-restart-scheduled-task-policy" {
             "Effect": "Allow",
             "Action": "ecs:RunTask",
             "Resource": "${replace(
-  aws_ecs_task_definition.safe-restart-task-definition[0].arn,
+  aws_ecs_task_definition.safe_restart_task_definition[0].arn,
   "/:\\d+$/",
   ":*",
 )}"
@@ -194,16 +194,16 @@ DOC
 
 }
 
-resource "aws_cloudwatch_event_target" "daily-safe-restart" {
+resource "aws_cloudwatch_event_target" "daily_safe_restart" {
   count     = var.safe-restart-enabled
   target_id = "${var.Env-Name}-safe-restart"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.daily_safe_restart[0].name
-  role_arn  = aws_iam_role.safe-restart-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.safe_restart_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.safe-restart-task-definition[0].arn
+    task_definition_arn = aws_ecs_task_definition.safe_restart_task_definition[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -212,8 +212,8 @@ resource "aws_cloudwatch_event_target" "daily-safe-restart" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true

--- a/govwifi-api/scaling-policy.tf
+++ b/govwifi-api/scaling-policy.tf
@@ -1,16 +1,16 @@
-resource "aws_appautoscaling_target" "auth-ecs-target" {
+resource "aws_appautoscaling_target" "auth_ecs_target" {
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
+  resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.authorisation_api_service.name}"
   max_capacity       = 20
   min_capacity       = 3
   scalable_dimension = "ecs:service:DesiredCount"
 }
 
-resource "aws_appautoscaling_policy" "ecs-policy-up" {
+resource "aws_appautoscaling_policy" "ecs_policy_up" {
   name               = "ECS Scale Up"
   service_namespace  = "ecs"
   policy_type        = "StepScaling"
-  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
+  resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.authorisation_api_service.name}"
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
@@ -23,13 +23,13 @@ resource "aws_appautoscaling_policy" "ecs-policy-up" {
     }
   }
 
-  depends_on = [aws_appautoscaling_target.auth-ecs-target]
+  depends_on = [aws_appautoscaling_target.auth_ecs_target]
 }
 
-resource "aws_appautoscaling_policy" "ecs-policy-down" {
+resource "aws_appautoscaling_policy" "ecs_policy_down" {
   name               = "ECS Scale Down"
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_cluster.api-cluster.name}/${aws_ecs_service.authorisation-api-service.name}"
+  resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.authorisation_api_service.name}"
   policy_type        = "StepScaling"
   scalable_dimension = "ecs:service:DesiredCount"
 
@@ -43,6 +43,6 @@ resource "aws_appautoscaling_policy" "ecs-policy-down" {
     }
   }
 
-  depends_on = [aws_appautoscaling_target.auth-ecs-target]
+  depends_on = [aws_appautoscaling_target.auth_ecs_target]
 }
 

--- a/govwifi-api/security-groups.tf
+++ b/govwifi-api/security-groups.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "api-in" {
+resource "aws_security_group" "api_in" {
   name        = "api-in"
   description = "Allow Inbound Traffic To API"
   vpc_id      = var.vpc-id
@@ -11,11 +11,11 @@ resource "aws_security_group" "api-in" {
     from_port       = 0
     to_port         = 65535
     protocol        = "tcp"
-    security_groups = [aws_security_group.api-alb-out.id]
+    security_groups = [aws_security_group.api_alb_out.id]
   }
 }
 
-resource "aws_security_group" "api-out" {
+resource "aws_security_group" "api_out" {
   name        = "api-out"
   description = "Allow Outbound Traffic From the API"
   vpc_id      = var.vpc-id

--- a/govwifi-api/user-signup-api-certs.tf
+++ b/govwifi-api/user-signup-api-certs.tf
@@ -1,6 +1,6 @@
-resource "aws_acm_certificate" "user-signup-api-global" {
+resource "aws_acm_certificate" "user_signup_api_global" {
   count             = var.user-signup-enabled
-  domain_name       = aws_route53_record.user-signup-api-global[0].fqdn
+  domain_name       = aws_route53_record.user_signup_api_global[0].fqdn
   validation_method = "DNS"
 
   lifecycle {
@@ -8,15 +8,15 @@ resource "aws_acm_certificate" "user-signup-api-global" {
   }
 }
 
-resource "aws_acm_certificate_validation" "user-signup-api-global" {
+resource "aws_acm_certificate_validation" "user_signup_api_global" {
   count                   = var.user-signup-enabled
-  certificate_arn         = aws_acm_certificate.user-signup-api-global[0].arn
-  validation_record_fqdns = [aws_route53_record.user-signup-api-global-verification[0].fqdn]
+  certificate_arn         = aws_acm_certificate.user_signup_api_global[0].arn
+  validation_record_fqdns = [aws_route53_record.user_signup_api_global_verification[0].fqdn]
 }
 
-resource "aws_acm_certificate" "user-signup-api-regional" {
+resource "aws_acm_certificate" "user_signup_api_regional" {
   count             = var.user-signup-enabled
-  domain_name       = aws_route53_record.user-signup-api-regional[0].fqdn
+  domain_name       = aws_route53_record.user_signup_api_regional[0].fqdn
   validation_method = "DNS"
 
   lifecycle {
@@ -24,9 +24,9 @@ resource "aws_acm_certificate" "user-signup-api-regional" {
   }
 }
 
-resource "aws_acm_certificate_validation" "user-signup-api-regional" {
+resource "aws_acm_certificate_validation" "user_signup_api_regional" {
   count                   = var.user-signup-enabled
-  certificate_arn         = aws_acm_certificate.user-signup-api-regional[0].arn
-  validation_record_fqdns = [aws_route53_record.user-signup-api-regional-verification[0].fqdn]
+  certificate_arn         = aws_acm_certificate.user_signup_api_regional[0].arn
+  validation_record_fqdns = [aws_route53_record.user_signup_api_regional_verification[0].fqdn]
 }
 

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -1,16 +1,16 @@
-resource "aws_cloudwatch_log_group" "user-signup-api-log-group" {
+resource "aws_cloudwatch_log_group" "user_signup_api_log_group" {
   count = var.user-signup-enabled
   name  = "${var.Env-Name}-user-signup-api-docker-log-group"
 
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "user-signup-api-ecr" {
+resource "aws_ecr_repository" "user_signup_api_ecr" {
   count = var.ecr-repository-count
   name  = "govwifi/user-signup-api"
 }
 
-resource "aws_iam_role" "user-signup-api-task-role" {
+resource "aws_iam_role" "user_signup_api_task_role" {
   count = var.user-signup-enabled
   name  = "${var.Env-Name}-user-signup-api-task-role"
 
@@ -32,11 +32,11 @@ EOF
 
 }
 
-resource "aws_iam_role_policy" "user-signup-api-task-policy" {
+resource "aws_iam_role_policy" "user_signup_api_task_policy" {
   count      = var.user-signup-enabled
   name       = "${var.Env-Name}-user-signup-api-task-policy"
-  role       = aws_iam_role.user-signup-api-task-role[0].id
-  depends_on = [aws_iam_role.user-signup-api-task-role]
+  role       = aws_iam_role.user_signup_api_task_role[0].id
+  depends_on = [aws_iam_role.user_signup_api_task_role]
 
   policy = <<EOF
 {
@@ -73,10 +73,10 @@ data "aws_s3_bucket" "admin-bucket" {
   bucket = var.admin-bucket-name
 }
 
-resource "aws_ecs_task_definition" "user-signup-api-task" {
+resource "aws_ecs_task_definition" "user_signup_api_task" {
   count                    = var.user-signup-enabled
   family                   = "user-signup-api-task-${var.Env-Name}"
-  task_role_arn            = aws_iam_role.user-signup-api-task-role[0].arn
+  task_role_arn            = aws_iam_role.user_signup_api_task_role[0].arn
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
   memory                   = 512
@@ -160,7 +160,7 @@ resource "aws_ecs_task_definition" "user-signup-api-task" {
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "${aws_cloudwatch_log_group.user-signup-api-log-group[0].name}",
+          "awslogs-group": "${aws_cloudwatch_log_group.user_signup_api_log_group[0].name}",
           "awslogs-region": "${var.aws-region}",
           "awslogs-stream-prefix": "${var.Env-Name}-user-signup-api-docker-logs"
         }
@@ -174,11 +174,11 @@ EOF
 
 }
 
-resource "aws_ecs_service" "user-signup-api-service" {
+resource "aws_ecs_service" "user_signup_api_service" {
   count            = var.user-signup-enabled
   name             = "user-signup-api-service-${var.Env-Name}"
-  cluster          = aws_ecs_cluster.api-cluster.id
-  task_definition  = aws_ecs_task_definition.user-signup-api-task[0].arn
+  cluster          = aws_ecs_cluster.api_cluster.id
+  task_definition  = aws_ecs_task_definition.user_signup_api_task[0].arn
   desired_count    = var.backend-instance-count
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
@@ -186,8 +186,8 @@ resource "aws_ecs_service" "user-signup-api-service" {
   network_configuration {
     security_groups = concat(
       var.backend-sg-list,
-      [aws_security_group.api-in.id],
-      [aws_security_group.api-out.id]
+      [aws_security_group.api_in.id],
+      [aws_security_group.api_out.id]
     )
 
     subnets          = var.subnet-ids
@@ -195,15 +195,15 @@ resource "aws_ecs_service" "user-signup-api-service" {
   }
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.user-signup-api-tg[0].arn
+    target_group_arn = aws_alb_target_group.user_signup_api_tg[0].arn
     container_name   = "user-signup"
     container_port   = "8080"
   }
 }
 
-resource "aws_alb_target_group" "user-signup-api-tg" {
+resource "aws_alb_target_group" "user_signup_api_tg" {
   count       = var.user-signup-enabled
-  depends_on  = [aws_lb.api-alb]
+  depends_on  = [aws_lb.api_alb]
   name        = "user-signup-api-${var.Env-Name}"
   port        = "8080"
   protocol    = "HTTP"

--- a/govwifi-api/user-signup-api-lb.tf
+++ b/govwifi-api/user-signup-api-lb.tf
@@ -1,13 +1,13 @@
-resource "aws_lb" "user-signup-api" {
+resource "aws_lb" "user_signup_api" {
   count    = var.user-signup-enabled
   name     = "user-signup-api-${var.Env-Name}"
   internal = false
   subnets  = var.subnet-ids
 
   security_groups = concat(
-    [aws_security_group.api-alb-in.id],
-    [aws_security_group.api-alb-out.id],
-    aws_security_group.user-signup-api-lb-in.*.id
+    [aws_security_group.api_alb_in.id],
+    [aws_security_group.api_alb_out.id],
+    aws_security_group.user_signup_api_lb_in.*.id
   )
 
   load_balancer_type = "application"
@@ -17,25 +17,25 @@ resource "aws_lb" "user-signup-api" {
   }
 }
 
-resource "aws_lb_listener" "user-signup-api" {
+resource "aws_lb_listener" "user_signup_api" {
   count             = var.user-signup-enabled
-  load_balancer_arn = aws_lb.user-signup-api[0].arn
+  load_balancer_arn = aws_lb.user_signup_api[0].arn
   port              = "8443"
   protocol          = "HTTPS"
-  certificate_arn   = aws_acm_certificate.user-signup-api-global[0].arn
+  certificate_arn   = aws_acm_certificate.user_signup_api_global[0].arn
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
 
   default_action {
-    target_group_arn = aws_alb_target_group.user-signup-api-tg[0].arn
+    target_group_arn = aws_alb_target_group.user_signup_api_tg[0].arn
     type             = "forward"
   }
 }
 
-resource "aws_lb_listener_certificate" "user-signup-api-regional" {
+resource "aws_lb_listener_certificate" "user_signup_api_regional" {
   count           = var.user-signup-enabled
-  listener_arn    = aws_lb_listener.user-signup-api[0].arn
-  certificate_arn = aws_acm_certificate.user-signup-api-regional[0].arn
+  listener_arn    = aws_lb_listener.user_signup_api[0].arn
+  certificate_arn = aws_acm_certificate.user_signup_api_regional[0].arn
 
-  depends_on = [aws_acm_certificate_validation.user-signup-api-regional]
+  depends_on = [aws_acm_certificate_validation.user_signup_api_regional]
 }
 

--- a/govwifi-api/user-signup-api-route53.tf
+++ b/govwifi-api/user-signup-api-route53.tf
@@ -1,17 +1,17 @@
-resource "aws_route53_record" "user-signup-api-regional" {
+resource "aws_route53_record" "user_signup_api_regional" {
   count   = var.user-signup-enabled
   zone_id = var.route53-zone-id
   name    = "user-signup-api.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk"
   type    = "A"
 
   alias {
-    name                   = aws_lb.user-signup-api[0].dns_name
-    zone_id                = aws_lb.user-signup-api[0].zone_id
+    name                   = aws_lb.user_signup_api[0].dns_name
+    zone_id                = aws_lb.user_signup_api[0].zone_id
     evaluate_target_health = true
   }
 }
 
-resource "aws_route53_record" "user-signup-api-global" {
+resource "aws_route53_record" "user_signup_api_global" {
   count          = var.user-signup-enabled
   zone_id        = var.route53-zone-id
   name           = "user-signup-api.${var.Env-Subdomain}.service.gov.uk"
@@ -19,8 +19,8 @@ resource "aws_route53_record" "user-signup-api-global" {
   set_identifier = var.aws-region
 
   alias {
-    name                   = aws_route53_record.user-signup-api-regional[0].name
-    zone_id                = aws_route53_record.user-signup-api-regional[0].zone_id
+    name                   = aws_route53_record.user_signup_api_regional[0].name
+    zone_id                = aws_route53_record.user_signup_api_regional[0].zone_id
     evaluate_target_health = true
   }
 
@@ -29,21 +29,21 @@ resource "aws_route53_record" "user-signup-api-global" {
   }
 }
 
-resource "aws_route53_record" "user-signup-api-regional-verification" {
+resource "aws_route53_record" "user_signup_api_regional_verification" {
   count   = var.user-signup-enabled
-  name    = aws_acm_certificate.user-signup-api-regional[0].domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.user-signup-api-regional[0].domain_validation_options[0].resource_record_type
+  name    = aws_acm_certificate.user_signup_api_regional[0].domain_validation_options[0].resource_record_name
+  type    = aws_acm_certificate.user_signup_api_regional[0].domain_validation_options[0].resource_record_type
   zone_id = var.route53-zone-id
-  records = [aws_acm_certificate.user-signup-api-regional[0].domain_validation_options[0].resource_record_value]
+  records = [aws_acm_certificate.user_signup_api_regional[0].domain_validation_options[0].resource_record_value]
   ttl     = 60
 }
 
-resource "aws_route53_record" "user-signup-api-global-verification" {
+resource "aws_route53_record" "user_signup_api_global_verification" {
   count   = var.user-signup-enabled
-  name    = aws_acm_certificate.user-signup-api-global[0].domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.user-signup-api-global[0].domain_validation_options[0].resource_record_type
+  name    = aws_acm_certificate.user_signup_api_global[0].domain_validation_options[0].resource_record_name
+  type    = aws_acm_certificate.user_signup_api_global[0].domain_validation_options[0].resource_record_type
   zone_id = var.route53-zone-id
-  records = [aws_acm_certificate.user-signup-api-global[0].domain_validation_options[0].resource_record_value]
+  records = [aws_acm_certificate.user_signup_api_global[0].domain_validation_options[0].resource_record_value]
   ttl     = 60
 }
 

--- a/govwifi-api/user-signup-api-security-groups.tf
+++ b/govwifi-api/user-signup-api-security-groups.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "user-signup-api-lb-in" {
+resource "aws_security_group" "user_signup_api_lb_in" {
   count  = var.user-signup-api-is-public
   name   = "${var.Env-Name} User Signup API world inbound"
   vpc_id = var.vpc-id

--- a/govwifi-api/user-signup-metrics.tf
+++ b/govwifi-api/user-signup-metrics.tf
@@ -1,9 +1,9 @@
-resource "aws_cloudwatch_log_metric_filter" "notify-sms-successful-response" {
+resource "aws_cloudwatch_log_metric_filter" "notify_sms_successful_response" {
   count = var.user-signup-enabled
   name  = "${var.Env-Name}-notify-sms-success"
 
   pattern        = "\"user-signup/sms-notification\" \"status=200\" -\"Processing\""
-  log_group_name = aws_cloudwatch_log_group.user-signup-api-log-group[0].name
+  log_group_name = aws_cloudwatch_log_group.user_signup_api_log_group[0].name
 
   metric_transformation {
     name          = "${var.Env-Name}-notify-sms-success-count"
@@ -13,12 +13,12 @@ resource "aws_cloudwatch_log_metric_filter" "notify-sms-successful-response" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "notify-sms-failed-response" {
+resource "aws_cloudwatch_log_metric_filter" "notify_sms_failed_response" {
   count = var.user-signup-enabled
   name  = "${var.Env-Name}-notify-sms-failed"
 
   pattern        = "\"user-signup/sms-notification\" -\"status=200\" -\"Processing\""
-  log_group_name = aws_cloudwatch_log_group.user-signup-api-log-group[0].name
+  log_group_name = aws_cloudwatch_log_group.user_signup_api_log_group[0].name
 
   metric_transformation {
     name          = "${var.Env-Name}-notify-sms-failed-count"
@@ -28,12 +28,12 @@ resource "aws_cloudwatch_log_metric_filter" "notify-sms-failed-response" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "notify-email-successful-response" {
+resource "aws_cloudwatch_log_metric_filter" "notify_email_successful_response" {
   count = var.user-signup-enabled
   name  = "${var.Env-Name}-notify-email-success"
 
   pattern        = "\"user-signup/email-notification\" \"status=200\" -\"Processing\""
-  log_group_name = aws_cloudwatch_log_group.user-signup-api-log-group[0].name
+  log_group_name = aws_cloudwatch_log_group.user_signup_api_log_group[0].name
 
   metric_transformation {
     name          = "${var.Env-Name}-notify-email-success-count"
@@ -43,12 +43,12 @@ resource "aws_cloudwatch_log_metric_filter" "notify-email-successful-response" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "notify-email-failed-response" {
+resource "aws_cloudwatch_log_metric_filter" "notify_email_failed_response" {
   count = var.user-signup-enabled
   name  = "${var.Env-Name}-notify-email-failed"
 
   pattern        = "\"user-signup/email-notification\" -\"status=200\" -\"Processing\" -\"Sending performance\""
-  log_group_name = aws_cloudwatch_log_group.user-signup-api-log-group[0].name
+  log_group_name = aws_cloudwatch_log_group.user_signup_api_log_group[0].name
 
   metric_transformation {
     name          = "${var.Env-Name}-notify-email-failed-count"

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -1,13 +1,13 @@
-resource "aws_cloudwatch_event_target" "retrieve-notifications" {
+resource "aws_cloudwatch_event_target" "retrieve_notifications" {
   count     = var.user-signup-enabled
   target_id = "${var.Env-Name}-retrieve-notifications"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.retrieve_notifications_event[0].name
-  role_arn  = aws_iam_role.user-signup-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.user_signup_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.user_signup_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -16,8 +16,8 @@ resource "aws_cloudwatch_event_target" "retrieve-notifications" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id],
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id],
       )
 
       assign_public_ip = true
@@ -37,7 +37,7 @@ EOF
 
 }
 
-resource "aws_iam_role" "user-signup-scheduled-task-role" {
+resource "aws_iam_role" "user_signup_scheduled_task_role" {
   count = var.user-signup-enabled
   name  = "${var.Env-Name}-user-signup-scheduled-task-role"
 
@@ -59,10 +59,10 @@ DOC
 
 }
 
-resource "aws_iam_role_policy" "user-signup-scheduled-task-policy" {
+resource "aws_iam_role_policy" "user_signup_scheduled_task_policy" {
   count = var.user-signup-enabled
   name  = "${var.Env-Name}-user-signup-scheduled-task-policy"
-  role  = aws_iam_role.user-signup-scheduled-task-role[0].id
+  role  = aws_iam_role.user_signup_scheduled_task_role[0].id
 
   policy = <<DOC
 {
@@ -72,7 +72,7 @@ resource "aws_iam_role_policy" "user-signup-scheduled-task-policy" {
             "Effect": "Allow",
             "Action": "ecs:RunTask",
             "Resource": "${replace(
-  aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn,
+  aws_ecs_task_definition.user_signup_api_scheduled_task[0].arn,
   "/:\\d+$/",
   ":*",
 )}"
@@ -95,16 +95,16 @@ DOC
 
 }
 
-resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
+resource "aws_cloudwatch_event_target" "user_signup_daily_user_deletion" {
   count     = var.user-signup-enabled
   target_id = "${var.Env-Name}-user-signup-daily-user-deletion"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.daily_user_deletion_event[0].name
-  role_arn  = aws_iam_role.user-signup-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.user_signup_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.user_signup_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -113,8 +113,8 @@ resource "aws_cloudwatch_event_target" "user-signup-daily-user-deletion" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -134,16 +134,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "smoke-test-user-deletion" {
+resource "aws_cloudwatch_event_target" "smoke_test_user_deletion" {
   count     = var.user-signup-enabled
   target_id = "${var.Env-Name}-smoke-test-user-deletion"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.smoke_test_user_deletion_event[0].name
-  role_arn  = aws_iam_role.user-signup-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.user_signup_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.user_signup_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -152,8 +152,8 @@ resource "aws_cloudwatch_event_target" "smoke-test-user-deletion" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -173,16 +173,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "trim-sessions-database-table" {
+resource "aws_cloudwatch_event_target" "trim_sessions_database_table" {
   count     = var.user-signup-enabled
   target_id = "${var.Env-Name}-trim-sessions-database-table"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.trim_sessions_database_table_event[0].name
-  role_arn  = aws_iam_role.user-signup-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.user_signup_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.user_signup_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -191,8 +191,8 @@ resource "aws_cloudwatch_event_target" "trim-sessions-database-table" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -212,10 +212,10 @@ EOF
 
 }
 
-resource "aws_ecs_task_definition" "user-signup-api-scheduled-task" {
+resource "aws_ecs_task_definition" "user_signup_api_scheduled_task" {
   count                    = var.user-signup-enabled
   family                   = "user-signup-api-scheduled-task-${var.Env-Name}"
-  task_role_arn            = aws_iam_role.user-signup-api-task-role[0].arn
+  task_role_arn            = aws_iam_role.user_signup_api_task_role[0].arn
   execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
   requires_compatibilities = ["FARGATE"]
   cpu                      = 512
@@ -296,7 +296,7 @@ resource "aws_ecs_task_definition" "user-signup-api-scheduled-task" {
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "${aws_cloudwatch_log_group.user-signup-api-log-group[0].name}",
+          "awslogs-group": "${aws_cloudwatch_log_group.user_signup_api_log_group[0].name}",
           "awslogs-region": "${var.aws-region}",
           "awslogs-stream-prefix": "${var.Env-Name}-user-signup-api-docker-logs"
         }
@@ -310,16 +310,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "active-users-signup-surveys" {
+resource "aws_cloudwatch_event_target" "active_users_signup_surveys" {
   count     = var.user-signup-enabled
   target_id = "${var.Env-Name}-active-users-signup-surveys"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.active_users_signup_survey_event[0].name
-  role_arn  = aws_iam_role.user-signup-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.user_signup_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.user_signup_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -328,8 +328,8 @@ resource "aws_cloudwatch_event_target" "active-users-signup-surveys" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true
@@ -349,16 +349,16 @@ EOF
 
 }
 
-resource "aws_cloudwatch_event_target" "inactive-users-signup-surveys" {
+resource "aws_cloudwatch_event_target" "inactive_users_signup_surveys" {
   count     = var.user-signup-enabled
   target_id = "${var.Env-Name}-inactive-users-signup-surveys"
-  arn       = aws_ecs_cluster.api-cluster.arn
+  arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.inactive_users_signup_survey_event[0].name
-  role_arn  = aws_iam_role.user-signup-scheduled-task-role[0].arn
+  role_arn  = aws_iam_role.user_signup_scheduled_task_role[0].arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.user-signup-api-scheduled-task[0].arn
+    task_definition_arn = aws_ecs_task_definition.user_signup_api_scheduled_task[0].arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -367,8 +367,8 @@ resource "aws_cloudwatch_event_target" "inactive-users-signup-surveys" {
 
       security_groups = concat(
         var.backend-sg-list,
-        [aws_security_group.api-in.id],
-        [aws_security_group.api-out.id]
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
       )
 
       assign_public_ip = true


### PR DESCRIPTION
### What
Try to move towards using underscores rather than dashes, as this is
more consistent with Terraform itself. Just change the resources
within the govwifi-api module.

This shouldn't have any effects beyond the names used in Terraform
changing. Unfortunately, when applying this change, either the
existing resources will need to be moved (using the state mv command
for example), or need destroying and re-creating through running
terraform apply.

### Why
Consistency with Terraform itself.
