### PR TITLE
Change module "govwifi-admin" to "govwifi_admin"

### DIFF
--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -211,7 +211,7 @@ module "frontend" {
 
 }
 
-module "govwifi-admin" {
+module "govwifi_admin" {
   providers = {
     aws = aws.AWS-main
   }

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -208,7 +208,7 @@ module "frontend" {
   use_env_prefix = var.use_env_prefix
 }
 
-module "govwifi-admin" {
+module "govwifi_admin" {
   providers = {
     aws = aws.AWS-main
   }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -223,7 +223,7 @@ module "frontend" {
   use_env_prefix = var.use_env_prefix
 }
 
-module "govwifi-admin" {
+module "govwifi_admin" {
   providers = {
     aws = aws.AWS-main
   }


### PR DESCRIPTION
### What
Change module "govwifi-admin" to "govwifi_admin".

### Why
So that the resource names just have underscores rather than dashes
plus underscores.