### PR TITLE
Tweak the frontend fe-admin-in security group

### DIFF
--- a/govwifi-frontend/security_groups.tf
+++ b/govwifi-frontend/security_groups.tf
@@ -47,7 +47,7 @@ resource "aws_security_group" "fe_admin_in" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = distinct(var.bastion-ips)
+    cidr_blocks = ["${var.bastion_server_ip}/32"]
   }
 }
 

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -84,10 +84,7 @@ variable "create-ecr" {
   default     = 0
 }
 
-variable "bastion-ips" {
-  description = "The list of allowed hosts to connect to the ec2 instances"
-  type        = list(string)
-  default     = []
+variable "bastion_server_ip" {
 }
 
 variable "route53-critical-notifications-arn" {

--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -228,9 +228,7 @@ module "frontend" {
   # Security groups ---------------------------------------
   radius-instance-sg-ids = []
 
-  bastion-ips = [
-    var.bastion-server-IP,
-  ]
+  bastion_server_ip = split("/", var.bastion-server-IP)[0]
 
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -197,10 +197,7 @@ module "frontend" {
   # Security groups ---------------------------------------
   radius-instance-sg-ids = []
 
-  bastion-ips = concat(
-    [var.bastion-server-IP],
-    split(",", var.backend-subnet-IPs),
-  )
+  bastion_server_ip = split("/", var.bastion-server-IP)[0]
 
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -195,10 +195,7 @@ module "frontend" {
   # Security groups ---------------------------------------
   radius-instance-sg-ids = []
 
-  bastion-ips = concat(
-    [var.bastion-server-IP],
-    split(",", var.backend-subnet-IPs),
-  )
+  bastion_server_ip = split("/", var.bastion-server-IP)[0]
 
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -223,9 +223,7 @@ module "frontend" {
   # Security groups ---------------------------------------
   radius-instance-sg-ids = []
 
-  bastion-ips = [
-    var.bastion-server-IP,
-  ]
+  bastion_server_ip = split("/", var.bastion-server-IP)[0]
 
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -210,10 +210,7 @@ module "frontend" {
   # Security groups ---------------------------------------
   radius-instance-sg-ids = []
 
-  bastion-ips = concat(
-    split(",", var.bastion-server-IP),
-    split(",", var.backend-subnet-IPs),
-  )
+  bastion_server_ip = split("/", var.bastion-server-IP)[0]
 
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -245,10 +245,7 @@ module "frontend" {
   # Security groups ---------------------------------------
   radius-instance-sg-ids = []
 
-  bastion-ips = concat(
-    split(",", var.bastion-server-IP),
-    split(",", var.backend-subnet-IPs)
-  )
+  bastion_server_ip = split("/", var.bastion-server-IP)[0]
 
   prometheus-IP-london  = "${var.prometheus-IP-london}/32"
   prometheus-IP-ireland = "${var.prometheus-IP-ireland}/32"


### PR DESCRIPTION
### What
Tweak the frontend fe-admin-in security group in most environments, no change expected in staging and
staging-dublin-temp.

### Why
Rather than passing a list of bastion-ips to govwifi-frontend, just
pass the singular bastion IP. I'm not sure why, but in most
environments the backend-subnet-IPs where also on this list. I believe
that's a capability that can be removed. I don't think everything in
those IP ranges needs acesss.
