### PR TITLE
Remove the unused aws-region variable from terraform-state

### DIFF
--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -7,7 +7,6 @@ module "tfstate" {
   product-name       = var.product-name
   Env-Name           = var.Env-Name
   aws-account-id     = local.aws_account_id
-  aws-region         = var.aws-region
   aws-region-name    = var.aws-region-name
   backup-region-name = var.backup-region-name
 

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -7,7 +7,6 @@ module "tfstate" {
   product-name       = var.product-name
   Env-Name           = var.Env-Name
   aws-account-id     = local.aws_account_id
-  aws-region         = var.aws-region
   aws-region-name    = var.aws-region-name
   backup-region-name = var.backup-region-name
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -7,7 +7,6 @@ module "tfstate" {
   product-name       = var.product-name
   Env-Name           = var.Env-Name
   aws-account-id     = local.aws_account_id
-  aws-region         = var.aws-region
   aws-region-name    = var.aws-region-name
   backup-region-name = var.backup-region-name
 

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -7,7 +7,6 @@ module "tfstate" {
   product-name       = var.product-name
   Env-Name           = var.Env-Name
   aws-account-id     = local.aws_account_id
-  aws-region         = var.aws-region
   aws-region-name    = var.aws-region-name
   backup-region-name = var.backup-region-name
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -7,7 +7,6 @@ module "tfstate" {
   product-name       = var.product-name
   Env-Name           = var.Env-Name
   aws-account-id     = local.aws_account_id
-  aws-region         = var.aws-region
   aws-region-name    = var.aws-region-name
   backup-region-name = var.backup-region-name
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -7,7 +7,6 @@ module "tfstate" {
   product-name       = var.product-name
   Env-Name           = var.Env-Name
   aws-account-id     = local.aws_account_id
-  aws-region         = var.aws-region
   aws-region-name    = var.aws-region-name
   backup-region-name = var.backup-region-name
 

--- a/terraform-state/variables.tf
+++ b/terraform-state/variables.tf
@@ -4,9 +4,6 @@ variable "Env-Name" {
 variable "aws-account-id" {
 }
 
-variable "aws-region" {
-}
-
 variable "aws-region-name" {
 }
 


### PR DESCRIPTION
### What
Remove the unused aws-region variable from terraform-state

### Why
The last use was removed in bc94b0f1c41555fc889dfb12e6ba5ee4f42a0f69.


Link to Trello card: https://trello.com/c/F7bQzMFi/1740-remove-the-unused-aws-region-variable-from-the-terraform-state-terraform-module