### PR TITLE
Remove the need for frontend region IPs

### DIFF
--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -177,5 +177,5 @@ DATA
 resource "aws_eip_association" "eip_assoc" {
   count       = var.radius-instance-count
   instance_id = element(aws_instance.radius.*.id, count.index)
-  public_ip   = replace(element(var.elastic-ip-list, count.index), "/32", "")
+  public_ip   = element(var.elastic-ip-list, count.index)
 }

--- a/govwifi/staging-dublin-temp/locals.tf
+++ b/govwifi/staging-dublin-temp/locals.tf
@@ -13,3 +13,7 @@ locals {
 locals {
   frontend_radius_ips = concat(var.london-radius-ip-addresses, var.dublin-radius-ip-addresses)
 }
+
+locals {
+  frontend_region_ips = var.dublin-radius-ip-addresses
+}

--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -208,7 +208,7 @@ module "frontend" {
   # where N = this base + 1 + server#
   dns-numbering-base = 0
 
-  elastic-ip-list       = split(",", var.frontend-region-IPs)
+  elastic-ip-list       = local.frontend_region_ips
   ami                   = var.ami
   ssh-key-name          = var.ssh-key-name
   users                 = var.users

--- a/govwifi/staging-london-temp/locals.tf
+++ b/govwifi/staging-london-temp/locals.tf
@@ -13,3 +13,7 @@ locals {
 locals {
   frontend_radius_ips = concat(var.london-radius-ip-addresses, var.dublin-radius-ip-addresses)
 }
+
+locals {
+  frontend_region_ips = var.london-radius-ip-addresses
+}

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -175,7 +175,7 @@ module "frontend" {
   # where N = this base + 1 + server#
   dns-numbering-base = 3
 
-  elastic-ip-list       = split(",", var.frontend-region-IPs)
+  elastic-ip-list       = local.frontend_region_ips
   ami                   = var.ami
   ssh-key-name          = var.ssh-key-name
   users                 = var.users

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -13,3 +13,7 @@ locals {
 locals {
   frontend_radius_ips = concat(var.london-radius-ip-addresses, var.dublin-radius-ip-addresses)
 }
+
+locals {
+  frontend_region_ips = var.london-radius-ip-addresses
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -173,7 +173,7 @@ module "frontend" {
   # where N = this base + 1 + server#
   dns-numbering-base = 3
 
-  elastic-ip-list       = split(",", var.frontend-region-IPs)
+  elastic-ip-list       = local.frontend_region_ips
   ami                   = var.ami
   ssh-key-name          = var.ssh-key-name
   users                 = var.users

--- a/govwifi/staging/locals.tf
+++ b/govwifi/staging/locals.tf
@@ -13,3 +13,7 @@ locals {
 locals {
   frontend_radius_ips = concat(var.london-radius-ip-addresses, var.dublin-radius-ip-addresses)
 }
+
+locals {
+  frontend_region_ips = var.dublin-radius-ip-addresses
+}

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -203,7 +203,7 @@ module "frontend" {
   # where N = this base + 1 + server#
   dns-numbering-base = 0
 
-  elastic-ip-list       = split(",", var.frontend-region-IPs)
+  elastic-ip-list       = local.frontend_region_ips
   ami                   = var.ami
   ssh-key-name          = var.ssh-key-name
   users                 = var.users

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -13,3 +13,7 @@ locals {
 locals {
   frontend_radius_ips = concat(var.london-radius-ip-addresses, var.dublin-radius-ip-addresses)
 }
+
+locals {
+  frontend_region_ips = var.london-radius-ip-addresses
+}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -189,7 +189,7 @@ module "frontend" {
   # where N = this base + 1 + server#
   dns-numbering-base = 3
 
-  elastic-ip-list       = split(",", var.frontend-region-IPs)
+  elastic-ip-list       = local.frontend_region_ips
   ami                   = var.ami
   ssh-key-name          = var.ssh-key-name
   users                 = var.users

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -17,3 +17,7 @@ locals {
 locals {
   frontend_radius_ips = concat(var.london-radius-ip-addresses, var.dublin-radius-ip-addresses)
 }
+
+locals {
+  frontend_region_ips = var.dublin-radius-ip-addresses
+}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -225,7 +225,7 @@ module "frontend" {
   # where N = this base + 1 + server#
   dns-numbering-base = 0
 
-  elastic-ip-list       = split(",", var.frontend-region-IPs)
+  elastic-ip-list       = local.frontend_region_ips
   ami                   = var.ami
   ssh-key-name          = var.ssh-key-name
   users                 = var.users


### PR DESCRIPTION
### What
Remove the need for frontend region IPs

### Why
The frontend-region-IPs variable doesn't actually contain a list of IP addresses, and it seems pointless to explicitly define it for each environment when it can just be derived from other variables.