### PR TITLE
Remove the Stage-Name variable

### DIFF
--- a/govwifi/staging-dublin-temp/variables.tf
+++ b/govwifi/staging-dublin-temp/variables.tf
@@ -3,11 +3,6 @@ variable "Env-Name" {
   default = "staging-temp"
 }
 
-variable "Stage-Name" {
-  type    = string
-  default = "staging"
-}
-
 variable "product-name" {
   type    = string
   default = "GovWifi"

--- a/govwifi/staging-london-temp/variables.tf
+++ b/govwifi/staging-london-temp/variables.tf
@@ -3,11 +3,6 @@ variable "Env-Name" {
   default = "staging-temp"
 }
 
-variable "Stage-Name" {
-  type    = string
-  default = "staging"
-}
-
 variable "product-name" {
   type    = string
   default = "GovWifi"


### PR DESCRIPTION
### What
Remove the Stage-Name variable

### Why
It's unused. I think it crept in through
https://github.com/alphagov/govwifi-terraform/pull/506 and was added
and then partially removed in the same Pull Request.
