### PR TITLE
Remove prometheus module feature toggle

### DIFF
--- a/govwifi-prometheus/cluster.tf
+++ b/govwifi-prometheus/cluster.tf
@@ -1,5 +1,4 @@
 resource "aws_cloudwatch_log_group" "prometheus_log_group" {
-  count             = var.create_prometheus_server
   name              = "${var.Env-Name}-prometheus-log-group"
   retention_in_days = 90
 }

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -45,7 +45,6 @@ data "template_file" "prometheus_startup" {
 # The element() function used in subnets wraps around when the index is over the number of elements
 # eg. in the 4th iteration the value returned will be the 1st, if there are only 3 elements in the list.
 resource "aws_instance" "prometheus_instance" {
-  count                   = var.create_prometheus_server
   ami                     = data.aws_ami.ubuntu.id
   instance_type           = "t2.small"
   key_name                = var.ssh-key-name
@@ -77,7 +76,6 @@ resource "aws_instance" "prometheus_instance" {
 }
 
 resource "aws_ebs_volume" "prometheus_ebs" {
-  count             = var.create_prometheus_server
   size              = 40
   encrypted         = true
   availability_zone = "${var.aws-region}a"
@@ -88,17 +86,15 @@ resource "aws_ebs_volume" "prometheus_ebs" {
 }
 
 resource "aws_volume_attachment" "prometheus_ebs_attach" {
-  count       = var.create_prometheus_server
   depends_on  = [aws_ebs_volume.prometheus_ebs]
   device_name = "/dev/xvdp"
-  volume_id   = aws_ebs_volume.prometheus_ebs[0].id
-  instance_id = aws_instance.prometheus_instance[0].id
+  volume_id   = aws_ebs_volume.prometheus_ebs.id
+  instance_id = aws_instance.prometheus_instance.id
 }
 
 resource "aws_eip_association" "prometheus_eip_assoc" {
-  count       = var.create_prometheus_server
   depends_on  = [aws_instance.prometheus_instance]
-  instance_id = aws_instance.prometheus_instance[0].id
+  instance_id = aws_instance.prometheus_instance.id
   public_ip   = var.prometheus_ip
 }
 

--- a/govwifi-prometheus/variables.tf
+++ b/govwifi-prometheus/variables.tf
@@ -36,13 +36,6 @@ variable "fe-radius-in" {
 variable "fe-radius-out" {
 }
 
-# Feature toggle to create (1) or not create (0) Prometheus server
-# Default value is 0, we only want Prometheus enabled in Staging and Production (London only).
-# To enable Prometheus, set the value to 1 in the relevant <environment>/main.tf
-variable "create_prometheus_server" {
-  default = 0
-}
-
 variable "london_radius_ip_addresses" {
   type    = list(string)
   default = []

--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -322,33 +322,3 @@ module "route53-notifications" {
   topic_name = "govwifi-staging-dublin-temp"
   emails     = [var.notification_email]
 }
-
-module "govwifi_prometheus" {
-  providers = {
-    aws = aws.main
-  }
-
-  source     = "../../govwifi-prometheus"
-  Env-Name   = var.Env-Name
-  aws-region = var.aws-region
-
-  ssh-key-name = var.ssh-key-name
-
-  frontend-vpc-id = module.frontend.frontend-vpc-id
-
-  fe-admin-in   = module.frontend.fe-admin-in
-  fe-ecs-out    = module.frontend.fe-ecs-out
-  fe-radius-in  = module.frontend.fe-radius-in
-  fe-radius-out = module.frontend.fe-radius-out
-
-  wifi-frontend-subnet       = module.frontend.wifi-frontend-subnet
-  london_radius_ip_addresses = var.london_radius_ip_addresses
-  dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
-
-  # Feature toggle creating Prometheus server.
-  # Value defaults to 0 and should only be enabled (i.e., value = 1)
-  create_prometheus_server = 0
-
-  prometheus_ip = var.prometheus_ip_ireland
-  grafana_ip    = var.grafana_ip
-}

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -382,10 +382,6 @@ module "govwifi_prometheus" {
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
-  // Feature toggle creating Prometheus server.
-  // Value defaults to 0 and is only enabled (i.e., value = 1) in staging-london
-  create_prometheus_server = 1
-
   prometheus_ip = var.prometheus_ip_london
   grafana_ip    = var.grafana_ip
 }

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -378,10 +378,6 @@ module "govwifi_prometheus" {
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
-  # Feature toggle creating Prometheus server.
-  # Value defaults to 0 and is only enabled (i.e., value = 1) in staging-london
-  create_prometheus_server = 1
-
   prometheus_ip = var.prometheus_ip_london
   grafana_ip    = var.grafana_ip
 }

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -314,33 +314,3 @@ module "route53-notifications" {
   topic_name = "govwifi-staging"
   emails     = [var.notification_email]
 }
-
-module "govwifi_prometheus" {
-  providers = {
-    aws = aws.main
-  }
-
-  source     = "../../govwifi-prometheus"
-  Env-Name   = var.Env-Name
-  aws-region = var.aws-region
-
-  ssh-key-name = var.ssh-key-name
-
-  frontend-vpc-id = module.frontend.frontend-vpc-id
-
-  fe-admin-in   = module.frontend.fe-admin-in
-  fe-ecs-out    = module.frontend.fe-ecs-out
-  fe-radius-in  = module.frontend.fe-radius-in
-  fe-radius-out = module.frontend.fe-radius-out
-
-  wifi-frontend-subnet       = module.frontend.wifi-frontend-subnet
-  london_radius_ip_addresses = var.london_radius_ip_addresses
-  dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
-
-  # Feature toggle creating Prometheus server.
-  # Value defaults to 0 and should only be enabled (i.e., value = 1)
-  create_prometheus_server = 0
-
-  prometheus_ip = var.prometheus_ip_ireland
-  grafana_ip    = var.grafana_ip
-}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -417,10 +417,6 @@ module "govwifi_prometheus" {
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
-  # Feature toggle creating Prometheus server.
-  # Value defaults to 0 and should only be enabled (i.e., value = 1) in staging-london and wifi-london
-  create_prometheus_server = 1
-
   prometheus_ip = var.prometheus_ip_london
   grafana_ip    = var.grafana_ip
 }

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -400,9 +400,6 @@ module "govwifi_prometheus" {
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
-  # Feature toggle creating Prometheus server.
-  create_prometheus_server = 1
-
   prometheus_ip = var.prometheus_ip_ireland
   grafana_ip    = var.grafana_ip
 }


### PR DESCRIPTION
### What
Remove the `create_prometheus_server` variable, the use of the govwifi-prometheus module in environments where it was disabled, and adjust some Terraform to enable these changes.

### Why
I think this makes the Terraform simpler and easier to read, it also removes some redundant resources from AWS (in some environments).


Link to Trello card: https://trello.com/c/iqCWXt8I/1682-remove-the-terraform-govwifi-prometheus-module-feature-toggle
