### PR TITLE
Decrease the Logging API high CPU alarm threshold from 50% to 30%

### DIFF
--- a/govwifi-api/alarms-logging.tf
+++ b/govwifi-api/alarms-logging.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_metric_alarm" "logging_ecs_cpu_alarm_high" {
   namespace           = "AWS/ECS"
   period              = "300"
   statistic           = "Average"
-  threshold           = "50"
+  threshold           = "30"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.api_cluster.name


### PR DESCRIPTION
### What
Decrease the Logging API high CPU alarm threshold from 50% to 30%

### Why
The Logging API seemed to be timing out, and using a higher amount of
CPU, but not over the 50% threshold. Reducing this threshold to 30%
resulted in scaling up, which seemed like it could have helped.
