### PR TITLE
Specify the required providers in a couple more modules

### DIFF
--- a/global-dns/main.tf
+++ b/global-dns/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/govwifi-slack-alerts/main.tf
+++ b/govwifi-slack-alerts/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
 resource "aws_iam_role" "govwifi_wifi_london_aws_chatbot_role" {
   name        = "govwifi-aws-chatbot-role"
   path        = "/"


### PR DESCRIPTION
### What
Specify the required providers in a couple more modules

### Why
This is a follow up to 1f9407baa53006b1a6840c465776caf4f4336b25.

This addresses the warnings from Terraform like:

│ Warning: Provider aws is undefined
│
│   on main.tf line 365, in module "govwifi_prometheus":
│  365:     aws = aws.AWS-main
│
│ Module module.govwifi_prometheus does not declare a provider named aws.
│ If you wish to specify a provider configuration for the module, add an
| entry for aws in the required_providers block within
│ the module.

Specifying required providers was introduced in Terrafrom 0.13 [1],
and with Terraform 0.15, there are now warnings (like the one above)
about modules that are being passed providers explicitly, but don't
specify the providers they require.


Link to Trello card: https://trello.com/c/t63XMcK3/1698-specify-the-requiredproviders-in-a-couple-more-terraform-modules