### PR TITLE
Remove the unused elb-public-IPs variable

### DIFF
--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -105,10 +105,6 @@ variable "prometheus-IP-ireland" {
 variable "grafana-IP" {
 }
 
-variable "elb-public-IPs" {
-  description = "Unused in this configuration"
-}
-
 variable "use_env_prefix" {
   default     = true
   type        = bool


### PR DESCRIPTION
### What
Remove the unused elb-public-IPs variable

### Why
As it's unused. I'm going to also remove the value from govwifi-build.
