### PR TITLE
Use underscores for resource names in the terraform-state module

### DIFF
--- a/terraform-state/accesslogs.tf
+++ b/terraform-state/accesslogs.tf
@@ -2,7 +2,7 @@
 # Access logs
 # --------------------------------------------------------------
 
-resource "aws_iam_role" "accesslogs-replication" {
+resource "aws_iam_role" "accesslogs_replication" {
   name = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs-replication-role"
 
   assume_role_policy = <<POLICY
@@ -23,7 +23,7 @@ POLICY
 
 }
 
-resource "aws_iam_policy" "accesslogs-replication" {
+resource "aws_iam_policy" "accesslogs_replication" {
   name = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs-replication-policy"
 
   policy = <<EOF
@@ -37,7 +37,7 @@ resource "aws_iam_policy" "accesslogs-replication" {
       ],
       "Effect": "Allow",
       "Resource": [
-        "${aws_s3_bucket.accesslogs-bucket.arn}"
+        "${aws_s3_bucket.accesslogs_bucket.arn}"
       ]
     },
     {
@@ -47,7 +47,7 @@ resource "aws_iam_policy" "accesslogs-replication" {
       ],
       "Effect": "Allow",
       "Resource": [
-        "${aws_s3_bucket.accesslogs-bucket.arn}/*"
+        "${aws_s3_bucket.accesslogs_bucket.arn}/*"
       ]
     },
     {
@@ -64,13 +64,13 @@ EOF
 
 }
 
-resource "aws_iam_policy_attachment" "accesslogs-replication" {
+resource "aws_iam_policy_attachment" "accesslogs_replication" {
   name       = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs-replication"
-  roles      = [aws_iam_role.accesslogs-replication.name]
-  policy_arn = aws_iam_policy.accesslogs-replication.arn
+  roles      = [aws_iam_role.accesslogs_replication.name]
+  policy_arn = aws_iam_policy.accesslogs_replication.arn
 }
 
-resource "aws_s3_bucket" "accesslogs-bucket" {
+resource "aws_s3_bucket" "accesslogs_bucket" {
   bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
   region = var.aws-region
   acl    = "log-delivery-write"
@@ -101,7 +101,7 @@ resource "aws_s3_bucket" "accesslogs-bucket" {
   }
 
   replication_configuration {
-    role = aws_iam_role.accesslogs-replication.arn
+    role = aws_iam_role.accesslogs_replication.arn
 
     rules {
       # ID is necessary to prevent continuous change issue

--- a/terraform-state/tfstate.tf
+++ b/terraform-state/tfstate.tf
@@ -1,5 +1,5 @@
 # Resources for setting up s3 for terraform backend. (state storage in s3)
-resource "aws_iam_role" "tfstate-replication" {
+resource "aws_iam_role" "tfstate_replication" {
   name = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate-replication-role"
 
   assume_role_policy = <<POLICY
@@ -20,7 +20,7 @@ POLICY
 
 }
 
-resource "aws_iam_policy" "tfstate-replication" {
+resource "aws_iam_policy" "tfstate_replication" {
   name = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate-replication-policy"
 
   policy = <<EOF
@@ -34,7 +34,7 @@ resource "aws_iam_policy" "tfstate-replication" {
       ],
       "Effect": "Allow",
       "Resource": [
-        "${aws_s3_bucket.state-bucket.arn}"
+        "${aws_s3_bucket.state_bucket.arn}"
       ]
     },
     {
@@ -44,7 +44,7 @@ resource "aws_iam_policy" "tfstate-replication" {
       ],
       "Effect": "Allow",
       "Resource": [
-        "${aws_s3_bucket.state-bucket.arn}/*"
+        "${aws_s3_bucket.state_bucket.arn}/*"
       ]
     },
     {
@@ -61,13 +61,13 @@ EOF
 
 }
 
-resource "aws_iam_policy_attachment" "tfstate-replication" {
+resource "aws_iam_policy_attachment" "tfstate_replication" {
   name       = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate-replication"
-  roles      = [aws_iam_role.tfstate-replication.name]
-  policy_arn = aws_iam_policy.tfstate-replication.arn
+  roles      = [aws_iam_role.tfstate_replication.name]
+  policy_arn = aws_iam_policy.tfstate_replication.arn
 }
 
-resource "aws_kms_key" "tfstate-key" {
+resource "aws_kms_key" "tfstate_key" {
   description             = "KMS key for the encryption of tfstate buckets."
   deletion_window_in_days = 10
   is_enabled              = true
@@ -80,12 +80,12 @@ resource "aws_kms_key" "tfstate-key" {
   }
 }
 
-resource "aws_kms_alias" "tfstate-key-alias" {
+resource "aws_kms_alias" "tfstate_key_alias" {
   name          = "alias/${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate-key"
-  target_key_id = aws_kms_key.tfstate-key.key_id
+  target_key_id = aws_kms_key.tfstate_key.key_id
 }
 
-resource "aws_s3_bucket" "state-bucket" {
+resource "aws_s3_bucket" "state_bucket" {
   bucket = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate"
   region = var.aws-region
 
@@ -126,7 +126,7 @@ EOF
   }
 
   replication_configuration {
-    role = aws_iam_role.tfstate-replication.arn
+    role = aws_iam_role.tfstate_replication.arn
 
     rules {
       # ID is necessary to prevent continuous change issue
@@ -144,7 +144,7 @@ EOF
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.tfstate-key.arn
+        kms_master_key_id = aws_kms_key.tfstate_key.arn
         sse_algorithm     = "aws:kms"
       }
     }


### PR DESCRIPTION
### What
Use underscores for resource names in the terraform-state module

### Why
Try to move towards using underscores rather than dashes, as this is
more consistent with Terraform itself. Just change the resources
within the terraform-state module.

This shouldn't have any effects beyond the names used in Terraform
changing. Unfortunately, when applying this change the existing
resources will need to be moved using the state mv command.


Link to Trello card: https://trello.com/c/6L90Gdrh/1690-use-underscores-for-resource-names-in-the-terraform-state-module