### PR TITLE
Use underscores rather than dashes for variables in terraform-state

### DIFF
--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -4,15 +4,15 @@ module "tfstate" {
   }
 
   source             = "../../terraform-state"
-  product-name       = var.product-name
-  Env-Name           = var.Env-Name
-  aws-account-id     = local.aws_account_id
-  aws-region-name    = var.aws-region-name
-  backup-region-name = var.backup-region-name
+  product_name       = var.product-name
+  env_name           = var.Env-Name
+  aws_account_id     = local.aws_account_id
+  aws_region_name    = var.aws-region-name
+  backup_region_name = var.backup-region-name
 
   # TODO: separate module for accesslogs
-  accesslogs-glacier-transition-days = 7
-  accesslogs-expiration-days         = 30
+  accesslogs_glacier_transition_days = 7
+  accesslogs_expiration_days         = 30
 }
 
 terraform {

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -4,15 +4,15 @@ module "tfstate" {
   }
 
   source             = "../../terraform-state"
-  product-name       = var.product-name
-  Env-Name           = var.Env-Name
-  aws-account-id     = local.aws_account_id
-  aws-region-name    = var.aws-region-name
-  backup-region-name = var.backup-region-name
+  product_name       = var.product-name
+  env_name           = var.Env-Name
+  aws_account_id     = local.aws_account_id
+  aws_region_name    = var.aws-region-name
+  backup_region_name = var.backup-region-name
 
   # TODO: separate module for accesslogs
-  accesslogs-glacier-transition-days = 7
-  accesslogs-expiration-days         = 30
+  accesslogs_glacier_transition_days = 7
+  accesslogs_expiration_days         = 30
 }
 
 terraform {

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -4,15 +4,15 @@ module "tfstate" {
   }
 
   source             = "../../terraform-state"
-  product-name       = var.product-name
-  Env-Name           = var.Env-Name
-  aws-account-id     = local.aws_account_id
-  aws-region-name    = var.aws-region-name
-  backup-region-name = var.backup-region-name
+  product_name       = var.product-name
+  env_name           = var.Env-Name
+  aws_account_id     = local.aws_account_id
+  aws_region_name    = var.aws-region-name
+  backup_region_name = var.backup-region-name
 
   # TODO: separate module for accesslogs
-  accesslogs-glacier-transition-days = 7
-  accesslogs-expiration-days         = 30
+  accesslogs_glacier_transition_days = 7
+  accesslogs_expiration_days         = 30
 }
 
 terraform {

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -4,15 +4,15 @@ module "tfstate" {
   }
 
   source             = "../../terraform-state"
-  product-name       = var.product-name
-  Env-Name           = var.Env-Name
-  aws-account-id     = local.aws_account_id
-  aws-region-name    = var.aws-region-name
-  backup-region-name = var.backup-region-name
+  product_name       = var.product-name
+  env_name           = var.Env-Name
+  aws_account_id     = local.aws_account_id
+  aws_region_name    = var.aws-region-name
+  backup_region_name = var.backup-region-name
 
   # TODO: separate module for accesslogs
-  accesslogs-glacier-transition-days = 7
-  accesslogs-expiration-days         = 30
+  accesslogs_glacier_transition_days = 7
+  accesslogs_expiration_days         = 30
 }
 
 terraform {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -4,15 +4,15 @@ module "tfstate" {
   }
 
   source             = "../../terraform-state"
-  product-name       = var.product-name
-  Env-Name           = var.Env-Name
-  aws-account-id     = local.aws_account_id
-  aws-region-name    = var.aws-region-name
-  backup-region-name = var.backup-region-name
+  product_name       = var.product-name
+  env_name           = var.Env-Name
+  aws_account_id     = local.aws_account_id
+  aws_region_name    = var.aws-region-name
+  backup_region_name = var.backup-region-name
 
   # TODO: separate module for accesslogs
-  accesslogs-glacier-transition-days = 30
-  accesslogs-expiration-days         = 90
+  accesslogs_glacier_transition_days = 30
+  accesslogs_expiration_days         = 90
 }
 
 terraform {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -4,15 +4,15 @@ module "tfstate" {
   }
 
   source             = "../../terraform-state"
-  product-name       = var.product-name
-  Env-Name           = var.Env-Name
-  aws-account-id     = local.aws_account_id
-  aws-region-name    = var.aws-region-name
-  backup-region-name = var.backup-region-name
+  product_name       = var.product-name
+  env_name           = var.Env-Name
+  aws_account_id     = local.aws_account_id
+  aws_region_name    = var.aws-region-name
+  backup_region_name = var.backup-region-name
 
   # TODO: separate module for accesslogs
-  accesslogs-glacier-transition-days = 30
-  accesslogs-expiration-days         = 90
+  accesslogs_glacier_transition_days = 30
+  accesslogs_expiration_days         = 90
 }
 
 terraform {

--- a/terraform-state/accesslogs.tf
+++ b/terraform-state/accesslogs.tf
@@ -3,7 +3,7 @@
 # --------------------------------------------------------------
 
 resource "aws_iam_role" "accesslogs_replication" {
-  name = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs-replication-role"
+  name = "${lower(var.product_name)}-${var.env_name}-${lower(var.aws_region_name)}-accesslogs-replication-role"
 
   assume_role_policy = <<POLICY
 {
@@ -24,7 +24,7 @@ POLICY
 }
 
 resource "aws_iam_policy" "accesslogs_replication" {
-  name = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs-replication-policy"
+  name = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-accesslogs-replication-policy"
 
   policy = <<EOF
 {
@@ -56,7 +56,7 @@ resource "aws_iam_policy" "accesslogs_replication" {
          "s3:ReplicateDelete"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::${lower(var.product-name)}-${var.Env-Name}-${lower(var.backup-region-name)}-accesslogs/*"
+      "Resource": "arn:aws:s3:::${lower(var.product_name)}-${var.env_name}-${lower(var.backup_region_name)}-accesslogs/*"
     }
   ]
 }
@@ -65,19 +65,19 @@ EOF
 }
 
 resource "aws_iam_policy_attachment" "accesslogs_replication" {
-  name       = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs-replication"
+  name       = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-accesslogs-replication"
   roles      = [aws_iam_role.accesslogs_replication.name]
   policy_arn = aws_iam_policy.accesslogs_replication.arn
 }
 
 resource "aws_s3_bucket" "accesslogs_bucket" {
-  bucket = "${lower(var.product-name)}-${var.Env-Name}-${lower(var.aws-region-name)}-accesslogs"
+  bucket = "${lower(var.product_name)}-${var.env_name}-${lower(var.aws_region_name)}-accesslogs"
   acl    = "log-delivery-write"
 
   tags = {
-    Region      = title(var.aws-region-name)
-    Product     = var.product-name
-    Environment = title(var.Env-Name)
+    Region      = title(var.aws_region_name)
+    Product     = var.product_name
+    Environment = title(var.env_name)
     Category    = "Accesslogs"
   }
 
@@ -86,16 +86,16 @@ resource "aws_s3_bucket" "accesslogs_bucket" {
   }
 
   lifecycle_rule {
-    id      = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs-lifecycle"
+    id      = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-accesslogs-lifecycle"
     enabled = true
 
     transition {
-      days          = var.accesslogs-glacier-transition-days
+      days          = var.accesslogs_glacier_transition_days
       storage_class = "GLACIER"
     }
 
     expiration {
-      days = var.accesslogs-expiration-days
+      days = var.accesslogs_expiration_days
     }
   }
 
@@ -104,12 +104,12 @@ resource "aws_s3_bucket" "accesslogs_bucket" {
 
     rules {
       # ID is necessary to prevent continuous change issue
-      id     = "${lower(var.aws-region-name)}-to-${lower(var.backup-region-name)}-accesslogs-backup"
-      prefix = "${lower(var.aws-region-name)}-accesslogs-backup"
+      id     = "${lower(var.aws_region_name)}-to-${lower(var.backup_region_name)}-accesslogs-backup"
+      prefix = "${lower(var.aws_region_name)}-accesslogs-backup"
       status = "Enabled"
 
       destination {
-        bucket        = "arn:aws:s3:::${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.backup-region-name)}-accesslogs"
+        bucket        = "arn:aws:s3:::${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.backup_region_name)}-accesslogs"
         storage_class = "STANDARD"
       }
     }

--- a/terraform-state/tfstate.tf
+++ b/terraform-state/tfstate.tf
@@ -1,6 +1,6 @@
 # Resources for setting up s3 for terraform backend. (state storage in s3)
 resource "aws_iam_role" "tfstate_replication" {
-  name = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate-replication-role"
+  name = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-tfstate-replication-role"
 
   assume_role_policy = <<POLICY
 {
@@ -21,7 +21,7 @@ POLICY
 }
 
 resource "aws_iam_policy" "tfstate_replication" {
-  name = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate-replication-policy"
+  name = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-tfstate-replication-policy"
 
   policy = <<EOF
 {
@@ -53,7 +53,7 @@ resource "aws_iam_policy" "tfstate_replication" {
         "s3:ReplicateDelete"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::${lower(var.product-name)}-${var.Env-Name}-${lower(var.backup-region-name)}-tfstate/*"
+      "Resource": "arn:aws:s3:::${lower(var.product_name)}-${var.env_name}-${lower(var.backup_region_name)}-tfstate/*"
     }
   ]
 }
@@ -62,7 +62,7 @@ EOF
 }
 
 resource "aws_iam_policy_attachment" "tfstate_replication" {
-  name       = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate-replication"
+  name       = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-tfstate-replication"
   roles      = [aws_iam_role.tfstate_replication.name]
   policy_arn = aws_iam_policy.tfstate_replication.arn
 }
@@ -73,20 +73,20 @@ resource "aws_kms_key" "tfstate_key" {
   is_enabled              = true
 
   tags = {
-    Region      = title(var.aws-region-name)
-    Product     = var.product-name
-    Environment = title(var.Env-Name)
+    Region      = title(var.aws_region_name)
+    Product     = var.product_name
+    Environment = title(var.env_name)
     Category    = "TFstate"
   }
 }
 
 resource "aws_kms_alias" "tfstate_key_alias" {
-  name          = "alias/${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate-key"
+  name          = "alias/${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-tfstate-key"
   target_key_id = aws_kms_key.tfstate_key.key_id
 }
 
 resource "aws_s3_bucket" "state_bucket" {
-  bucket = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate"
+  bucket = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-tfstate"
 
   policy = <<EOF
 {
@@ -96,10 +96,10 @@ resource "aws_s3_bucket" "state_bucket" {
             "Effect": "Allow",
             "Principal": "*",
             "Action": "s3:*",
-            "Resource": "arn:aws:s3:::${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-tfstate/*",
+            "Resource": "arn:aws:s3:::${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-tfstate/*",
             "Condition": {
                 "StringEquals": {
-                    "aws:SourceAccount": "${var.aws-account-id}",
+                    "aws:SourceAccount": "${var.aws_account_id}",
                     "s3:x-amz-acl": "bucket-owner-full-control"
                 }
             }
@@ -109,9 +109,9 @@ EOF
 
 
   tags = {
-    Region      = title(var.aws-region-name)
-    Product     = var.product-name
-    Environment = title(var.Env-Name)
+    Region      = title(var.aws_region_name)
+    Product     = var.product_name
+    Environment = title(var.env_name)
     Category    = "TFstate"
   }
 
@@ -120,8 +120,8 @@ EOF
   }
 
   logging {
-    target_bucket = "${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.aws-region-name)}-accesslogs"
-    target_prefix = "${lower(var.aws-region-name)}-tfstate"
+    target_bucket = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-accesslogs"
+    target_prefix = "${lower(var.aws_region_name)}-tfstate"
   }
 
   replication_configuration {
@@ -129,12 +129,12 @@ EOF
 
     rules {
       # ID is necessary to prevent continuous change issue
-      id     = "${lower(var.aws-region-name)}-to-${lower(var.backup-region-name)}-tfstate-backup"
-      prefix = "${lower(var.aws-region-name)}-tfstate"
+      id     = "${lower(var.aws_region_name)}-to-${lower(var.backup_region_name)}-tfstate-backup"
+      prefix = "${lower(var.aws_region_name)}-tfstate"
       status = "Enabled"
 
       destination {
-        bucket        = "arn:aws:s3:::${lower(var.product-name)}-${lower(var.Env-Name)}-${lower(var.backup-region-name)}-tfstate"
+        bucket        = "arn:aws:s3:::${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.backup_region_name)}-tfstate"
         storage_class = "STANDARD_IA"
       }
     }

--- a/terraform-state/variables.tf
+++ b/terraform-state/variables.tf
@@ -1,21 +1,21 @@
-variable "Env-Name" {
+variable "env_name" {
 }
 
-variable "aws-account-id" {
+variable "aws_account_id" {
 }
 
-variable "aws-region-name" {
+variable "aws_region_name" {
 }
 
-variable "backup-region-name" {
+variable "backup_region_name" {
 }
 
-variable "product-name" {
+variable "product_name" {
 }
 
-variable "accesslogs-glacier-transition-days" {
+variable "accesslogs_glacier_transition_days" {
 }
 
-variable "accesslogs-expiration-days" {
+variable "accesslogs_expiration_days" {
 }
 


### PR DESCRIPTION
### What
Use underscores rather than dashes for variables in terraform-state

### Why
The direction is to converge on using underscores rather than dashes
in variable names, this is more consistent with Terraform itself.


Link to Trello card: https://trello.com/c/OoRj077o/1747-use-underscores-rather-than-dashes-for-variables-in-the-terraform-state-terraform-module