### PR TITLE
Ensure S3 data export bucket name is unique across environments

### DIFF
--- a/govwifi-dashboard/s3.tf
+++ b/govwifi-dashboard/s3.tf
@@ -13,11 +13,12 @@ resource "aws_s3_bucket" "metrics_bucket" {
 }
 
 resource "aws_s3_bucket" "export_data_bucket" {
-  bucket = "govwifi-export-data-bucket"
+  bucket = "govwifi-${var.env_name}-export-data-bucket"
   acl    = "private"
 
   tags = {
-    Name = "Exported metrics data"
+    Name        = "${title(var.env_name)} Exported metrics data"
+    Environment = title(var.env_name)
   }
 
   versioning {


### PR DESCRIPTION
S3 buckets have globally unique names and so a different name is required
for each environment
