### PR TITLE
Use underscores rather than dashes for module names

### DIFF
--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -155,7 +155,7 @@ module "emails" {
   sns-endpoint = ""
 }
 
-module "govwifi-keys" {
+module "govwifi_keys" {
   providers = {
     aws = aws.AWS-main
   }
@@ -338,7 +338,7 @@ module "route53-notifications" {
   emails     = [var.notification-email]
 }
 
-module "govwifi-prometheus" {
+module "govwifi_prometheus" {
   providers = {
     aws = aws.AWS-main
   }

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -45,7 +45,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-module "govwifi-keys" {
+module "govwifi_keys" {
   providers = {
     aws = aws.AWS-main
   }
@@ -356,7 +356,7 @@ module "api" {
     module.backend.be-admin-in,
   ]
 
-  metrics-bucket-name = module.govwifi-dashboard.metrics-bucket-name
+  metrics-bucket-name = module.govwifi_dashboard.metrics-bucket-name
 
   use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
@@ -389,7 +389,7 @@ module "route53-notifications" {
   emails     = [var.notification-email]
 }
 
-module "govwifi-dashboard" {
+module "govwifi_dashboard" {
   providers = {
     aws = aws.AWS-main
   }
@@ -406,7 +406,7 @@ There are some problems with the Staging Bastion instance that is preventing
 us from mirroring the setup in Production in Staging. This will be rectified
 when we create a separate staging environment.
 */
-module "govwifi-prometheus" {
+module "govwifi_prometheus" {
   providers = {
     aws = aws.AWS-main
   }
@@ -436,7 +436,7 @@ module "govwifi-prometheus" {
   grafana-IP    = "${var.grafana-IP}/32"
 }
 
-module "govwifi-grafana" {
+module "govwifi_grafana" {
   providers = {
     aws = aws.AWS-main
   }
@@ -473,7 +473,7 @@ module "govwifi-grafana" {
   use_env_prefix = var.use_env_prefix
 }
 
-module "govwifi-elasticsearch" {
+module "govwifi_elasticsearch" {
   providers = {
     aws = aws.AWS-main
   }
@@ -490,7 +490,7 @@ module "govwifi-elasticsearch" {
   backend-subnet-id = module.backend.backend-subnet-ids[0]
 }
 
-module "govwifi-datasync" {
+module "govwifi_datasync" {
   providers = {
     aws = aws.route53-alarms
   }

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -45,7 +45,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-module "govwifi-keys" {
+module "govwifi_keys" {
   providers = {
     aws = aws.AWS-main
   }
@@ -353,7 +353,7 @@ module "api" {
     module.backend.be-admin-in,
   ]
 
-  metrics-bucket-name = module.govwifi-dashboard.metrics-bucket-name
+  metrics-bucket-name = module.govwifi_dashboard.metrics-bucket-name
 
   use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
@@ -385,7 +385,7 @@ module "route53-notifications" {
   emails     = [var.notification-email]
 }
 
-module "govwifi-dashboard" {
+module "govwifi_dashboard" {
   providers = {
     aws = aws.AWS-main
   }
@@ -402,7 +402,7 @@ There are some problems with the Staging Bastion instance that is preventing
 us from mirroring the setup in Production in Staging. This will be rectified
 when we create a separate staging environment.
 */
-module "govwifi-prometheus" {
+module "govwifi_prometheus" {
   providers = {
     aws = aws.AWS-main
   }
@@ -432,7 +432,7 @@ module "govwifi-prometheus" {
   grafana-IP    = "${var.grafana-IP}/32"
 }
 
-module "govwifi-grafana" {
+module "govwifi_grafana" {
   providers = {
     aws = aws.AWS-main
   }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -358,7 +358,7 @@ module "api" {
     module.backend.be-admin-in,
   ]
 
-  metrics-bucket-name = module.govwifi-dashboard.metrics-bucket-name
+  metrics-bucket-name = module.govwifi_dashboard.metrics-bucket-name
 
   use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
@@ -428,7 +428,7 @@ module "region_pagerduty" {
   sns_topic_subscription_https_endpoint = local.pagerduty_https_endpoint
 }
 
-module "govwifi-dashboard" {
+module "govwifi_dashboard" {
   providers = {
     aws = aws.AWS-main
   }


### PR DESCRIPTION
### What
Use underscores rather than dashes for some module names.

### Why
This is part of changing the names for resources to use underscores
rather than dashes. These changes should have ended up in earlier
commits, but where missed.