### PR TITLE
Use underscores rather than dashes for variables in govwifi-grafana

### DIFF
--- a/govwifi-grafana/alarms.tf
+++ b/govwifi-grafana/alarms.tf
@@ -1,8 +1,8 @@
 resource "aws_cloudwatch_metric_alarm" "grafana_instance_status" {
 
-  alarm_name         = "${var.Env-Name}-grafana-instance-status"
-  alarm_description  = "Alert in event of ${var.Env-Name}-grafana EC2 on instance Status Check failure. Investigate Grafana CloudWatch logs for root cause."
-  alarm_actions      = [var.critical-notifications-arn]
+  alarm_name         = "${var.env_name}-grafana-instance-status"
+  alarm_description  = "Alert in event of ${var.env_name}-grafana EC2 on instance Status Check failure. Investigate Grafana CloudWatch logs for root cause."
+  alarm_actions      = [var.critical_notifications_arn]
   treat_missing_data = "breaching"
 
   namespace           = "AWS/EC2"
@@ -21,9 +21,9 @@ resource "aws_cloudwatch_metric_alarm" "grafana_instance_status" {
 
 resource "aws_cloudwatch_metric_alarm" "grafana_system_status" {
 
-  alarm_name         = "${var.Env-Name}-grafana-system-status"
-  alarm_description  = "Alert in event of ${var.Env-Name}-grafana EC2 on system Status Check failure. Investigate Grafana CloudWatch logs for root cause."
-  alarm_actions      = [var.critical-notifications-arn]
+  alarm_name         = "${var.env_name}-grafana-system-status"
+  alarm_description  = "Alert in event of ${var.env_name}-grafana EC2 on system Status Check failure. Investigate Grafana CloudWatch logs for root cause."
+  alarm_actions      = [var.critical_notifications_arn]
   treat_missing_data = "breaching"
 
   namespace           = "AWS/EC2"
@@ -42,9 +42,9 @@ resource "aws_cloudwatch_metric_alarm" "grafana_system_status" {
 
 resource "aws_cloudwatch_metric_alarm" "grafana_service_status" {
 
-  alarm_name         = "${var.Env-Name}-grafana-service-status"
-  alarm_description  = "Alert in event of ${var.Env-Name}-grafana can not load the login page. This likely indicates the Grafana service is not running."
-  alarm_actions      = [var.critical-notifications-arn]
+  alarm_name         = "${var.env_name}-grafana-service-status"
+  alarm_description  = "Alert in event of ${var.env_name}-grafana can not load the login page. This likely indicates the Grafana service is not running."
+  alarm_actions      = [var.critical_notifications_arn]
   treat_missing_data = "breaching"
 
   namespace           = "AWS/ApplicationELB"
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_metric_alarm" "grafana_service_status" {
 
   dimensions = {
     TargetGroup      = aws_alb_target_group.grafana_tg.arn_suffix,
-    AvailabilityZone = "${var.aws-region}a",
+    AvailabilityZone = "${var.aws_region}a",
     LoadBalancer     = aws_lb.grafana_alb.arn_suffix
   }
 

--- a/govwifi-grafana/eip.tf
+++ b/govwifi-grafana/eip.tf
@@ -3,8 +3,8 @@ resource "aws_eip" "grafana_eip" {
   vpc      = true
 
   tags = {
-    Name = "grafana-${var.Env-Name}"
-    Env  = title(var.Env-Name)
+    Name = "grafana-${var.env_name}"
+    Env  = title(var.env_name)
   }
 }
 

--- a/govwifi-grafana/iam.tf
+++ b/govwifi-grafana/iam.tf
@@ -16,12 +16,12 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
 }
 
 resource "aws_iam_instance_profile" "grafana_instance_profile" {
-  name = "${var.aws-region}-${var.Env-Name}-grafana-instance-profile"
+  name = "${var.aws_region}-${var.env_name}-grafana-instance-profile"
   role = aws_iam_role.grafana_instance_role.name
 }
 
 resource "aws_iam_role" "grafana_instance_role" {
-  name = "${var.aws-region}-${var.Env-Name}-grafana-instance-role"
+  name = "${var.aws_region}-${var.env_name}-grafana-instance-role"
   path = "/"
 
   assume_role_policy = <<EOF
@@ -43,7 +43,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "grafana_instance_policy" {
-  name = "${var.aws-region}-${var.Env-Name}-grafana-instance-policy"
+  name = "${var.aws_region}-${var.env_name}-grafana-instance-policy"
   role = aws_iam_role.grafana_instance_role.id
 
   policy = <<EOF

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -19,13 +19,13 @@ data "aws_ami" "ubuntu" {
 resource "aws_instance" "grafana_instance" {
   ami                     = data.aws_ami.ubuntu.id
   instance_type           = "t2.small"
-  key_name                = var.ssh-key-name
+  key_name                = var.ssh_key_name
   user_data               = data.template_file.grafana_user_data.rendered
   disable_api_termination = false
   ebs_optimized           = false
 
   vpc_security_group_ids = [
-    var.be-admin-in,
+    var.be_admin_in,
     aws_security_group.grafana_ec2_in.id,
     aws_security_group.grafana_ec2_out.id,
   ]
@@ -33,8 +33,8 @@ resource "aws_instance" "grafana_instance" {
   iam_instance_profile = aws_iam_instance_profile.grafana_instance_profile.id
 
   tags = {
-    Name = "${title(var.Env-Name)} Grafana-Server"
-    Env  = title(var.Env-Name)
+    Name = "${title(var.env_name)} Grafana-Server"
+    Env  = title(var.env_name)
   }
 
   lifecycle {
@@ -47,16 +47,16 @@ resource "aws_instance" "grafana_instance" {
 resource "aws_ebs_volume" "grafana_ebs" {
   size              = 40
   encrypted         = true
-  availability_zone = "${var.aws-region}a"
+  availability_zone = "${var.aws_region}a"
 
   tags = {
-    Name = "${var.Env-Name} Grafana volume"
+    Name = "${var.env_name} Grafana volume"
   }
 }
 
 resource "aws_volume_attachment" "grafana_ebs_attach" {
   depends_on  = [aws_ebs_volume.grafana_ebs]
-  device_name = var.grafana-device-name
+  device_name = var.grafana_device_name
   volume_id   = aws_ebs_volume.grafana_ebs.id
   instance_id = aws_instance.grafana_instance.id
 }
@@ -65,13 +65,13 @@ data "template_file" "grafana_user_data" {
   template = file("${path.module}/user_data.sh")
 
   vars = {
-    grafana-log-group       = "${var.Env-Name}-grafana-log-group"
+    grafana-log-group       = "${var.env_name}-grafana-log-group"
     grafana_admin           = local.grafana-admin
     google_client_secret    = local.google-client-secret
     google_client_id        = local.google-client-id
     grafana_server_root_url = local.grafana-server-root-url
-    grafana_device_name     = var.grafana-device-name
-    grafana_docker_version  = var.grafana-docker-version
+    grafana_device_name     = var.grafana_device_name
+    grafana_docker_version  = var.grafana_docker_version
   }
 }
 

--- a/govwifi-grafana/loadbalancer.tf
+++ b/govwifi-grafana/loadbalancer.tf
@@ -1,7 +1,7 @@
 resource "aws_lb" "grafana_alb" {
-  name     = "grafana-alb-${var.Env-Name}"
+  name     = "grafana-alb-${var.env_name}"
   internal = false
-  subnets  = var.subnet-ids
+  subnets  = var.subnet_ids
 
   security_groups = [
     aws_security_group.grafana_alb_in.id,
@@ -11,7 +11,7 @@ resource "aws_lb" "grafana_alb" {
   load_balancer_type = "application"
 
   tags = {
-    Name = "grafana-alb-${var.Env-Name}"
+    Name = "grafana-alb-${var.env_name}"
   }
 }
 
@@ -30,10 +30,10 @@ resource "aws_alb_listener" "alb_listener" {
 
 resource "aws_alb_target_group" "grafana_tg" {
   depends_on           = [aws_lb.grafana_alb]
-  name                 = "grafana-${var.Env-Name}-fg-tg"
+  name                 = "grafana-${var.env_name}-fg-tg"
   port                 = "3000"
   protocol             = "HTTP"
-  vpc_id               = var.vpc-id
+  vpc_id               = var.vpc_id
   target_type          = "ip"
   deregistration_delay = 10
 

--- a/govwifi-grafana/route53.tf
+++ b/govwifi-grafana/route53.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "grafana_route53_record" {
   zone_id = data.aws_route53_zone.zone.id
-  name    = "grafana.${var.Env-Subdomain}.service.gov.uk"
+  name    = "grafana.${var.env_subdomain}.service.gov.uk"
   type    = "A"
 
   alias {
@@ -11,6 +11,6 @@ resource "aws_route53_record" "grafana_route53_record" {
 }
 
 data "aws_route53_zone" "zone" {
-  name         = var.is_production_aws_account ? "wifi.service.gov.uk." : "${var.Env-Subdomain}.service.gov.uk."
+  name         = var.is_production_aws_account ? "wifi.service.gov.uk." : "${var.env_subdomain}.service.gov.uk."
   private_zone = false
 }

--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -1,10 +1,10 @@
 resource "aws_security_group" "grafana_alb_in" {
-  name        = "grafana-alb-in-${var.Env-Name}"
+  name        = "grafana-alb-in-${var.env_name}"
   description = "Allow Inbound Traffic to the Grafana ALB"
-  vpc_id      = var.vpc-id
+  vpc_id      = var.vpc_id
 
   tags = {
-    Name = "${title(var.Env-Name)} Grafana ALB Traffic In"
+    Name = "${title(var.env_name)} Grafana ALB Traffic In"
   }
 
   ingress {
@@ -17,12 +17,12 @@ resource "aws_security_group" "grafana_alb_in" {
 }
 
 resource "aws_security_group" "grafana_alb_out" {
-  name        = "grafana-alb-out-${var.Env-Name}"
+  name        = "grafana-alb-out-${var.env_name}"
   description = "Allow Outbound Traffic from the Grafana ALB"
-  vpc_id      = var.vpc-id
+  vpc_id      = var.vpc_id
 
   tags = {
-    Name = "${title(var.Env-Name)} Grafana ALB Traffic Out"
+    Name = "${title(var.env_name)} Grafana ALB Traffic Out"
   }
 
   # Has an egress rule, defined as a separate resource below to avoid
@@ -41,12 +41,12 @@ resource "aws_security_group_rule" "grafana_alb_out_egress" {
 }
 
 resource "aws_security_group" "grafana_ec2_in" {
-  name        = "grafana-ec2-in-${var.Env-Name}"
+  name        = "grafana-ec2-in-${var.env_name}"
   description = "Allow Inbound Traffic To Grafana from the ALB"
-  vpc_id      = var.vpc-id
+  vpc_id      = var.vpc_id
 
   tags = {
-    Name = "${title(var.Env-Name)} Grafana EC2 Traffic In"
+    Name = "${title(var.env_name)} Grafana EC2 Traffic In"
   }
 
   ingress {
@@ -67,12 +67,12 @@ resource "aws_security_group" "grafana_ec2_in" {
 }
 
 resource "aws_security_group" "grafana_ec2_out" {
-  name        = "grafana-ec2-out-${var.Env-Name}"
+  name        = "grafana-ec2-out-${var.env_name}"
   description = "Allow Outbound Traffic From the Grafana EC2 container"
-  vpc_id      = var.vpc-id
+  vpc_id      = var.vpc_id
 
   tags = {
-    Name = "${title(var.Env-Name)} Grafana EC2 Traffic Out"
+    Name = "${title(var.env_name)} Grafana EC2 Traffic Out"
   }
 
   egress {

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -1,36 +1,36 @@
 # Unless there is a default provided, all values are inherited from the main deployment file.
 # Values can also be overwritten from the main deployment file.
 
-variable "Env-Name" {
+variable "env_name" {
   description = "Environment name for the component."
   type        = string
 }
 
-variable "Env-Subdomain" {
+variable "env_subdomain" {
   description = "E.g. grafana.staging.wifi"
 }
 
-variable "aws-region" {
+variable "aws_region" {
   description = "AWS region for the component."
   type        = string
 }
 
-variable "ssh-key-name" {
+variable "ssh_key_name" {
   description = "The SSH key name to use."
   type        = string
 }
 
-variable "backend-subnet-ids" {
+variable "backend_subnet_ids" {
   description = "List of AWS subnet IDs to place the EC2 instances and ELB into."
   type        = list(string)
 }
 
-variable "be-admin-in" {
+variable "be_admin_in" {
   description = "The relevant security group for this component."
   type        = string
 }
 
-variable "vpc-id" {
+variable "vpc_id" {
   description = "VPC ID used for the Application Load Balancer."
   type        = string
 }
@@ -46,7 +46,7 @@ variable "prometheus_ips" {
   default     = []
 }
 
-variable "subnet-ids" {
+variable "subnet_ids" {
   description = "List of AWS subnet IDs to place the EC2 instances and ELB into"
   type        = list(string)
 }
@@ -55,19 +55,19 @@ variable "administrator_ips" {
   description = "IPs associated with the GDS/CDIO VPN to allow access"
 }
 
-variable "grafana-device-name" {
+variable "grafana_device_name" {
   description = "Name of Grafana Persistent Drive Device Name"
   type        = string
   default     = "/dev/xvdp"
 }
 
-variable "grafana-docker-version" {
+variable "grafana_docker_version" {
   description = "Grafana Docker Version Number"
   type        = string
   default     = "7.5.2"
 }
 
-variable "critical-notifications-arn" {
+variable "critical_notifications_arn" {
   description = "Arn of the critical-nofications sns topic"
   type        = string
 }

--- a/govwifi-grafana/vpc-endpoint.tf
+++ b/govwifi-grafana/vpc-endpoint.tf
@@ -13,9 +13,9 @@ resource "aws_vpc_endpoint" "vpc_endpoint" {
 
   service_name = "com.amazonaws.eu-west-2.secretsmanager"
 
-  subnet_ids = var.backend-subnet-ids
+  subnet_ids = var.backend_subnet_ids
 
   vpc_endpoint_type = "Interface"
 
-  vpc_id = var.vpc-id
+  vpc_id = var.vpc_id
 }

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -397,20 +397,20 @@ module "govwifi_grafana" {
   }
 
   source                     = "../../govwifi-grafana"
-  Env-Name                   = var.Env-Name
-  Env-Subdomain              = var.Env-Subdomain
-  aws-region                 = var.aws-region
-  critical-notifications-arn = module.notifications.topic-arn
+  env_name                   = var.Env-Name
+  env_subdomain              = var.Env-Subdomain
+  aws_region                 = var.aws-region
+  critical_notifications_arn = module.notifications.topic-arn
   is_production_aws_account  = var.is_production_aws_account
 
 
-  ssh-key-name = var.ssh-key-name
+  ssh_key_name = var.ssh-key-name
 
-  subnet-ids         = module.backend.backend-subnet-ids
-  backend-subnet-ids = module.backend.backend-subnet-ids
-  be-admin-in        = module.backend.be-admin-in
+  subnet_ids         = module.backend.backend-subnet-ids
+  backend_subnet_ids = module.backend.backend-subnet-ids
+  be_admin_in        = module.backend.be-admin-in
 
-  vpc-id = module.backend.backend-vpc-id
+  vpc_id = module.backend.backend-vpc-id
 
   bastion_ip = var.bastion_server_ip
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -393,21 +393,21 @@ module "govwifi_grafana" {
   }
 
   source                     = "../../govwifi-grafana"
-  Env-Name                   = var.Env-Name
-  Env-Subdomain              = var.Env-Subdomain
-  aws-region                 = var.aws-region
-  critical-notifications-arn = module.notifications.topic-arn
+  env_name                   = var.Env-Name
+  env_subdomain              = var.Env-Subdomain
+  aws_region                 = var.aws-region
+  critical_notifications_arn = module.notifications.topic-arn
   is_production_aws_account  = var.is_production_aws_account
 
-  ssh-key-name = var.ssh-key-name
+  ssh_key_name = var.ssh-key-name
 
-  subnet-ids = module.backend.backend-subnet-ids
+  subnet_ids = module.backend.backend-subnet-ids
 
-  backend-subnet-ids = module.backend.backend-subnet-ids
+  backend_subnet_ids = module.backend.backend-subnet-ids
 
-  be-admin-in = module.backend.be-admin-in
+  be_admin_in = module.backend.be-admin-in
 
-  vpc-id = module.backend.backend-vpc-id
+  vpc_id = module.backend.backend-vpc-id
 
   bastion_ip = var.bastion_server_ip
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -432,21 +432,21 @@ module "govwifi_grafana" {
   }
 
   source                     = "../../govwifi-grafana"
-  Env-Name                   = var.Env-Name
-  Env-Subdomain              = var.Env-Subdomain
-  aws-region                 = var.aws-region
-  critical-notifications-arn = module.critical-notifications.topic-arn
+  env_name                   = var.Env-Name
+  env_subdomain              = var.Env-Subdomain
+  aws_region                 = var.aws-region
+  critical_notifications_arn = module.critical-notifications.topic-arn
   is_production_aws_account  = var.is_production_aws_account
 
-  ssh-key-name = var.ssh-key-name
+  ssh_key_name = var.ssh-key-name
 
-  subnet-ids = module.backend.backend-subnet-ids
+  subnet_ids = module.backend.backend-subnet-ids
 
-  backend-subnet-ids = module.backend.backend-subnet-ids
+  backend_subnet_ids = module.backend.backend-subnet-ids
 
-  be-admin-in = module.backend.be-admin-in
+  be_admin_in = module.backend.be-admin-in
 
-  vpc-id = module.backend.backend-vpc-id
+  vpc_id = module.backend.backend-vpc-id
 
   bastion_ip = var.bastion_server_ip
 


### PR DESCRIPTION
### What
Use underscores rather than dashes for variables in govwifi-grafana

### Why
The direction is to converge on using underscores rather than dashes
in variable names, this is more consistent with Terraform itself.



Link to Trello card: https://trello.com/c/WFDXEXJ1/1748-use-underscores-rather-than-dashes-for-variable-names-in-the-govwifi-grafana-terraform-module