### PR TITLE
Use underscores for resource names in govwifi-admin

### DIFF
--- a/govwifi-admin/alarms.tf
+++ b/govwifi-admin/alarms.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_metric_alarm" "admin-no-healthy-hosts" {
+resource "aws_cloudwatch_metric_alarm" "admin_no_healthy_hosts" {
   alarm_name          = "${var.Env-Name} admin no healthy hosts"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-no-healthy-hosts" {
   datapoints_to_alarm = "1"
 
   dimensions = {
-    LoadBalancer = aws_lb.admin-alb.arn_suffix
+    LoadBalancer = aws_lb.admin_alb.arn_suffix
   }
 
   alarm_description = "Load balancer detects no healthy admin targets. Investigate admin-api ECS cluster and CloudWatch logs for root cause."

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -1,22 +1,22 @@
-resource "aws_ecs_cluster" "admin-cluster" {
+resource "aws_ecs_cluster" "admin_cluster" {
   name = "${var.Env-Name}-admin-cluster"
 }
 
-resource "aws_cloudwatch_log_group" "admin-log-group" {
+resource "aws_cloudwatch_log_group" "admin_log_group" {
   name = "${var.Env-Name}-admin-log-group"
 
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "govwifi-admin-ecr" {
+resource "aws_ecr_repository" "govwifi_admin_ecr" {
   count = var.ecr-repository-count
   name  = "govwifi/admin"
 }
 
-resource "aws_ecs_task_definition" "admin-task" {
+resource "aws_ecs_task_definition" "admin_task" {
   family                   = "admin-task-${var.Env-Name}"
   requires_compatibilities = ["FARGATE"]
-  task_role_arn            = aws_iam_role.ecs-admin-instance-role.arn
+  task_role_arn            = aws_iam_role.ecs_admin_instance_role.arn
   execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
   cpu                      = "512"
   memory                   = "1024"
@@ -64,16 +64,16 @@ resource "aws_ecs_task_definition" "admin-task" {
           "value": "${var.sentry-dsn}"
         },{
           "name": "S3_MOU_BUCKET",
-          "value": "${aws_s3_bucket.admin-mou-bucket[0].id}"
+          "value": "${aws_s3_bucket.admin_mou_bucket[0].id}"
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_BUCKET",
-          "value": "${aws_s3_bucket.admin-bucket[0].id}"
+          "value": "${aws_s3_bucket.admin_bucket[0].id}"
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
         },{
           "name": "S3_SIGNUP_WHITELIST_BUCKET",
-          "value": "${aws_s3_bucket.admin-bucket[0].id}"
+          "value": "${aws_s3_bucket.admin_bucket[0].id}"
         },{
           "name": "S3_SIGNUP_WHITELIST_OBJECT_KEY",
           "value": "signup-whitelist.conf"
@@ -82,7 +82,7 @@ resource "aws_ecs_task_definition" "admin-task" {
           "value": "clients.conf"
         },{
           "name": "S3_PRODUCT_PAGE_DATA_BUCKET",
-          "value": "${aws_s3_bucket.product-page-data-bucket[0].id}"
+          "value": "${aws_s3_bucket.product_page_data_bucket[0].id}"
         },{
           "name": "S3_ORGANISATION_NAMES_OBJECT_KEY",
           "value": "organisations.yml"
@@ -158,7 +158,7 @@ resource "aws_ecs_task_definition" "admin-task" {
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "${aws_cloudwatch_log_group.admin-log-group.name}",
+          "awslogs-group": "${aws_cloudwatch_log_group.admin_log_group.name}",
           "awslogs-region": "${var.aws-region}",
           "awslogs-stream-prefix": "${var.Env-Name}-admin-docker-logs"
         }
@@ -170,17 +170,17 @@ EOF
 
 }
 
-resource "aws_ecs_service" "admin-service" {
+resource "aws_ecs_service" "admin_service" {
   depends_on       = [aws_alb_listener.alb_listener]
   name             = "admin-${var.Env-Name}"
-  cluster          = aws_ecs_cluster.admin-cluster.id
-  task_definition  = aws_ecs_task_definition.admin-task.arn
+  cluster          = aws_ecs_cluster.admin_cluster.id
+  task_definition  = aws_ecs_task_definition.admin_task.arn
   desired_count    = var.instance-count
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.admin-tg.arn
+    target_group_arn = aws_alb_target_group.admin_tg.arn
     container_name   = "admin"
     container_port   = "3000"
   }
@@ -189,16 +189,16 @@ resource "aws_ecs_service" "admin-service" {
     subnets = var.subnet-ids
 
     security_groups = [
-      aws_security_group.admin-ec2-in.id,
-      aws_security_group.admin-ec2-out.id,
+      aws_security_group.admin_ec2_in.id,
+      aws_security_group.admin_ec2_out.id,
     ]
 
     assign_public_ip = true
   }
 }
 
-resource "aws_alb_target_group" "admin-tg" {
-  depends_on           = [aws_lb.admin-alb]
+resource "aws_alb_target_group" "admin_tg" {
+  depends_on           = [aws_lb.admin_alb]
   name                 = "admin-${var.Env-Name}-fg-tg"
   port                 = "3000"
   protocol             = "HTTP"

--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -1,4 +1,4 @@
-resource "aws_db_parameter_group" "db-parameters" {
+resource "aws_db_parameter_group" "db_parameters" {
   name        = "${var.Env-Name}-admin-db-parameter-group"
   family      = "mysql5.7"
   description = "DB parameter configuration for govwifi-admin"
@@ -28,7 +28,7 @@ resource "aws_db_parameter_group" "db-parameters" {
   }
 }
 
-resource "aws_db_option_group" "mariadb-audit" {
+resource "aws_db_option_group" "mariadb_audit" {
   name = "${var.Env-Name}-admin-db-audit"
 
   option_group_description = "Mariadb audit configuration for govwifi-admin"
@@ -61,7 +61,7 @@ resource "aws_db_instance" "admin_db" {
   multi_az                    = true
   storage_encrypted           = var.db-encrypt-at-rest
   db_subnet_group_name        = "wifi-${var.Env-Name}-subnets"
-  vpc_security_group_ids      = [aws_security_group.admin-db-in.id]
+  vpc_security_group_ids      = [aws_security_group.admin_db_in.id]
   monitoring_role_arn         = var.rds-monitoring-role
   monitoring_interval         = var.db-monitoring-interval
   maintenance_window          = var.db-maintenance-window
@@ -70,8 +70,8 @@ resource "aws_db_instance" "admin_db" {
   deletion_protection         = true
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
-  option_group_name               = aws_db_option_group.mariadb-audit.name
-  parameter_group_name            = aws_db_parameter_group.db-parameters.name
+  option_group_name               = aws_db_option_group.mariadb_audit.name
+  parameter_group_name            = aws_db_parameter_group.db_parameters.name
 
   tags = {
     Name = "${title(var.Env-Name)} DB for govwifi-admin"

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -1,7 +1,7 @@
-resource "aws_iam_role_policy" "ecs-admin-instance-policy" {
+resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
   name       = "${var.aws-region-name}-ecs-admin-instance-policy-${var.Env-Name}"
-  role       = aws_iam_role.ecs-admin-instance-role.id
-  depends_on = [aws_s3_bucket.admin-bucket]
+  role       = aws_iam_role.ecs_admin_instance_role.id
+  depends_on = [aws_s3_bucket.admin_bucket]
 
   policy = <<EOF
 {
@@ -58,7 +58,7 @@ resource "aws_iam_role_policy" "ecs-admin-instance-policy" {
         "s3:PutObject",
         "s3:GetObject"
       ],
-      "Resource": ["${aws_s3_bucket.admin-bucket[0].arn}/*"]
+      "Resource": ["${aws_s3_bucket.admin_bucket[0].arn}/*"]
     },{
       "Effect": "Allow",
       "Action": [
@@ -68,13 +68,13 @@ resource "aws_iam_role_policy" "ecs-admin-instance-policy" {
         "s3:GetObjectAcl",
         "s3:DeleteObject"
       ],
-      "Resource": ["${aws_s3_bucket.admin-mou-bucket[0].arn}/*"]
+      "Resource": ["${aws_s3_bucket.admin_mou_bucket[0].arn}/*"]
     },{
       "Effect": "Allow",
       "Action": [
         "s3:ListBucket"
       ],
-      "Resource": ["${aws_s3_bucket.admin-mou-bucket[0].arn}"]
+      "Resource": ["${aws_s3_bucket.admin_mou_bucket[0].arn}"]
     },
     {
       "Effect": "Allow",
@@ -83,7 +83,7 @@ resource "aws_iam_role_policy" "ecs-admin-instance-policy" {
         "s3:PutObjectAcl",
         "s3:PutObjectVersionAcl"
       ],
-      "Resource": ["${aws_s3_bucket.product-page-data-bucket[0].arn}/*"]
+      "Resource": ["${aws_s3_bucket.product_page_data_bucket[0].arn}/*"]
     }
   ]
 }
@@ -91,7 +91,7 @@ EOF
 
 }
 
-resource "aws_iam_role" "ecs-admin-instance-role" {
+resource "aws_iam_role" "ecs_admin_instance_role" {
   name = "${var.aws-region-name}-ecs-admin-instance-role-${var.Env-Name}"
 
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json

--- a/govwifi-admin/loadbalancer.tf
+++ b/govwifi-admin/loadbalancer.tf
@@ -1,11 +1,11 @@
-resource "aws_lb" "admin-alb" {
+resource "aws_lb" "admin_alb" {
   name     = "admin-alb-${var.Env-Name}"
   internal = false
   subnets  = var.subnet-ids
 
   security_groups = [
-    aws_security_group.admin-alb-in.id,
-    aws_security_group.admin-alb-out.id,
+    aws_security_group.admin_alb_in.id,
+    aws_security_group.admin_alb_out.id,
   ]
 
   load_balancer_type = "application"
@@ -16,14 +16,14 @@ resource "aws_lb" "admin-alb" {
 }
 
 resource "aws_alb_listener" "alb_listener" {
-  load_balancer_arn = aws_lb.admin-alb.arn
+  load_balancer_arn = aws_lb.admin_alb.arn
   port              = "443"
   protocol          = "HTTPS"
   certificate_arn   = aws_acm_certificate_validation.certificate.certificate_arn
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
 
   default_action {
-    target_group_arn = aws_alb_target_group.admin-tg.arn
+    target_group_arn = aws_alb_target_group.admin_tg.arn
     type             = "forward"
   }
 }

--- a/govwifi-admin/outputs.tf
+++ b/govwifi-admin/outputs.tf
@@ -4,6 +4,6 @@ output "db-hostname" {
 
 output "aws-s3-admin-bucket-name" {
   description = "the name for the admin bucket"
-  value       = aws_s3_bucket.admin-bucket[0].id
+  value       = aws_s3_bucket.admin_bucket[0].id
 }
 

--- a/govwifi-admin/route53.tf
+++ b/govwifi-admin/route53.tf
@@ -4,8 +4,8 @@ resource "aws_route53_record" "admin" {
   type    = "A"
 
   alias {
-    name                   = aws_lb.admin-alb.dns_name
-    zone_id                = aws_lb.admin-alb.zone_id
+    name                   = aws_lb.admin_alb.dns_name
+    zone_id                = aws_lb.admin_alb.zone_id
     evaluate_target_health = true
   }
 }

--- a/govwifi-admin/s3.tf
+++ b/govwifi-admin/s3.tf
@@ -1,4 +1,4 @@
-resource "aws_s3_bucket" "admin-bucket" {
+resource "aws_s3_bucket" "admin_bucket" {
   count         = 1
   bucket        = var.is_production_aws_account ? "govwifi-${var.rack-env}-admin" : "govwifi-${var.Env-Subdomain}-admin"
   force_destroy = true
@@ -15,7 +15,7 @@ resource "aws_s3_bucket" "admin-bucket" {
   }
 }
 
-resource "aws_s3_bucket" "product-page-data-bucket" {
+resource "aws_s3_bucket" "product_page_data_bucket" {
   count         = 1
   bucket        = var.is_production_aws_account ? "govwifi-${var.rack-env}-product-page-data" : "govwifi-${var.Env-Subdomain}-product-page-data"
   force_destroy = true
@@ -32,7 +32,7 @@ resource "aws_s3_bucket" "product-page-data-bucket" {
   }
 }
 
-resource "aws_s3_bucket" "admin-mou-bucket" {
+resource "aws_s3_bucket" "admin_mou_bucket" {
   count         = 1
   bucket        = var.is_production_aws_account ? "govwifi-${var.rack-env}-admin-mou" : "govwifi-${var.Env-Subdomain}-admin-mou"
   force_destroy = true
@@ -49,8 +49,8 @@ resource "aws_s3_bucket" "admin-mou-bucket" {
   }
 }
 
-resource "aws_s3_bucket_policy" "admin-bucket-policy" {
-  bucket = aws_s3_bucket.admin-bucket[0].id
+resource "aws_s3_bucket_policy" "admin_bucket_policy" {
+  bucket = aws_s3_bucket.admin_bucket[0].id
 
   policy = <<POLICY
 {
@@ -62,7 +62,7 @@ resource "aws_s3_bucket_policy" "admin-bucket-policy" {
       "Effect": "Allow",
       "Principal": "*",
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::${aws_s3_bucket.admin-bucket[0].id}/clients.conf",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.admin_bucket[0].id}/clients.conf",
       "Condition": {
         "IpAddress": {
           "aws:SourceIp": [
@@ -86,8 +86,8 @@ POLICY
 
 }
 
-resource "aws_s3_bucket_policy" "product-page-data-bucket-policy" {
-  bucket = aws_s3_bucket.product-page-data-bucket[0].id
+resource "aws_s3_bucket_policy" "product_page_data_bucket_policy" {
+  bucket = aws_s3_bucket.product_page_data_bucket[0].id
 
   policy = <<POLICY
 {
@@ -102,7 +102,7 @@ resource "aws_s3_bucket_policy" "product-page-data-bucket-policy" {
                 "s3:GetObject",
                 "s3:GetObjectVersion"
             ],
-            "Resource": "arn:aws:s3:::${aws_s3_bucket.product-page-data-bucket[0].id}/*"
+            "Resource": "arn:aws:s3:::${aws_s3_bucket.product_page_data_bucket[0].id}/*"
         },
         {
             "Sid": "Get Product Page Data For Bucket",
@@ -113,7 +113,7 @@ resource "aws_s3_bucket_policy" "product-page-data-bucket-policy" {
                 "s3:ListBucket",
                 "s3:ListBucketVersions"
             ],
-            "Resource": "arn:aws:s3:::${aws_s3_bucket.product-page-data-bucket[0].id}"
+            "Resource": "arn:aws:s3:::${aws_s3_bucket.product_page_data_bucket[0].id}"
         }
     ]
 }

--- a/govwifi-admin/scheduled-tasks.tf
+++ b/govwifi-admin/scheduled-tasks.tf
@@ -31,7 +31,7 @@ resource "aws_iam_role_policy" "scheduled_task" {
             "Effect": "Allow",
             "Action": "ecs:RunTask",
             "Resource": "${replace(
-  aws_ecs_task_definition.admin-task.arn,
+  aws_ecs_task_definition.admin_task.arn,
   "/:\\d+$/",
   ":*",
 )}"
@@ -65,13 +65,13 @@ resource "aws_cloudwatch_event_rule" "daily_cleanup_orphan_users" {
 
 resource "aws_cloudwatch_event_target" "cleanup_orphan_admin_users" {
   target_id = "${var.Env-Name}-cleanup-orphan-admin-users"
-  arn       = aws_ecs_cluster.admin-cluster.arn
+  arn       = aws_ecs_cluster.admin_cluster.arn
   rule      = aws_cloudwatch_event_rule.daily_cleanup_orphan_users.name
   role_arn  = aws_iam_role.scheduled_task.arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.admin-task.arn
+    task_definition_arn = aws_ecs_task_definition.admin_task.arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -79,8 +79,8 @@ resource "aws_cloudwatch_event_target" "cleanup_orphan_admin_users" {
       subnets = var.subnet-ids
 
       security_groups = concat(
-        [aws_security_group.admin-ec2-in.id],
-        [aws_security_group.admin-ec2-out.id]
+        [aws_security_group.admin_ec2_in.id],
+        [aws_security_group.admin_ec2_out.id]
       )
 
       assign_public_ip = true
@@ -111,13 +111,13 @@ resource "aws_cloudwatch_event_rule" "daily_backup_service_emails" {
 
 resource "aws_cloudwatch_event_target" "admin_backup_service_emails" {
   target_id = "${var.Env-Name}-admin-backup-service-emails"
-  arn       = aws_ecs_cluster.admin-cluster.arn
+  arn       = aws_ecs_cluster.admin_cluster.arn
   rule      = aws_cloudwatch_event_rule.daily_backup_service_emails.name
   role_arn  = aws_iam_role.scheduled_task.arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.admin-task.arn
+    task_definition_arn = aws_ecs_task_definition.admin_task.arn
     launch_type         = "FARGATE"
     platform_version    = "1.3.0"
 
@@ -125,8 +125,8 @@ resource "aws_cloudwatch_event_target" "admin_backup_service_emails" {
       subnets = var.subnet-ids
 
       security_groups = concat(
-        [aws_security_group.admin-ec2-in.id],
-        [aws_security_group.admin-ec2-out.id]
+        [aws_security_group.admin_ec2_in.id],
+        [aws_security_group.admin_ec2_out.id]
       )
 
       assign_public_ip = true

--- a/govwifi-admin/security_groups.tf
+++ b/govwifi-admin/security_groups.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "admin-alb-in" {
+resource "aws_security_group" "admin_alb_in" {
   name        = "admin-alb-in"
   description = "Allow Inbound Traffic to the admin platform ALB"
   vpc_id      = var.vpc-id
@@ -15,7 +15,7 @@ resource "aws_security_group" "admin-alb-in" {
   }
 }
 
-resource "aws_security_group" "admin-alb-out" {
+resource "aws_security_group" "admin_alb_out" {
   name        = "admin-alb-out"
   description = "Allow Outbound Traffic from the admin platform ALB"
   vpc_id      = var.vpc-id
@@ -32,7 +32,7 @@ resource "aws_security_group" "admin-alb-out" {
   }
 }
 
-resource "aws_security_group" "admin-ec2-in" {
+resource "aws_security_group" "admin_ec2_in" {
   name        = "admin-ec2-in"
   description = "Allow Inbound Traffic To Admin from the ALB"
   vpc_id      = var.vpc-id
@@ -45,7 +45,7 @@ resource "aws_security_group" "admin-ec2-in" {
     from_port       = 0
     to_port         = 65535
     protocol        = "tcp"
-    security_groups = [aws_security_group.admin-alb-out.id]
+    security_groups = [aws_security_group.admin_alb_out.id]
   }
 
   ingress {
@@ -56,7 +56,7 @@ resource "aws_security_group" "admin-ec2-in" {
   }
 }
 
-resource "aws_security_group" "admin-ec2-out" {
+resource "aws_security_group" "admin_ec2_out" {
   name        = "api-ec2-out"
   description = "Allow Outbound Traffic From the Admin EC2 container"
   vpc_id      = var.vpc-id
@@ -73,7 +73,7 @@ resource "aws_security_group" "admin-ec2-out" {
   }
 }
 
-resource "aws_security_group" "admin-db-in" {
+resource "aws_security_group" "admin_db_in" {
   name        = "admin-db-in"
   description = "Allow connections to the DB"
   vpc_id      = var.vpc-id


### PR DESCRIPTION
### What
Try to move towards using underscores rather than dashes, as this is
more consistent with Terraform itself. Just change the resources
within the govwifi-admin module.

This shouldn't have any effects beyond the names used in Terraform
changing. Unfortunately, when applying this change, either the
existing resources will need to be moved (using the state mv command
for example), or need destroying and re-creating through running
terraform apply.

### Why
Consistency with Terraform.
