### PR TITLE
Use underscores rather for variables in govwifi-dashboard

### DIFF
--- a/govwifi-dashboard/s3.tf
+++ b/govwifi-dashboard/s3.tf
@@ -1,10 +1,10 @@
 resource "aws_s3_bucket" "metrics_bucket" {
-  bucket = "govwifi-${var.Env-Name}-metrics-bucket"
+  bucket = "govwifi-${var.env_name}-metrics-bucket"
   acl    = "private"
 
   tags = {
-    Name        = "${title(var.Env-Name)} Metrics data"
-    Environment = title(var.Env-Name)
+    Name        = "${title(var.env_name)} Metrics data"
+    Environment = title(var.env_name)
   }
 
   versioning {

--- a/govwifi-dashboard/variables.tf
+++ b/govwifi-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "Env-Name" {
+variable "env_name" {
   description = "E.g. staging"
 }
 

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -350,7 +350,7 @@ module "govwifi_dashboard" {
   }
 
   source   = "../../govwifi-dashboard"
-  Env-Name = var.Env-Name
+  env_name = var.Env-Name
 }
 
 /*

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -345,7 +345,7 @@ module "govwifi_dashboard" {
   }
 
   source   = "../../govwifi-dashboard"
-  Env-Name = var.Env-Name
+  env_name = var.Env-Name
 }
 
 /*

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -387,7 +387,7 @@ module "govwifi_dashboard" {
   }
 
   source   = "../../govwifi-dashboard"
-  Env-Name = var.Env-Name
+  env_name = var.Env-Name
 }
 
 /*


### PR DESCRIPTION
### What
Use underscores rather for variables in govwifi-dashboard

### Why
The direction is to converge on using underscores rather than dashes
in variable names, this is more consistent with Terraform itself.


Link to Trello card: https://trello.com/c/Dt6RKX2H/1746-use-underscores-rather-than-dashes-for-variables-in-the-govwifi-dashboard-terraform-module