### PR TITLE
Use underscores for variables in govwifi-elasticsearch

### DIFF
--- a/govwifi-elasticsearch/elasticsearch.tf
+++ b/govwifi-elasticsearch/elasticsearch.tf
@@ -1,22 +1,22 @@
 resource "aws_security_group" "elasticsearch_inbound" {
   name        = "elasticsearch-inbound"
   description = "Allow Outbound Traffic From the API"
-  vpc_id      = var.vpc-id
+  vpc_id      = var.vpc_id
 
   tags = {
-    Name = "${title(var.Env-Name)} Elasticsearch inbound traffic"
+    Name = "${title(var.env_name)} Elasticsearch inbound traffic"
   }
 
   ingress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = [var.vpc-cidr-block]
+    cidr_blocks = [var.vpc_cidr_block]
   }
 }
 
 resource "aws_elasticsearch_domain" "govwifi_elasticsearch" {
-  domain_name           = var.domain-name
+  domain_name           = var.domain_name
   elasticsearch_version = "7.9"
 
   cluster_config {
@@ -28,7 +28,7 @@ resource "aws_elasticsearch_domain" "govwifi_elasticsearch" {
 
   vpc_options {
     subnet_ids = [
-      var.backend-subnet-id
+      var.backend_subnet_id
     ]
 
     security_group_ids = [
@@ -51,7 +51,7 @@ resource "aws_elasticsearch_domain" "govwifi_elasticsearch" {
         "AWS": "*"
       },
       "Action": "es:*",
-      "Resource": "arn:aws:es:${var.aws-region}:${var.aws-account-id}:domain/${var.domain-name}/*"
+      "Resource": "arn:aws:es:${var.aws_region}:${var.aws_account_id}:domain/${var.domain_name}/*"
     }
   ]
 }

--- a/govwifi-elasticsearch/variables.tf
+++ b/govwifi-elasticsearch/variables.tf
@@ -1,20 +1,20 @@
-variable "Env-Name" {
+variable "env_name" {
 }
 
-variable "aws-region" {
+variable "aws_region" {
 }
 
-variable "backend-subnet-id" {
+variable "backend_subnet_id" {
 }
 
-variable "vpc-id" {
+variable "vpc_id" {
 }
 
-variable "vpc-cidr-block" {
+variable "vpc_cidr_block" {
 }
 
-variable "aws-account-id" {
+variable "aws_account_id" {
 }
 
-variable "domain-name" {
+variable "domain_name" {
 }

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -431,14 +431,14 @@ module "govwifi_elasticsearch" {
   }
 
   source         = "../../govwifi-elasticsearch"
-  domain-name    = "${var.Env-Name}-elasticsearch"
-  Env-Name       = var.Env-Name
-  aws-region     = var.aws-region
-  aws-account-id = local.aws_account_id
-  vpc-id         = module.backend.backend-vpc-id
-  vpc-cidr-block = module.backend.vpc-cidr-block
+  domain_name    = "${var.Env-Name}-elasticsearch"
+  env_name       = var.Env-Name
+  aws_region     = var.aws-region
+  aws_account_id = local.aws_account_id
+  vpc_id         = module.backend.backend-vpc-id
+  vpc_cidr_block = module.backend.vpc-cidr-block
 
-  backend-subnet-id = module.backend.backend-subnet-ids[0]
+  backend_subnet_id = module.backend.backend-subnet-ids[0]
 }
 
 module "govwifi_datasync" {

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -428,12 +428,12 @@ module "govwifi_elasticsearch" {
   }
 
   source         = "../../govwifi-elasticsearch"
-  domain-name    = "${var.Env-Name}-elasticsearch"
-  Env-Name       = var.Env-Name
-  aws-region     = var.aws-region
-  aws-account-id = local.aws_account_id
-  vpc-id         = module.backend.backend-vpc-id
-  vpc-cidr-block = module.backend.vpc-cidr-block
+  domain_name    = "${var.Env-Name}-elasticsearch"
+  env_name       = var.Env-Name
+  aws_region     = var.aws-region
+  aws_account_id = local.aws_account_id
+  vpc_id         = module.backend.backend-vpc-id
+  vpc_cidr_block = module.backend.vpc-cidr-block
 
-  backend-subnet-id = module.backend.backend-subnet-ids[0]
+  backend_subnet_id = module.backend.backend-subnet-ids[0]
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -481,12 +481,12 @@ module "govwifi_elasticsearch" {
   }
 
   source         = "../../govwifi-elasticsearch"
-  domain-name    = "${var.Env-Name}-elasticsearch"
-  Env-Name       = var.Env-Name
-  aws-region     = var.aws-region
-  aws-account-id = local.aws_account_id
-  vpc-id         = module.backend.backend-vpc-id
-  vpc-cidr-block = module.backend.vpc-cidr-block
+  domain_name    = "${var.Env-Name}-elasticsearch"
+  env_name       = var.Env-Name
+  aws_region     = var.aws-region
+  aws_account_id = local.aws_account_id
+  vpc_id         = module.backend.backend-vpc-id
+  vpc_cidr_block = module.backend.vpc-cidr-block
 
-  backend-subnet-id = module.backend.backend-subnet-ids[0]
+  backend_subnet_id = module.backend.backend-subnet-ids[0]
 }


### PR DESCRIPTION
### What
Use underscores for variables in govwifi-elasticsearch

### Why
The direction is to converge on using underscores rather than dashes
in variable names, this is more consistent with Terraform itself.


Link to Trello card: https://trello.com/c/cf60Q9ei/1742-use-underscores-rather-than-dashes-for-variables-in-the-govwifi-elasticsearch-module