### PR TITLE
Bring Up Grafana and Prometheus In Secondary Staging

### DIFF
--- a/govwifi-frontend/route53.tf
+++ b/govwifi-frontend/route53.tf
@@ -2,10 +2,14 @@
 resource "aws_route53_record" "radius" {
   count   = var.radius-instance-count
   zone_id = var.route53-zone-id
-  name = format(
+  name = var.is_production_aws_account ? format(
     "radius%d.%s.service.gov.uk",
     var.dns-numbering-base + count.index + 1,
     var.Env-Subdomain
+    ) : format(
+    "radius%d.%s.service.gov.uk",
+    var.dns-numbering-base + count.index + 1,
+    "staging"
   )
   type    = "CNAME"
   ttl     = "300"
@@ -18,8 +22,11 @@ resource "aws_route53_record" "radius" {
 
 resource "aws_route53_health_check" "radius" {
   count = var.radius-instance-count
-  reference_name = format(
+  reference_name = var.is_production_aws_account ? format(
     "${var.Env-Name}-${var.aws-region-name}-frontend-%d",
+    count.index + 1
+    ) : format(
+    "${var.rack-env}-${var.aws-region-name}-frontend-%d",
     count.index + 1
   )
   ip_address        = element(aws_eip_association.eip_assoc.*.public_ip, count.index)

--- a/govwifi-grafana/route53.tf
+++ b/govwifi-grafana/route53.tf
@@ -11,7 +11,6 @@ resource "aws_route53_record" "grafana-route53-record" {
 }
 
 data "aws_route53_zone" "zone" {
-  name         = "wifi.service.gov.uk."
+  name         = var.is_production_aws_account ? "wifi.service.gov.uk." : "${var.Env-Subdomain}.service.gov.uk."
   private_zone = false
 }
-

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -80,3 +80,6 @@ variable "critical-notifications-arn" {
 
 variable "use_env_prefix" {
 }
+
+variable "is_production_aws_account" {
+}

--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -341,32 +341,32 @@ module "route53-notifications" {
   emails     = [var.notification-email]
 }
 
-# module "govwifi-prometheus" {
-#   providers = {
-#     aws = aws.AWS-main
-#   }
-#
-#   source     = "../../govwifi-prometheus"
-#   Env-Name   = var.Env-Name
-#   aws-region = var.aws-region
-#
-#   ssh-key-name = var.ssh-key-name
-#
-#   frontend-vpc-id = module.frontend.frontend-vpc-id
-#
-#   fe-admin-in   = module.frontend.fe-admin-in
-#   fe-ecs-out    = module.frontend.fe-ecs-out
-#   fe-radius-in  = module.frontend.fe-radius-in
-#   fe-radius-out = module.frontend.fe-radius-out
-#
-#   wifi-frontend-subnet       = module.frontend.wifi-frontend-subnet
-#   london-radius-ip-addresses = var.london-radius-ip-addresses
-#   dublin-radius-ip-addresses = var.dublin-radius-ip-addresses
-#
-#   # Feature toggle creating Prometheus server.
-#   # Value defaults to 0 and should only be enabled (i.e., value = 1)
-#   create_prometheus_server = 0
-#
-#   prometheus-IP = var.prometheus-IP-ireland
-#   grafana-IP    = "${var.grafana-IP}/32"
-# }
+module "govwifi-prometheus" {
+  providers = {
+    aws = aws.AWS-main
+  }
+
+  source     = "../../govwifi-prometheus"
+  Env-Name   = var.Env-Name
+  aws-region = var.aws-region
+
+  ssh-key-name = var.ssh-key-name
+
+  frontend-vpc-id = module.frontend.frontend-vpc-id
+
+  fe-admin-in   = module.frontend.fe-admin-in
+  fe-ecs-out    = module.frontend.fe-ecs-out
+  fe-radius-in  = module.frontend.fe-radius-in
+  fe-radius-out = module.frontend.fe-radius-out
+
+  wifi-frontend-subnet       = module.frontend.wifi-frontend-subnet
+  london-radius-ip-addresses = var.london-radius-ip-addresses
+  dublin-radius-ip-addresses = var.dublin-radius-ip-addresses
+
+  # Feature toggle creating Prometheus server.
+  # Value defaults to 0 and should only be enabled (i.e., value = 1)
+  create_prometheus_server = 0
+
+  prometheus-IP = var.prometheus-IP-ireland
+  grafana-IP    = "${var.grafana-IP}/32"
+}

--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -239,7 +239,6 @@ module "frontend" {
 
   use_env_prefix = var.use_env_prefix
 
-  is_production_aws_account = var.is_production_aws_account
 }
 
 module "api" {
@@ -313,8 +312,6 @@ module "api" {
   use_env_prefix = var.use_env_prefix
 
   low_cpu_threshold = 0.3
-
-  is_production_aws_account = var.is_production_aws_account
 }
 
 module "notifications" {

--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -180,9 +180,10 @@ module "frontend" {
     aws.route53-alarms = aws.route53-alarms
   }
 
-  source        = "../../govwifi-frontend"
-  Env-Name      = var.Env-Name
-  Env-Subdomain = var.Env-Subdomain
+  source                    = "../../govwifi-frontend"
+  Env-Name                  = var.Env-Name
+  Env-Subdomain             = var.Env-Subdomain
+  is_production_aws_account = var.is_production_aws_account
 
   # AWS VPC setup -----------------------------------------
   aws-region         = var.aws-region
@@ -246,10 +247,11 @@ module "api" {
     aws = aws.AWS-main
   }
 
-  source        = "../../govwifi-api"
-  env           = "staging"
-  Env-Name      = "staging"
-  Env-Subdomain = var.Env-Subdomain
+  source                    = "../../govwifi-api"
+  env                       = "staging"
+  Env-Name                  = "staging"
+  Env-Subdomain             = var.Env-Subdomain
+  is_production_aws_account = var.is_production_aws_account
 
   ami                    = ""
   ssh-key-name           = ""

--- a/govwifi/staging-dublin-temp/variables.tf
+++ b/govwifi/staging-dublin-temp/variables.tf
@@ -95,6 +95,16 @@ variable "prometheus-IP-london" {
 variable "prometheus-IP-ireland" {
 }
 
+variable "london-radius-ip-addresses" {
+  type        = list(any)
+  description = "Frontend RADIUS server IP addresses - London"
+}
+
+variable "dublin-radius-ip-addresses" {
+  type        = list(string)
+  description = "Frontend RADIUS server IP addresses - Dublin"
+}
+
 variable "grafana-IP" {
 }
 

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -438,44 +438,38 @@ when we create a separate staging environment.
 #   grafana-IP    = "${var.grafana-IP}/32"
 # }
 
-# module "govwifi-grafana" {
-#   providers = {
-#     aws = aws.AWS-main
-#   }
-#
-#   source                     = "../../govwifi-grafana"
-#   Env-Name                   = var.Env-Name
-#   Env-Subdomain              = var.Env-Subdomain
-#   aws-region                 = var.aws-region
-#   critical-notifications-arn = module.notifications.topic-arn
-#
-#   ssh-key-name = var.ssh-key-name
-#
-#   subnet-ids = module.backend.backend-subnet-ids
-#
-#   backend-subnet-ids = module.backend.backend-subnet-ids
-#
-#   be-admin-in = module.backend.be-admin-in
-#
-#   # Feature toggle so we only create the Grafana instance in Staging London
-#   create_grafana_server = "1"
-#
-#   vpc-id = module.backend.backend-vpc-id
-#
-#   bastion-ips = concat(
-#     split(",", var.bastion-server-IP),
-#     split(",", var.backend-subnet-IPs)
-#   )
-#
-#   administrator-IPs = var.administrator-IPs
-#
-#   prometheus-IPs = concat(
-#     split(",", "${var.prometheus-IP-london}/32"),
-#     split(",", "${var.prometheus-IP-ireland}/32")
-#   )
-#
-#   use_env_prefix = var.use_env_prefix
-# }
+module "govwifi-grafana" {
+  providers = {
+    aws = aws.AWS-main
+  }
+
+  source                     = "../../govwifi-grafana"
+  Env-Name                   = var.Env-Name
+  Env-Subdomain              = var.Env-Subdomain
+  aws-region                 = var.aws-region
+  critical-notifications-arn = module.notifications.topic-arn
+
+  ssh-key-name = var.ssh-key-name
+
+  subnet-ids = module.backend.backend-subnet-ids
+  backend-subnet-ids = module.backend.backend-subnet-ids
+  be-admin-in = module.backend.be-admin-in
+
+  # Feature toggle so we only create the Grafana instance in Staging London
+  create_grafana_server = "1"
+  vpc-id = module.backend.backend-vpc-id
+  bastion-ips = concat(
+    split(",", var.bastion-server-IP),
+    split(",", var.backend-subnet-IPs)
+  )
+  administrator-IPs = var.administrator-IPs
+  prometheus-IPs = concat(
+    split(",", "${var.prometheus-IP-london}/32"),
+    split(",", "${var.prometheus-IP-ireland}/32")
+  )
+
+  use_env_prefix = var.use_env_prefix
+}
 
 module "govwifi-elasticsearch" {
   providers = {

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -209,7 +209,6 @@ module "frontend" {
 
   use_env_prefix = var.use_env_prefix
 
-  is_production_aws_account = var.is_production_aws_account
 }
 
 module "govwifi-admin" {
@@ -364,7 +363,6 @@ module "api" {
 
   low_cpu_threshold = 0.3
 
-  is_production_aws_account = var.is_production_aws_account
 }
 
 module "notifications" {

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -408,35 +408,35 @@ There are some problems with the Staging Bastion instance that is preventing
 us from mirroring the setup in Production in Staging. This will be rectified
 when we create a separate staging environment.
 */
-# module "govwifi-prometheus" {
-#   providers = {
-#     aws = aws.AWS-main
-#   }
-#
-#   source     = "../../govwifi-prometheus"
-#   Env-Name   = var.Env-Name
-#   aws-region = var.aws-region
-#
-#   ssh-key-name = var.ssh-key-name
-#
-#   frontend-vpc-id = module.frontend.frontend-vpc-id
-#
-#   fe-admin-in   = module.frontend.fe-admin-in
-#   fe-ecs-out    = module.frontend.fe-ecs-out
-#   fe-radius-in  = module.frontend.fe-radius-in
-#   fe-radius-out = module.frontend.fe-radius-out
-#
-#   wifi-frontend-subnet       = module.frontend.wifi-frontend-subnet
-#   london-radius-ip-addresses = var.london-radius-ip-addresses
-#   dublin-radius-ip-addresses = var.dublin-radius-ip-addresses
-#
-#   # Feature toggle creating Prometheus server.
-#   # Value defaults to 0 and is only enabled (i.e., value = 1) in staging-london
-#   create_prometheus_server = 1
-#
-#   prometheus-IP = var.prometheus-IP-london
-#   grafana-IP    = "${var.grafana-IP}/32"
-# }
+module "govwifi-prometheus" {
+  providers = {
+    aws = aws.AWS-main
+  }
+
+  source     = "../../govwifi-prometheus"
+  Env-Name   = var.Env-Name
+  aws-region = var.aws-region
+
+  ssh-key-name = var.ssh-key-name
+
+  frontend-vpc-id = module.frontend.frontend-vpc-id
+
+  fe-admin-in   = module.frontend.fe-admin-in
+  fe-ecs-out    = module.frontend.fe-ecs-out
+  fe-radius-in  = module.frontend.fe-radius-in
+  fe-radius-out = module.frontend.fe-radius-out
+
+  wifi-frontend-subnet       = module.frontend.wifi-frontend-subnet
+  london-radius-ip-addresses = var.london-radius-ip-addresses
+  dublin-radius-ip-addresses = var.dublin-radius-ip-addresses
+
+  // Feature toggle creating Prometheus server.
+  // Value defaults to 0 and is only enabled (i.e., value = 1) in staging-london
+  create_prometheus_server = 1
+
+  prometheus-IP = var.prometheus-IP-london
+  grafana-IP    = "${var.grafana-IP}/32"
+}
 
 module "govwifi-grafana" {
   providers = {

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -446,16 +446,18 @@ module "govwifi-grafana" {
   Env-Subdomain              = var.Env-Subdomain
   aws-region                 = var.aws-region
   critical-notifications-arn = module.notifications.topic-arn
+  is_production_aws_account  = var.is_production_aws_account
+
 
   ssh-key-name = var.ssh-key-name
 
-  subnet-ids = module.backend.backend-subnet-ids
+  subnet-ids         = module.backend.backend-subnet-ids
   backend-subnet-ids = module.backend.backend-subnet-ids
-  be-admin-in = module.backend.be-admin-in
+  be-admin-in        = module.backend.be-admin-in
 
   # Feature toggle so we only create the Grafana instance in Staging London
   create_grafana_server = "1"
-  vpc-id = module.backend.backend-vpc-id
+  vpc-id                = module.backend.backend-vpc-id
   bastion-ips = concat(
     split(",", var.bastion-server-IP),
     split(",", var.backend-subnet-IPs)

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -145,9 +145,10 @@ module "frontend" {
     aws.route53-alarms = aws.route53-alarms
   }
 
-  source        = "../../govwifi-frontend"
-  Env-Name      = var.Env-Name
-  Env-Subdomain = var.Env-Subdomain
+  source                    = "../../govwifi-frontend"
+  Env-Name                  = var.Env-Name
+  Env-Subdomain             = var.Env-Subdomain
+  is_production_aws_account = var.is_production_aws_account
 
   # AWS VPC setup -----------------------------------------
   # LONDON
@@ -291,10 +292,11 @@ module "api" {
     aws = aws.AWS-main
   }
 
-  source        = "../../govwifi-api"
-  env           = "staging"
-  Env-Name      = "staging"
-  Env-Subdomain = var.Env-Subdomain
+  source                    = "../../govwifi-api"
+  env                       = "staging"
+  Env-Name                  = "staging"
+  Env-Subdomain             = var.Env-Subdomain
+  is_production_aws_account = var.is_production_aws_account
 
   ami                    = var.ami
   ssh-key-name           = var.ssh-key-name

--- a/govwifi/staging-london-temp/variables.tf
+++ b/govwifi/staging-london-temp/variables.tf
@@ -78,11 +78,6 @@ variable "public-google-api-key" {
   default = "xxxxxxxxxxxxxxxxxxxxx"
 }
 
-variable "otp-secret-encryption-key" {
-  type        = string
-  description = "Encryption key used to verify OTP authentication codes"
-}
-
 variable "user-signup-sentry-dsn" {
   type = string
 }
@@ -93,26 +88,6 @@ variable "logging-sentry-dsn" {
 
 variable "admin-sentry-dsn" {
   type = string
-}
-
-variable "db-password" {
-  type        = string
-  description = "Database main password"
-}
-
-variable "db-user" {
-  type        = string
-  description = "Database username"
-}
-
-variable "user-db-password" {
-  type        = string
-  description = "User details database main password"
-}
-
-variable "user-db-username" {
-  type        = string
-  description = "Users database username"
 }
 
 variable "user-db-hostname" {
@@ -131,111 +106,10 @@ variable "admin-db-username" {
   type        = string
   description = "Database main username for govwifi-admin"
 }
-variable "admin-db-password" {
-  type        = string
-  description = "Database main password for govwifi-admin"
-}
 
 variable "zendesk-api-user" {
   type        = string
   description = "Username for authenticating with Zendesk API"
-}
-
-variable "zendesk-api-token" {
-  type        = string
-  description = "Token for authenticating with Zendesk API"
-}
-
-variable "hc-key" {
-  type        = string
-  description = "Health check process shared secret"
-}
-
-variable "hc-ssid" {
-  type        = string
-  description = "Health check simulated SSID"
-}
-
-variable "hc-identity" {
-  type        = string
-  description = "Health check identity"
-}
-
-variable "hc-password" {
-  type        = string
-  description = "Health check password"
-}
-
-variable "shared-key" {
-  type        = string
-  description = "A random key to be shared between the fronend and backend to retrieve initial client setup."
-}
-
-variable "notify-api-key" {
-  type        = string
-  description = "API key used to authenticate with GOV.UK Notify"
-}
-
-variable "aws-account-id" {
-  type        = string
-  description = "The ID of the AWS tenancy."
-}
-
-variable "admin-secret-key-base" {
-  type        = string
-  description = "Rails secret key base for the Admin platform"
-}
-
-variable "docker-image-path" {
-  type        = string
-  description = "ARN used to identify the common path element used for the docker API image repositories."
-}
-
-variable "route53-zone-id" {
-  type        = string
-  description = "Zone ID used by the Route53 DNS service."
-}
-
-variable "performance-url" {
-  type        = string
-  description = "URL endpoint leading to Performance platform API, with a trailing slash at the end"
-  default     = "unused-on-staging"
-}
-
-variable "performance-dataset" {
-  type        = string
-  description = "Dataset to which Performance statistics should be saved e.g `gov-wifi`"
-  default     = "unused-on-staging"
-}
-
-variable "performance-bearer-volumetrics" {
-  type        = string
-  description = "Bearer token for `volumetrics` Performance platform statistics"
-  default     = "unused-on-staging"
-}
-
-variable "performance-bearer-completion-rate" {
-  type        = string
-  description = "Bearer token for `completion-rate` Performance platform statistics"
-  default     = "unused-on-staging"
-}
-
-variable "performance-bearer-active-users" {
-  type        = string
-  description = "Bearer token for `active-users` Performance platform statistics"
-  default     = "unused-on-staging"
-}
-
-variable "performance-bearer-unique-users" {
-  type        = string
-  description = "Bearer token for `unique-users` Performance platform statistics"
-  default     = "unused-on-staging"
-}
-
-variable "performance-bearer-roaming-users" {
-  type        = string
-  description = "Bearer token for `roaming-users` Performance platform statistics"
-  default     = "unused-on-staging"
 }
 
 variable "london-radius-ip-addresses" {
@@ -254,10 +128,6 @@ variable "london-api-base-url" {
   default     = "https://api-elb.london.staging-temp.wifi.service.gov.uk:8443"
 }
 
-variable "govnotify-bearer-token" {
-  type = string
-}
-
 variable "notification-email" {
 }
 
@@ -268,17 +138,6 @@ variable "prometheus-IP-ireland" {
 }
 
 variable "grafana-IP" {
-}
-
-variable "aws-parent-account-id" {
-  description = "Unused in this configuration"
-}
-
-variable "govwifi-api-ssl-cert-arn" {
-  description = "Unused in this configuration"
-}
-
-variable "gds-slack-workplace-id" {
 }
 
 variable "gds-slack-channel-id" {

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -442,6 +442,7 @@ module "govwifi-grafana" {
   Env-Subdomain              = var.Env-Subdomain
   aws-region                 = var.aws-region
   critical-notifications-arn = module.notifications.topic-arn
+  is_production_aws_account  = var.is_production_aws_account
 
   ssh-key-name = var.ssh-key-name
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -483,6 +483,7 @@ module "govwifi-grafana" {
   Env-Subdomain              = var.Env-Subdomain
   aws-region                 = var.aws-region
   critical-notifications-arn = module.critical-notifications.topic-arn
+  is_production_aws_account  = var.is_production_aws_account
 
   ssh-key-name = var.ssh-key-name
 


### PR DESCRIPTION
### What
Add Grafana and Prometheus to Secondary Staging London
Remove unnecessary variables for Performance platform, and migrated secret values.
Add `monitoring-stats-user` to terraform. This will need importing into the appropriate environments directly after this branch is merged with `master`. 

### Why
These changes are needed to make the Secondary Staging environment functional.

**Trello:** 
https://trello.com/c/DnFOMDcA/1586-get-grafana-prometheus-running-smoothly-in-secondary-staging
