### PR TITLE
Remove the frontend-radius-IPs variable from all environments

### DIFF
--- a/govwifi/staging-dublin-temp/firewall-variables.tf
+++ b/govwifi/staging-dublin-temp/firewall-variables.tf
@@ -10,6 +10,3 @@ variable "bastion-server-IP" {
 
 variable "backend-subnet-IPs" {
 }
-
-variable "frontend-radius-IPs" {
-}

--- a/govwifi/staging-london-temp/firewall-variables.tf
+++ b/govwifi/staging-london-temp/firewall-variables.tf
@@ -5,10 +5,6 @@ variable "bastion-server-IP" {
 variable "administrator-IPs" {
 }
 
-# Also used for the new site setup PDF - unless overridden in main.tf
-variable "frontend-radius-IPs" {
-}
-
 # The frontend RADIUS IPs for the current region - used for EIP association
 variable "frontend-region-IPs" {
 }

--- a/govwifi/staging-london/firewall-variables.tf
+++ b/govwifi/staging-london/firewall-variables.tf
@@ -5,10 +5,6 @@ variable "bastion-server-IP" {
 variable "administrator-IPs" {
 }
 
-# Also used for the new site setup PDF - unless overridden in main.tf
-variable "frontend-radius-IPs" {
-}
-
 # The frontend RADIUS IPs for the current region - used for EIP association
 variable "frontend-region-IPs" {
 }

--- a/govwifi/staging/firewall-variables.tf
+++ b/govwifi/staging/firewall-variables.tf
@@ -10,7 +10,3 @@ variable "bastion-server-IP" {
 
 variable "backend-subnet-IPs" {
 }
-
-variable "frontend-radius-IPs" {
-}
-

--- a/govwifi/wifi-london/firewall-variables.tf
+++ b/govwifi/wifi-london/firewall-variables.tf
@@ -5,10 +5,6 @@ variable "bastion-server-IP" {
 variable "administrator-IPs" {
 }
 
-# Also used for the new site setup PDF - unless overridden in main.tf
-variable "frontend-radius-IPs" {
-}
-
 # The frontend RADIUS IPs for the current region - used for EIP association
 variable "frontend-region-IPs" {
 }

--- a/govwifi/wifi/firewall-variables.tf
+++ b/govwifi/wifi/firewall-variables.tf
@@ -1,7 +1,3 @@
-# Also used for the new site setup PDF - unless overridden in main.tf
-variable "frontend-radius-IPs" {
-}
-
 # The frontend RADIUS IPs for the current region - used for EIP association
 variable "frontend-region-IPs" {
 }


### PR DESCRIPTION
### What
Remove the frontend-radius-IPs variable from all environments

### Why
This is now unused, replaced by the local added in
2c5001718f2dc9a24f7cc64c73a107096802c29c.
