### PR TITLE
Tweak the govwifi-admin admin_ec2_in security group

### DIFF
--- a/govwifi-admin/security_groups.tf
+++ b/govwifi-admin/security_groups.tf
@@ -52,7 +52,7 @@ resource "aws_security_group" "admin_ec2_in" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = distinct(var.bastion-ips)
+    cidr_blocks = ["${var.bastion_server_ip}/32"]
   }
 }
 

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -162,10 +162,7 @@ variable "zendesk-api-user" {
 variable "public-google-api-key" {
 }
 
-variable "bastion-ips" {
-  description = "The list of allowed hosts to connect to the ec2 instances"
-  type        = list(string)
-  default     = []
+variable "bastion_server_ip" {
 }
 
 variable "use_env_prefix" {

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -276,10 +276,7 @@ module "govwifi_admin" {
   zendesk-api-endpoint = "https://govuk.zendesk.com/api/v2/"
   zendesk-api-user     = var.zendesk-api-user
 
-  bastion-ips = concat(
-    split(",", var.bastion-server-IP),
-    split(",", var.backend-subnet-IPs),
-  )
+  bastion_server_ip = split("/", var.bastion-server-IP)[0]
 
   use_env_prefix = var.use_env_prefix
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -273,10 +273,7 @@ module "govwifi_admin" {
   zendesk-api-endpoint = "https://govuk.zendesk.com/api/v2/"
   zendesk-api-user     = var.zendesk-api-user
 
-  bastion-ips = concat(
-    split(",", var.bastion-server-IP),
-    split(",", var.backend-subnet-IPs),
-  )
+  bastion_server_ip = split("/", var.bastion-server-IP)[0]
 
   use_env_prefix = true
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -289,10 +289,7 @@ module "govwifi_admin" {
   zendesk-api-endpoint = "https://govuk.zendesk.com/api/v2/"
   zendesk-api-user     = var.zendesk-api-user
 
-  bastion-ips = concat(
-    split(",", var.bastion-server-IP),
-    split(",", var.backend-subnet-IPs)
-  )
+  bastion_server_ip = split("/", var.bastion-server-IP)[0]
 
   use_env_prefix = false
 }


### PR DESCRIPTION
### What
Tweak the govwifi-admin admin_ec2_in security group

### Why
Rather than passing a list of bastion-ips to govwifi-admin, just pass
the singular bastion IP. I'm not sure why the backend-subnet-IPs where
also on this list. I believe that's a capability that can be
removed. I don't think everything in those IP ranges needs acesss.