### PR TITLE
Clarify bastion-server-ip variable and type

### DIFF
--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "grafana-ec2-in" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = distinct(var.bastion-ips)
+    cidr_blocks = ["${var.bastion_ip}/32"]
   }
 }
 
@@ -80,7 +80,7 @@ resource "aws_security_group" "grafana-ec2-out" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = distinct(var.bastion-ips)
+    cidr_blocks = ["${var.bastion_ip}/32"]
   }
 
   egress {

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -40,10 +40,9 @@ variable "vpc-id" {
   type        = string
 }
 
-variable "bastion-ips" {
-  description = "The list of allowed hosts to connect to the EC2 instances."
-  type        = list(string)
-  default     = []
+variable "bastion_ip" {
+  description = "The IP address of the bastion machine."
+  type        = string
 }
 
 variable "prometheus-IPs" {

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -458,10 +458,12 @@ module "govwifi-grafana" {
   # Feature toggle so we only create the Grafana instance in Staging London
   create_grafana_server = "1"
   vpc-id                = module.backend.backend-vpc-id
-  bastion-ips = concat(
-    split(",", var.bastion-server-IP),
-    split(",", var.backend-subnet-IPs)
-  )
+
+  # The value of bastion-server-IP isn't actually an IP address, but a
+  # /32 CIDR block, extract the IP address from CIDR block here before
+  # passing it on.
+  bastion_ip = split("/", var.bastion-server-IP)[0]
+
   administrator-IPs = var.administrator-IPs
   prometheus-IPs = concat(
     split(",", "${var.prometheus-IP-london}/32"),

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -457,10 +457,10 @@ module "govwifi-grafana" {
 
   vpc-id = module.backend.backend-vpc-id
 
-  bastion-ips = concat(
-    split(",", var.bastion-server-IP),
-    split(",", var.backend-subnet-IPs)
-  )
+  # The value of bastion-server-IP isn't actually an IP address, but a
+  # /32 CIDR block, extract the IP address from CIDR block here before
+  # passing it on.
+  bastion_ip = split("/", var.bastion-server-IP)[0]
 
   administrator-IPs = var.administrator-IPs
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -498,10 +498,10 @@ module "govwifi-grafana" {
 
   vpc-id = module.backend.backend-vpc-id
 
-  bastion-ips = concat(
-    split(",", var.bastion-server-IP),
-    split(",", var.backend-subnet-IPs)
-  )
+  # The value of bastion-server-IP isn't actually an IP address, but a
+  # /32 CIDR block, extract the IP address from CIDR block here before
+  # passing it on.
+  bastion_ip = split("/", var.bastion-server-IP)[0]
 
   administrator-IPs = var.administrator-IPs
 


### PR DESCRIPTION
### What

Clarify in the code that the `bastion-server-ip` variable is a CIDR range, not an IP. 

### Why 

The description says it's a list of hosts, but it's actually a list of CIDR blocks, one of which is a /32 containing the IP address of the bastion machine, but there's some other larger blocks as well.

All that's required for the grafana module is just the IP address of the bastion machine, so move things in that direction.

Unfortunately, `var.bastion-server-IP` is also not actually an IP address, but a single CIDR block –– so fix that when passing the value to the module.