### PR TITLE
Fix some uses of var.frontend-radius-IPs

### DIFF
--- a/govwifi/staging-london-temp/security-groups-performance-testing.tf
+++ b/govwifi/staging-london-temp/security-groups-performance-testing.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "be-perf-out" {
     from_port   = 1812
     to_port     = 1812
     protocol    = "udp"
-    cidr_blocks = split(",", var.frontend-radius-IPs)
+    cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
   }
 
   # accounting
@@ -20,7 +20,7 @@ resource "aws_security_group" "be-perf-out" {
     from_port   = 1813
     to_port     = 1813
     protocol    = "udp"
-    cidr_blocks = split(",", var.frontend-radius-IPs)
+    cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
   }
 
   # healthchecks and direct calls to ELB

--- a/govwifi/staging-london/security-groups-performance-testing.tf
+++ b/govwifi/staging-london/security-groups-performance-testing.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "be-perf-out" {
     from_port   = 1812
     to_port     = 1812
     protocol    = "udp"
-    cidr_blocks = split(",", var.frontend-radius-IPs)
+    cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
   }
 
   # accounting
@@ -20,7 +20,7 @@ resource "aws_security_group" "be-perf-out" {
     from_port   = 1813
     to_port     = 1813
     protocol    = "udp"
-    cidr_blocks = split(",", var.frontend-radius-IPs)
+    cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
   }
 
   # healthchecks and direct calls to ELB


### PR DESCRIPTION
### What
Fix some uses of var.frontend-radius-IPs

### Why
These should have been changed in
2c5001718f2dc9a24f7cc64c73a107096802c29c, but it was missed.
