### PR TITLE
Remove the grafana module feature toggle

### DIFF
--- a/govwifi-grafana/alarms.tf
+++ b/govwifi-grafana/alarms.tf
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_metric_alarm" "grafana_instance_status" {
   threshold           = "0"
 
   dimensions = {
-    InstanceId = aws_instance.grafana_instance.*.id[0]
+    InstanceId = aws_instance.grafana_instance.id
   }
 
 }
@@ -35,7 +35,7 @@ resource "aws_cloudwatch_metric_alarm" "grafana_system_status" {
   threshold           = "0"
 
   dimensions = {
-    InstanceId = aws_instance.grafana_instance.*.id[0]
+    InstanceId = aws_instance.grafana_instance.id
   }
 
 }

--- a/govwifi-grafana/eip.tf
+++ b/govwifi-grafana/eip.tf
@@ -1,5 +1,5 @@
 resource "aws_eip" "grafana_eip" {
-  instance = aws_instance.grafana_instance[0].id
+  instance = aws_instance.grafana_instance.id
   vpc      = true
 
   tags = {
@@ -9,9 +9,8 @@ resource "aws_eip" "grafana_eip" {
 }
 
 resource "aws_eip_association" "grafana_eip_assoc" {
-  count         = var.create_grafana_server
   depends_on    = [aws_instance.grafana_instance]
-  instance_id   = aws_instance.grafana_instance[0].id
+  instance_id   = aws_instance.grafana_instance.id
   allocation_id = aws_eip.grafana_eip.id
 }
 

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -17,7 +17,6 @@ data "aws_ami" "ubuntu" {
 # The element() function used in subnets wraps around when the index is over the number of elements
 # eg. in the 4th iteration the value returned will be the 1st, if there are only 3 elements in the list.
 resource "aws_instance" "grafana_instance" {
-  count                   = var.create_grafana_server
   ami                     = data.aws_ami.ubuntu.id
   instance_type           = "t2.small"
   key_name                = var.ssh-key-name
@@ -46,7 +45,6 @@ resource "aws_instance" "grafana_instance" {
 }
 
 resource "aws_ebs_volume" "grafana_ebs" {
-  count             = var.create_grafana_server
   size              = 40
   encrypted         = true
   availability_zone = "${var.aws-region}a"
@@ -57,11 +55,10 @@ resource "aws_ebs_volume" "grafana_ebs" {
 }
 
 resource "aws_volume_attachment" "grafana_ebs_attach" {
-  count       = var.create_grafana_server
   depends_on  = [aws_ebs_volume.grafana_ebs]
   device_name = var.grafana-device-name
-  volume_id   = aws_ebs_volume.grafana_ebs[0].id
-  instance_id = aws_instance.grafana_instance[0].id
+  volume_id   = aws_ebs_volume.grafana_ebs.id
+  instance_id = aws_instance.grafana_instance.id
 }
 
 data "template_file" "grafana_user_data" {

--- a/govwifi-grafana/loadbalancer.tf
+++ b/govwifi-grafana/loadbalancer.tf
@@ -52,6 +52,6 @@ resource "aws_alb_target_group" "grafana_tg" {
 
 resource "aws_alb_target_group_attachment" "grafana" {
   target_group_arn = aws_alb_target_group.grafana_tg.arn
-  target_id        = aws_instance.grafana_instance[0].private_ip
+  target_id        = aws_instance.grafana_instance.private_ip
   port             = 3000
 }

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -30,11 +30,6 @@ variable "be-admin-in" {
   type        = string
 }
 
-variable "create_grafana_server" {
-  description = "A feature toggle for the Grafana instance (1 = enabled; value defaults to disabled and is overwritten in the main deployment file.)"
-  default     = "0"
-}
-
 variable "vpc-id" {
   description = "VPC ID used for the Application Load Balancer."
   type        = string

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -410,9 +410,7 @@ module "govwifi_grafana" {
   backend-subnet-ids = module.backend.backend-subnet-ids
   be-admin-in        = module.backend.be-admin-in
 
-  # Feature toggle so we only create the Grafana instance in Staging London
-  create_grafana_server = "1"
-  vpc-id                = module.backend.backend-vpc-id
+  vpc-id = module.backend.backend-vpc-id
 
   bastion_ip = var.bastion_server_ip
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -406,9 +406,6 @@ module "govwifi_grafana" {
 
   be-admin-in = module.backend.be-admin-in
 
-  # Feature toggle so we only create the Grafana instance in Staging London
-  create_grafana_server = "1"
-
   vpc-id = module.backend.backend-vpc-id
 
   bastion_ip = var.bastion_server_ip

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -446,9 +446,6 @@ module "govwifi_grafana" {
 
   be-admin-in = module.backend.be-admin-in
 
-  # Feature toggle so we only create the Grafana instance in Staging London
-  create_grafana_server = "1"
-
   vpc-id = module.backend.backend-vpc-id
 
   bastion_ip = var.bastion_server_ip


### PR DESCRIPTION
### What
Remove the grafana module feature toggle

### Why
The module was only present where it was enabled, so the feature
toggle doesn't seem to be in use currently. I also think this makes
the Terraform simpler and easier to read.


Link to Trello card: https://trello.com/c/5gNsE6el/1745-remove-the-govwifi-grafana-terraform-module-feature-toggle
