### PR TITLE
Fix scheduled logging task error in new staging

### DIFF
--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -468,7 +468,7 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
           "value": "${var.Env-Name}"
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_BUCKET",
-          "value": "govwifi-${var.rack-env}-admin"
+          "value": "${var.admin-bucket-name}"
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"


### PR DESCRIPTION
### What
Fix scheduled logging task error in new staging

### Why
This module was using a hardcoded bucket name, which caused an error. S3 bucket names are unique across all AWS accounts, so this should passed as a variable.


Link to Trello card (if applicable): https://trello.com/c/t3nubhgx/1671-fix-connection-error-between-staging-logging-api-and-elastic-search
