### PR TITLE
Disable other unnecessary govwifi-account resources in new staging

### DIFF
--- a/govwifi-account/iam-attachments.tf
+++ b/govwifi-account/iam-attachments.tf
@@ -5,6 +5,7 @@ resource "aws_iam_group_policy_attachment" "GovWifi_Audit_policy_attachment_GovW
 }
 
 resource "aws_iam_group_policy_attachment" "LambdaUpdateFunctionCode_policy_attachment_GovWifi_Pipeline" {
+  count      = var.is_production_aws_account ? 1 : 0
   group      = "GovWifi-Pipeline"
   policy_arn = "arn:aws:iam::${var.aws-account-id}:policy/LambdaUpdateFunctionCode"
 }

--- a/govwifi-account/iam-policy.tf
+++ b/govwifi-account/iam-policy.tf
@@ -1532,6 +1532,7 @@ POLICY
 }
 
 resource "aws_iam_policy" "can_restart_ecs_services" {
+  count       = var.is_production_aws_account ? 1 : 0
   name        = "can-restart-ecs-services"
   path        = "/"
   description = "Allows deploy pipeline group to restart elasticsearch services"


### PR DESCRIPTION
### What
Disable other unnecessary govwifi-account resources in new staging

### Why
These two resources were causing errors on apply.
