### PR TITLE
Fix an argument to the frontend module in wifi/main.tf

### DIFF
--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -239,7 +239,7 @@ module "frontend" {
   frontend-docker-image = format("%s/frontend:production", local.docker_image_path)
   raddb-docker-image    = format("%s/raddb:production", local.docker_image_path)
 
-  admin_bucket_name = data.terraform_remote_state.london.outputs.admin_app_data_s3_bucket_name
+  admin_app_data_s3_bucket_name = data.terraform_remote_state.london.outputs.admin_app_data_s3_bucket_name
 
   logging-api-base-url = var.london-api-base-url
   auth-api-base-url    = var.dublin-api-base-url


### PR DESCRIPTION
### What
Fix an argument to the frontend module in wifi/main.tf

### Why
This was changed a bit in 1772f35fed595f09766c18ce0a905feeab11a5d1,
but not fully.


Link to Trello card: https://trello.com/c/eTobuYyV/1684-convert-hard-coded-bucket-name-to-output