### PR TITLE
Use underscores for variables in the sns-notifications module

### DIFF
--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -296,7 +296,7 @@ module "notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-staging-temp"
+  topic_name = "govwifi-staging-temp"
   emails     = [var.notification_email]
 }
 
@@ -307,7 +307,7 @@ module "route53-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-staging-dublin-temp"
+  topic_name = "govwifi-staging-dublin-temp"
   emails     = [var.notification_email]
 }
 

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -328,7 +328,7 @@ module "notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-staging-temp"
+  topic_name = "govwifi-staging-temp"
   emails     = [var.notification_email]
 }
 
@@ -339,7 +339,7 @@ module "route53-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-staging-london-temp"
+  topic_name = "govwifi-staging-london-temp"
   emails     = [var.notification_email]
 }
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -324,7 +324,7 @@ module "notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-staging"
+  topic_name = "govwifi-staging"
   emails     = [var.notification_email]
 }
 
@@ -335,7 +335,7 @@ module "route53-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-staging-london"
+  topic_name = "govwifi-staging-london"
   emails     = [var.notification_email]
 }
 

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -290,7 +290,7 @@ module "notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-staging"
+  topic_name = "govwifi-staging"
   emails     = [var.notification_email]
 }
 
@@ -301,7 +301,7 @@ module "route53-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-staging"
+  topic_name = "govwifi-staging"
   emails     = [var.notification_email]
 }
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -329,7 +329,7 @@ module "critical-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-wifi-critical"
+  topic_name = "govwifi-wifi-critical"
   emails     = [var.critical_notification_email]
 }
 
@@ -340,7 +340,7 @@ module "capacity-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-wifi-capacity"
+  topic_name = "govwifi-wifi-capacity"
   emails     = [var.capacity_notification_email]
 }
 
@@ -351,7 +351,7 @@ module "devops-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-wifi-devops"
+  topic_name = "govwifi-wifi-devops"
   emails     = [var.devops_notification_email]
 }
 
@@ -362,7 +362,7 @@ module "route53-critical-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-wifi-critical-london"
+  topic_name = "govwifi-wifi-critical-london"
   emails     = [var.critical_notification_email]
 }
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -309,7 +309,7 @@ module "critical-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-wifi-critical"
+  topic_name = "govwifi-wifi-critical"
   emails     = [var.critical_notification_email]
 }
 
@@ -320,7 +320,7 @@ module "capacity-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-wifi-capacity"
+  topic_name = "govwifi-wifi-capacity"
   emails     = [var.capacity_notification_email]
 }
 
@@ -331,7 +331,7 @@ module "devops-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-wifi-devops"
+  topic_name = "govwifi-wifi-devops"
   emails     = [var.devops_notification_email]
 }
 
@@ -342,7 +342,7 @@ module "route53-critical-notifications" {
 
   source = "../../sns-notification"
 
-  topic-name = "govwifi-wifi-critical"
+  topic_name = "govwifi-wifi-critical"
   emails     = [var.critical_notification_email]
 }
 

--- a/sns-notification/main.tf
+++ b/sns-notification/main.tf
@@ -1,5 +1,5 @@
 resource "aws_sns_topic" "this" {
-  name = var.topic-name
+  name = var.topic_name
 }
 
 data "template_file" "email_subscription" {
@@ -11,7 +11,7 @@ data "template_file" "email_subscription" {
     topic_arn = aws_sns_topic.this.arn
     # Name must be alphanumeric, unique, but also consistent based on the email address.
     # It also needs to stay under 255 characters.
-    name = sha256("${var.topic-name}-${element(var.emails, count.index)}")
+    name = sha256("${var.topic_name}-${element(var.emails, count.index)}")
   }
 
   template = <<-STACK
@@ -29,7 +29,7 @@ STACK
 
 resource "aws_cloudformation_stack" "email" {
   count = local.enable-emails
-  name  = "${var.topic-name}-subscriptions"
+  name  = "${var.topic_name}-subscriptions"
 
   template_body = <<-STACK
   {

--- a/sns-notification/variables.tf
+++ b/sns-notification/variables.tf
@@ -1,4 +1,4 @@
-variable "topic-name" {
+variable "topic_name" {
   type = string
 }
 


### PR DESCRIPTION
### What
Use underscores for variables in the sns-notifications module

### Why
The direction is to converge on using underscores rather than dashes
in variable names, this is more consistent with Terraform itself.


Link to Trello card: https://trello.com/c/zH82WeUX/1694-use-underscores-rather-than-dashes-for-variable-names-in-the-sns-notifications-terraform-module