### PR TITLE
Add weekly rake task to keep the data exported to data.gov.uk in sync.

### DIFF
--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -153,6 +153,12 @@ variable "metrics-bucket-name" {
   description = "Name of the S3 bucket to write metrics into"
 }
 
+variable "export-data-bucket-name" {
+  type        = string
+  default     = ""
+  description = "Name of the bucket we use to export data to data.gov.uk"
+}
+
 variable "use_env_prefix" {
 
 }

--- a/govwifi-dashboard/outputs.tf
+++ b/govwifi-dashboard/outputs.tf
@@ -3,3 +3,8 @@ output "metrics-bucket-name" {
   value       = aws_s3_bucket.metrics_bucket.id
 }
 
+output "export-data-bucket-name" {
+  description = "the name for the bucket used to export data to data.gov.uk"
+  value       = aws_s3_bucket.export_data_bucket.id
+}
+

--- a/govwifi-dashboard/s3.tf
+++ b/govwifi-dashboard/s3.tf
@@ -12,3 +12,15 @@ resource "aws_s3_bucket" "metrics_bucket" {
   }
 }
 
+resource "aws_s3_bucket" "export_data_bucket" {
+  bucket = "govwifi-export-data-bucket"
+  acl    = "private"
+
+  tags = {
+    Name = "Exported metrics data"
+  }
+
+  versioning {
+    enabled = false
+  }
+}


### PR DESCRIPTION
### What
Every week we run a rake task that takes all the data from the metrics bucket
and merges it into a number of files which are copied to an S3 bucket so that data.gov.uk can harvest our performance data. This change runs this rake task weekly so that our data is in sync.

### Why
We want to keep the data we export to data.gov.uk in sync.

Link to Trello card (if applicable): https://trello.com/c/7XXcjgKz/1645-write-aws-lambda-to-create-metrics-file-in-s3
