### PR TITLE
Create frontend ECR resources in production

### DIFF
--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -192,6 +192,7 @@ module "frontend" {
   ssh-key-name          = var.ssh-key-name
   frontend-docker-image = format("%s/frontend:production", local.docker_image_path)
   raddb-docker-image    = format("%s/raddb:production", local.docker_image_path)
+  create-ecr            = 1
 
   admin_app_data_s3_bucket_name = module.govwifi_admin.app_data_s3_bucket_name
 


### PR DESCRIPTION
### What
Create frontend ECR resources in production

### Why
These were only being created via the old staging code. Now the old staging
account is being removed, we need these repos to be created via the wifi-london
environment instead.

Link to Trello card (if applicable): https://trello.com/c/0PuXy2Ov/1630-destroy-staging-components-in-the-primary-account
