### PR TITLE
Change elasticsearch module name in staging-london

### DIFF
--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -472,7 +472,7 @@ module "govwifi_grafana" {
   use_env_prefix = var.use_env_prefix
 }
 
-module "govwifi-elasticsearch" {
+module "govwifi_elasticsearch" {
   providers = {
     aws = aws.AWS-main
   }


### PR DESCRIPTION
### What
Change elasticsearch module name in staging-london.

### Why
This is to match changes made to the statefile, as part of using
underscores rather than dashes in resource names.