### PR TITLE
Fix a mismatch between AWS regions and SNS topic notification ARNs

### DIFF
--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_metric_alarm" "radius_healthcheck" {
   }
 
   alarm_actions = [
-    var.route53-critical-notifications-arn,
+    var.us_east_1_critical_notifications_arn,
   ]
 
   alarm_description = "Route53 healthcheck request failed to authenticate via FreeRADIUS and Authentication API. Investigate CloudWatch logs for root cause."
@@ -61,7 +61,7 @@ resource "aws_cloudwatch_metric_alarm" "radius_latency" {
   }
 
   alarm_actions = [
-    var.route53-critical-notifications-arn,
+    var.us_east_1_critical_notifications_arn,
   ]
 
   alarm_description = "FreeRADIUS response rate is slow (greater than 1s). Investigate CloudWatch logs for root cause."
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_metric_alarm" "radius_cannot_connect_to_api" {
   namespace           = aws_cloudwatch_log_metric_filter.radius_cannot_connect_to_api.metric_transformation[0].namespace
 
   alarm_actions = [
-    var.route53-critical-notifications-arn,
+    var.critical_notifications_arn,
   ]
 
   alarm_description = "FreeRADIUS cannot connect to the Logging and/or Authentication API. Investigate CloudWatch logs for root cause."

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -79,7 +79,11 @@ variable "create-ecr" {
 variable "bastion_server_ip" {
 }
 
-variable "route53-critical-notifications-arn" {
+variable "critical_notifications_arn" {
+  type = string
+}
+
+variable "us_east_1_critical_notifications_arn" {
   type = string
 }
 

--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -219,7 +219,8 @@ module "frontend" {
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.dublin-api-base-url
 
-  route53-critical-notifications-arn = module.route53-notifications.topic-arn
+  critical_notifications_arn           = module.notifications.topic-arn
+  us_east_1_critical_notifications_arn = module.route53-notifications.topic-arn
 
   bastion_server_ip = var.bastion_server_ip
 

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -187,8 +187,8 @@ module "frontend" {
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.london-api-base-url
 
-  # This must be based on us-east-1, as that's where the alarms go
-  route53-critical-notifications-arn = module.route53-notifications.topic-arn
+  critical_notifications_arn           = module.notifications.topic-arn
+  us_east_1_critical_notifications_arn = module.route53-notifications.topic-arn
 
   bastion_server_ip = var.bastion_server_ip
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -185,8 +185,8 @@ module "frontend" {
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.london-api-base-url
 
-  # This must be based on us-east-1, as that's where the alarms go
-  route53-critical-notifications-arn = module.route53-notifications.topic-arn
+  critical_notifications_arn           = module.notifications.topic-arn
+  us_east_1_critical_notifications_arn = module.route53-notifications.topic-arn
 
   bastion_server_ip = var.bastion_server_ip
 

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -214,7 +214,8 @@ module "frontend" {
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.dublin-api-base-url
 
-  route53-critical-notifications-arn = module.route53-notifications.topic-arn
+  critical_notifications_arn           = module.notifications.topic-arn
+  us_east_1_critical_notifications_arn = module.route53-notifications.topic-arn
 
   bastion_server_ip = var.bastion_server_ip
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -199,8 +199,8 @@ module "frontend" {
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.london-api-base-url
 
-  # This must be based on us-east-1, as that's where the alarms go
-  route53-critical-notifications-arn = module.route53-critical-notifications.topic-arn
+  critical_notifications_arn           = module.critical-notifications.topic-arn
+  us_east_1_critical_notifications_arn = module.route53-critical-notifications.topic-arn
 
   bastion_server_ip = var.bastion_server_ip
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -235,7 +235,8 @@ module "frontend" {
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.dublin-api-base-url
 
-  route53-critical-notifications-arn = module.route53-critical-notifications.topic-arn
+  critical_notifications_arn           = module.critical-notifications.topic-arn
+  us_east_1_critical_notifications_arn = module.route53-critical-notifications.topic-arn
 
   bastion_server_ip = var.bastion_server_ip
 


### PR DESCRIPTION
### What
Fix a mismatch between AWS regions and SNS topic notification ARNs by adding a critical_notifications_arn variable to the govwifi-frontend module, to contain the current region SNS topic ARN.

### Why
In the govwifi-frontend module. This commit
d09a5913017955d3faf7535c94cac9f01342dab9 changed the
radius_cannot_connect_to_api alarm action, but this caused a problem
as the topic used was in us-east-1, which can't be hooked up to the
alarm in the eu-west-1/eu-west-2 regions.

Now that I've seen this, I think I can see that the
route53-critical-notifications-arn should probably be called
us_east_1_critical_notifications_arn. It was probably called route53
because route53 is managed from us-east-1, but actually saying
us-east-1 makes so much more sense.


Link to Trello card: https://trello.com/c/dZRzJxb6/1683-staging-prod-radius-cannot-connect-to-api-should-alert-to-slack