### PR TITLE
Increase the bastion status alarm evaluation periods from 2 to 3

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -281,7 +281,7 @@ resource "aws_cloudwatch_metric_alarm" "bastion_statusalarm" {
   count               = var.enable_bastion
   alarm_name          = "${lower(var.env_name)}-bastion-status-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
+  evaluation_periods  = "3"
   metric_name         = "StatusCheckFailed"
   namespace           = "AWS/EC2"
   period              = "60"


### PR DESCRIPTION
### What
Increase the bastion status alarm evaluation periods from 2 to 3

### Why
So that it's slightly less sensitive, and less likely to go off when
the machine reboots (which can happen automatically).


Link to Trello card: https://trello.com/c/rp93fEaU/1678-increase-the-cloudwatch-bastion-status-alarm-evaluation-periods-from-2-to-3