### PR TITLE
Use underscores rather than dashes for variables in govwifi-emails

### DIFF
--- a/govwifi-emails/emails.tf
+++ b/govwifi-emails/emails.tf
@@ -1,5 +1,5 @@
 resource "aws_ses_receipt_rule" "user_signup_rule" {
-  name          = "${var.Env-Name}-user-signup-rule"
+  name          = "${var.env_name}-user-signup-rule"
   rule_set_name = "GovWifiRuleSet"
   enabled       = true
   scan_enabled  = true
@@ -10,14 +10,14 @@ resource "aws_ses_receipt_rule" "user_signup_rule" {
   ]
 
   recipients = [
-    "enrol@${var.Env-Subdomain}.service.gov.uk",
-    "enroll@${var.Env-Subdomain}.service.gov.uk",
-    "signup@${var.Env-Subdomain}.service.gov.uk",
-    "sponsor@${var.Env-Subdomain}.service.gov.uk",
+    "enrol@${var.env_subdomain}.service.gov.uk",
+    "enroll@${var.env_subdomain}.service.gov.uk",
+    "signup@${var.env_subdomain}.service.gov.uk",
+    "sponsor@${var.env_subdomain}.service.gov.uk",
   ]
 
   s3_action {
-    bucket_name = "${var.Env-Name}-emailbucket"
+    bucket_name = "${var.env_name}-emailbucket"
     topic_arn   = aws_sns_topic.user_signup_notifications.arn
     position    = 1
   }
@@ -29,11 +29,11 @@ resource "aws_ses_receipt_rule" "user_signup_rule" {
 }
 
 resource "aws_ses_receipt_rule" "all_mail_rule" {
-  name          = "${var.Env-Name}-all-mail-rule"
+  name          = "${var.env_name}-all-mail-rule"
   rule_set_name = "GovWifiRuleSet"
   enabled       = true
   scan_enabled  = true
-  after         = "${var.Env-Name}-user-signup-rule"
+  after         = "${var.env_name}-user-signup-rule"
 
   depends_on = [
     aws_sns_topic.govwifi_email_notifications,
@@ -42,22 +42,22 @@ resource "aws_ses_receipt_rule" "all_mail_rule" {
   ]
 
   recipients = [
-    "verify@${var.Env-Subdomain}.service.gov.uk",
+    "verify@${var.env_subdomain}.service.gov.uk",
   ]
 
   s3_action {
-    bucket_name = "${var.Env-Name}-emailbucket"
+    bucket_name = "${var.env_name}-emailbucket"
     topic_arn   = aws_sns_topic.govwifi_email_notifications.arn
     position    = 1
   }
 }
 
 resource "aws_ses_receipt_rule" "newsite_mail_rule" {
-  name          = "${var.Env-Name}-newsite-mail-rule"
+  name          = "${var.env_name}-newsite-mail-rule"
   rule_set_name = "GovWifiRuleSet"
   enabled       = true
   scan_enabled  = true
-  after         = "${var.Env-Name}-all-mail-rule"
+  after         = "${var.env_name}-all-mail-rule"
 
   depends_on = [
     aws_sns_topic.govwifi_email_notifications,
@@ -66,21 +66,21 @@ resource "aws_ses_receipt_rule" "newsite_mail_rule" {
   ]
 
   recipients = [
-    "newsite@${var.Env-Subdomain}.service.gov.uk",
+    "newsite@${var.env_subdomain}.service.gov.uk",
   ]
 
   sns_action {
-    topic_arn = var.devops-notifications-arn
+    topic_arn = var.devops_notifications_arn
     position  = 1
   }
 }
 
 resource "aws_ses_receipt_rule" "admin_email_rule" {
-  name          = "${var.Env-Name}-admin-email-rule"
+  name          = "${var.env_name}-admin-email-rule"
   rule_set_name = "GovWifiRuleSet"
   enabled       = true
   scan_enabled  = true
-  after         = "${var.Env-Name}-newsite-mail-rule"
+  after         = "${var.env_name}-newsite-mail-rule"
 
   depends_on = [
     aws_s3_bucket.admin_emailbucket,
@@ -88,28 +88,28 @@ resource "aws_ses_receipt_rule" "admin_email_rule" {
   ]
 
   recipients = [
-    "admin@${var.Env-Subdomain}.service.gov.uk",
+    "admin@${var.env_subdomain}.service.gov.uk",
   ]
 
   s3_action {
-    bucket_name = "${var.Env-Name}-admin-emailbucket"
+    bucket_name = "${var.env_name}-admin-emailbucket"
     position    = 1
   }
 }
 
 resource "aws_ses_receipt_rule" "log_request_rule" {
-  name          = "${var.Env-Name}-log-request-rule"
+  name          = "${var.env_name}-log-request-rule"
   rule_set_name = "GovWifiRuleSet"
   enabled       = true
   scan_enabled  = true
-  after         = "${var.Env-Name}-admin-email-rule"
+  after         = "${var.env_name}-admin-email-rule"
 
   recipients = [
-    "logrequest@${var.Env-Subdomain}.service.gov.uk",
+    "logrequest@${var.env_subdomain}.service.gov.uk",
   ]
 
   sns_action {
-    topic_arn = var.devops-notifications-arn
+    topic_arn = var.devops_notifications_arn
     position  = 1
   }
 }

--- a/govwifi-emails/route53.tf
+++ b/govwifi-emails/route53.tf
@@ -3,10 +3,10 @@
 
 # MX record for this environment
 resource "aws_route53_record" "mx" {
-  zone_id = var.route53-zone-id
-  name    = "${var.Env-Subdomain}.service.gov.uk"
+  zone_id = var.route53_zone_id
+  name    = "${var.env_subdomain}.service.gov.uk"
   type    = "MX"
   ttl     = "300"
-  records = [var.mail-exchange-server]
+  records = [var.mail_exchange_server]
 }
 

--- a/govwifi-emails/s3sns.tf
+++ b/govwifi-emails/s3sns.tf
@@ -1,6 +1,6 @@
 # S3 bucket to store the emails
 resource "aws_s3_bucket" "emailbucket" {
-  bucket        = "${var.Env-Name}-emailbucket"
+  bucket        = "${var.env_name}-emailbucket"
   force_destroy = true
 
   policy = <<EOF
@@ -13,10 +13,10 @@ resource "aws_s3_bucket" "emailbucket" {
           "Service": "ses.amazonaws.com"
         },
         "Action": "s3:PutObject",
-        "Resource": "arn:aws:s3:::${var.Env-Name}-emailbucket/*",
+        "Resource": "arn:aws:s3:::${var.env_name}-emailbucket/*",
         "Condition": {
           "StringEquals": {
-            "aws:Referer": "${var.aws-account-id}"
+            "aws:Referer": "${var.aws_account_id}"
           }
         }
     },{
@@ -26,14 +26,14 @@ resource "aws_s3_bucket" "emailbucket" {
                 "Service": "s3.amazonaws.com"
             },
             "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::${var.Env-Name}-emailbucket/*",
+            "Resource": "arn:aws:s3:::${var.env_name}-emailbucket/*",
             "Condition": {
                 "StringEquals": {
-                    "aws:SourceAccount": "${var.aws-account-id}",
+                    "aws:SourceAccount": "${var.aws_account_id}",
                     "s3:x-amz-acl": "bucket-owner-full-control"
                 },
                 "ArnLike": {
-                    "aws:SourceArn": "arn:aws:s3:::${var.Env-Name}-emailbucket"
+                    "aws:SourceArn": "arn:aws:s3:::${var.env_name}-emailbucket"
                 }
             }
     }]
@@ -42,15 +42,15 @@ EOF
 
 
   tags = {
-    Name   = "${title(var.Env-Name)} Email Bucket"
-    Region = title(var.aws-region-name)
-    #   Product     = "${var.product-name}"
-    Environment = title(var.Env-Name)
+    Name   = "${title(var.env_name)} Email Bucket"
+    Region = title(var.aws_region_name)
+    #   Product     = "${var.product_name}"
+    Environment = title(var.env_name)
     Category    = "User emails"
   }
 
   logging {
-    target_bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
+    target_bucket = "${lower(var.product_name)}-${var.env_name}-${lower(var.aws_region_name)}-accesslogs"
     target_prefix = "user-emails"
   }
 
@@ -74,7 +74,7 @@ EOF
 # S3 bucket to store administration emails - mostly set up so we can receive
 # emails regards to the AWS-provided certificate(used for the elb) approval process.
 resource "aws_s3_bucket" "admin_emailbucket" {
-  bucket        = "${var.Env-Name}-admin-emailbucket"
+  bucket        = "${var.env_name}-admin-emailbucket"
   force_destroy = true
 
   policy = <<EOF
@@ -87,10 +87,10 @@ resource "aws_s3_bucket" "admin_emailbucket" {
           "Service": "ses.amazonaws.com"
         },
         "Action": "s3:PutObject",
-        "Resource": "arn:aws:s3:::${var.Env-Name}-admin-emailbucket/*",
+        "Resource": "arn:aws:s3:::${var.env_name}-admin-emailbucket/*",
         "Condition": {
           "StringEquals": {
-            "aws:Referer": "${var.aws-account-id}"
+            "aws:Referer": "${var.aws_account_id}"
           }
         }
     },{
@@ -100,14 +100,14 @@ resource "aws_s3_bucket" "admin_emailbucket" {
                 "Service": "s3.amazonaws.com"
             },
             "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::${var.Env-Name}-admin-emailbucket/*",
+            "Resource": "arn:aws:s3:::${var.env_name}-admin-emailbucket/*",
             "Condition": {
                 "StringEquals": {
-                    "aws:SourceAccount": "${var.aws-account-id}",
+                    "aws:SourceAccount": "${var.aws_account_id}",
                     "s3:x-amz-acl": "bucket-owner-full-control"
                 },
                 "ArnLike": {
-                    "aws:SourceArn": "arn:aws:s3:::${var.Env-Name}-admin-emailbucket"
+                    "aws:SourceArn": "arn:aws:s3:::${var.env_name}-admin-emailbucket"
                 }
             }
     }]
@@ -116,10 +116,10 @@ EOF
 
 
   tags = {
-    Name   = "${title(var.Env-Name)} Admin Email Bucket"
-    Region = title(var.aws-region-name)
-    #   Product     = "${var.product-name}"
-    Environment = title(var.Env-Name)
+    Name   = "${title(var.env_name)} Admin Email Bucket"
+    Region = title(var.aws_region_name)
+    #   Product     = "${var.product_name}"
+    Environment = title(var.env_name)
     Category    = "Admin emails"
   }
 
@@ -128,15 +128,15 @@ EOF
   }
 
   logging {
-    target_bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
+    target_bucket = "${lower(var.product_name)}-${var.env_name}-${lower(var.aws_region_name)}-accesslogs"
     target_prefix = "admin-emails"
   }
 }
 
 # SNS topic to notify the old backend when an email arrives
 resource "aws_sns_topic" "govwifi_email_notifications" {
-  name         = "${var.Env-Name}-email-notifications"
-  display_name = "${title(var.Env-Name)} GovWifi email notifications"
+  name         = "${var.env_name}-email-notifications"
+  display_name = "${title(var.env_name)} GovWifi email notifications"
 
   policy = <<EOF
 {
@@ -160,10 +160,10 @@ resource "aws_sns_topic" "govwifi_email_notifications" {
         "SNS:Publish",
         "SNS:Receive"
       ],
-      "Resource": "arn:aws:sns:${var.aws-region}:${var.aws-account-id}:${var.Env-Name}-email-notifications",
+      "Resource": "arn:aws:sns:${var.aws_region}:${var.aws_account_id}:${var.env_name}-email-notifications",
       "Condition": {
         "StringEquals": {
-          "AWS:SourceOwner": "${var.aws-account-id}"
+          "AWS:SourceOwner": "${var.aws_account_id}"
         }
       }
     }
@@ -196,7 +196,7 @@ resource "aws_sns_topic_subscription" "email_notifications_target" {
   count                           = var.is_production_aws_account ? 1 : 0
   topic_arn                       = aws_sns_topic.govwifi_email_notifications.arn
   protocol                        = "https"
-  endpoint                        = var.sns-endpoint
+  endpoint                        = var.sns_endpoint
   endpoint_auto_confirms          = true
   confirmation_timeout_in_minutes = 2
   depends_on                      = [aws_sns_topic.govwifi_email_notifications]
@@ -204,14 +204,14 @@ resource "aws_sns_topic_subscription" "email_notifications_target" {
 
 # SNS topic to notify the new user-signup API when an email arrives
 resource "aws_sns_topic" "user_signup_notifications" {
-  name         = "${var.Env-Name}-user-signup-notifications"
-  display_name = "${title(var.Env-Name)} user signup email notifications"
+  name         = "${var.env_name}-user-signup-notifications"
+  display_name = "${title(var.env_name)} user signup email notifications"
 }
 
 resource "aws_sns_topic_subscription" "user_signup_notifications_target" {
   topic_arn              = aws_sns_topic.user_signup_notifications.arn
   protocol               = "https"
-  endpoint               = var.user-signup-notifications-endpoint
+  endpoint               = var.user_signup_notifications_endpoint
   endpoint_auto_confirms = true
   depends_on             = [aws_sns_topic.user_signup_notifications]
 }

--- a/govwifi-emails/variables.tf
+++ b/govwifi-emails/variables.tf
@@ -1,35 +1,35 @@
-variable "product-name" {
+variable "product_name" {
 }
 
-variable "Env-Name" {
+variable "env_name" {
 }
 
-variable "Env-Subdomain" {
+variable "env_subdomain" {
 }
 
-variable "aws-account-id" {
+variable "aws_account_id" {
 }
 
-variable "route53-zone-id" {
+variable "route53_zone_id" {
 }
 
-variable "aws-region" {
+variable "aws_region" {
 }
 
-variable "aws-region-name" {
+variable "aws_region_name" {
 }
 
-variable "mail-exchange-server" {
+variable "mail_exchange_server" {
 }
 
-variable "sns-endpoint" {
+variable "sns_endpoint" {
 }
 
-variable "user-signup-notifications-endpoint" {
+variable "user_signup_notifications_endpoint" {
   description = "HTTP endpoint used by SNS to send user signup email notifications"
 }
 
-variable "devops-notifications-arn" {
+variable "devops_notifications_arn" {
 }
 
 variable "is_production_aws_account" {

--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -146,21 +146,21 @@ module "emails" {
   source = "../../govwifi-emails"
 
   is_production_aws_account = var.is_production_aws_account
-  product-name              = var.product-name
-  Env-Name                  = var.Env-Name
-  Env-Subdomain             = var.Env-Subdomain
-  aws-account-id            = local.aws_account_id
-  route53-zone-id           = local.route53_zone_id
-  aws-region                = var.aws-region
-  aws-region-name           = var.aws-region-name
-  mail-exchange-server      = "10 inbound-smtp.eu-west-1.amazonaws.com"
-  devops-notifications-arn  = module.notifications.topic-arn
+  product_name              = var.product-name
+  env_name                  = var.Env-Name
+  env_subdomain             = var.Env-Subdomain
+  aws_account_id            = local.aws_account_id
+  route53_zone_id           = local.route53_zone_id
+  aws_region                = var.aws-region
+  aws_region_name           = var.aws-region-name
+  mail_exchange_server      = "10 inbound-smtp.eu-west-1.amazonaws.com"
+  devops_notifications_arn  = module.notifications.topic-arn
 
-  user-signup-notifications-endpoint = "https://user-signup-api.${var.Env-Subdomain}.service.gov.uk:8443/user-signup/email-notification"
+  user_signup_notifications_endpoint = "https://user-signup-api.${var.Env-Subdomain}.service.gov.uk:8443/user-signup/email-notification"
 
   // The SNS endpoint is disabled in the secondary AWS account
   // We will conduct an SNS inventory (see this card: https://trello.com/c/EMeet3tl/315-investigate-and-inventory-sns-topics)
-  sns-endpoint = ""
+  sns_endpoint = ""
 }
 
 module "govwifi_keys" {

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -143,19 +143,19 @@ module "emails" {
 
   is_production_aws_account = var.is_production_aws_account
   source                    = "../../govwifi-emails"
-  product-name              = var.product-name
-  Env-Name                  = var.Env-Name
-  Env-Subdomain             = var.Env-Subdomain
-  aws-account-id            = local.aws_account_id
-  route53-zone-id           = local.route53_zone_id
-  aws-region                = var.aws-region
-  aws-region-name           = var.aws-region-name
-  mail-exchange-server      = "10 inbound-smtp.eu-west-1.amazonaws.com"
-  devops-notifications-arn  = module.notifications.topic-arn
+  product_name              = var.product-name
+  env_name                  = var.Env-Name
+  env_subdomain             = var.Env-Subdomain
+  aws_account_id            = local.aws_account_id
+  route53_zone_id           = local.route53_zone_id
+  aws_region                = var.aws-region
+  aws_region_name           = var.aws-region-name
+  mail_exchange_server      = "10 inbound-smtp.eu-west-1.amazonaws.com"
+  devops_notifications_arn  = module.notifications.topic-arn
 
   #sns-endpoint             = "https://elb.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk/sns/"
-  sns-endpoint                       = "https://elb.london.${var.Env-Subdomain}.service.gov.uk/sns/"
-  user-signup-notifications-endpoint = "https://user-signup-api.${var.Env-Subdomain}.service.gov.uk:8443/user-signup/email-notification"
+  sns_endpoint                       = "https://elb.london.${var.Env-Subdomain}.service.gov.uk/sns/"
+  user_signup_notifications_endpoint = "https://user-signup-api.${var.Env-Subdomain}.service.gov.uk:8443/user-signup/email-notification"
 }
 
 module "govwifi_keys" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -158,19 +158,19 @@ module "emails" {
   source = "../../govwifi-emails"
 
   is_production_aws_account = var.is_production_aws_account
-  product-name              = var.product-name
-  Env-Name                  = var.Env-Name
-  Env-Subdomain             = var.Env-Subdomain
-  aws-account-id            = local.aws_account_id
-  route53-zone-id           = local.route53_zone_id
-  aws-region                = var.aws-region
-  aws-region-name           = var.aws-region-name
-  mail-exchange-server      = "10 inbound-smtp.eu-west-1.amazonaws.com"
-  devops-notifications-arn  = module.devops-notifications.topic-arn
+  product_name              = var.product-name
+  env_name                  = var.Env-Name
+  env_subdomain             = var.Env-Subdomain
+  aws_account_id            = local.aws_account_id
+  route53_zone_id           = local.route53_zone_id
+  aws_region                = var.aws-region
+  aws_region_name           = var.aws-region-name
+  mail_exchange_server      = "10 inbound-smtp.eu-west-1.amazonaws.com"
+  devops_notifications_arn  = module.devops-notifications.topic-arn
 
   #sns-endpoint             = "https://elb.${lower(var.aws-region-name)}.${var.Env-Subdomain}.service.gov.uk/sns/"
-  sns-endpoint                       = "https://elb.london.${var.Env-Subdomain}.service.gov.uk/sns/"
-  user-signup-notifications-endpoint = "https://user-signup-api.${var.Env-Subdomain}.service.gov.uk:8443/user-signup/email-notification"
+  sns_endpoint                       = "https://elb.london.${var.Env-Subdomain}.service.gov.uk/sns/"
+  user_signup_notifications_endpoint = "https://user-signup-api.${var.Env-Subdomain}.service.gov.uk:8443/user-signup/email-notification"
 }
 
 # Global ====================================================================


### PR DESCRIPTION
### What
Use underscores rather than dashes for variables in govwifi-emails

### Why
The direction is to converge on using underscores rather than dashes
in variable names, this is more consistent with Terraform itself.


Link to Trello card: https://trello.com/c/ceOJeFUc/1691-use-underscores-rather-than-dashes-for-variable-names-in-the-govwifi-emails-terraform-module
