### PR TITLE
Specify the required version of Terraform for all environments

### DIFF
--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -17,6 +17,8 @@ module "tfstate" {
 }
 
 terraform {
+  required_version = "~> 0.15.5"
+
   backend "s3" {
     # Interpolation is not allowed here.
     #bucket = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate"

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -17,6 +17,8 @@ module "tfstate" {
 }
 
 terraform {
+  required_version = "~> 0.15.5"
+
   backend "s3" {
     # Interpolation is not allowed here.
     #bucket = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate"

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -17,6 +17,8 @@ module "tfstate" {
 }
 
 terraform {
+  required_version = "~> 0.15.5"
+
   backend "s3" {
     # Interpolation is not allowed here.
     #bucket = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate"

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -17,6 +17,8 @@ module "tfstate" {
 }
 
 terraform {
+  required_version = "~> 0.15.5"
+
   backend "s3" {
     # Interpolation is not allowed here.
     #bucket = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -17,6 +17,8 @@ module "tfstate" {
 }
 
 terraform {
+  required_version = "~> 0.15.5"
+
   backend "s3" {
     # Interpolation is not allowed here.
     #bucket = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate"

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -17,6 +17,8 @@ module "tfstate" {
 }
 
 terraform {
+  required_version = "~> 0.15.5"
+
   backend "s3" {
     # Interpolation is not allowed here.
     #bucket = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate"


### PR DESCRIPTION
### What
Specify the required version of Terraform for all environments

### Why
To help to ensure that the configuration is used with the intended
version of Terraform.


Link to Trello card: https://trello.com/c/38iTMsqg/1695-specify-the-required-version-of-terraform-for-all-environments-in-the-terraform-configuration