### PR TITLE
Use underscores for variables in govwifi-slack-alerts

### DIFF
--- a/govwifi-slack-alerts/main.tf
+++ b/govwifi-slack-alerts/main.tf
@@ -41,7 +41,7 @@ resource "aws_cloudformation_stack" "aws_slack_chatbot" {
           "LoggingLevel" : "NONE",
           "SlackChannelId" : "${local.slack-channel-id}",
           "SlackWorkspaceId" : "${local.slack-workplace-id}",
-          "SnsTopicArns" : [ "${var.critical-notifications-topic-arn}","${var.capacity-notifications-topic-arn}","${var.route53-critical-notifications-topic-arn}" ]
+          "SnsTopicArns" : [ "${var.critical_notifications_topic_arn}","${var.capacity_notifications_topic_arn}","${var.route53_critical_notifications_topic_arn}" ]
         }
       }
     }

--- a/govwifi-slack-alerts/variables.tf
+++ b/govwifi-slack-alerts/variables.tf
@@ -1,5 +1,5 @@
-variable "critical-notifications-topic-arn" {}
+variable "critical_notifications_topic_arn" {}
 
-variable "capacity-notifications-topic-arn" {}
+variable "capacity_notifications_topic_arn" {}
 
-variable "route53-critical-notifications-topic-arn" {}
+variable "route53_critical_notifications_topic_arn" {}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -470,9 +470,9 @@ module "govwifi_slack_alerts" {
 
   source = "../../govwifi-slack-alerts"
 
-  critical-notifications-topic-arn         = module.critical-notifications.topic-arn
-  capacity-notifications-topic-arn         = module.capacity-notifications.topic-arn
-  route53-critical-notifications-topic-arn = module.route53-critical-notifications.topic-arn
+  critical_notifications_topic_arn         = module.critical-notifications.topic-arn
+  capacity_notifications_topic_arn         = module.capacity-notifications.topic-arn
+  route53_critical_notifications_topic_arn = module.route53-critical-notifications.topic-arn
 }
 
 module "govwifi_elasticsearch" {


### PR DESCRIPTION
### What
Use underscores for variables in govwifi-slack-alerts

### Why
The direction is to converge on using underscores rather than dashes
in variable names, this is more consistent with Terraform itself.


Link to Trello card: https://trello.com/c/TP4cZTjL/1743-use-underscores-rather-than-dashes-for-variables-in-the-terraform-govwifi-slack-alerts-module