### PR TITLE
Remove Old Staging IAM Resources

### DIFF
--- a/govwifi-account/iam-instances.tf
+++ b/govwifi-account/iam-instances.tf
@@ -22,12 +22,6 @@ resource "aws_iam_instance_profile" "GDSAdminAccessGovWifi" {
   role = "GDSAdminAccessGovWifi"
 }
 
-resource "aws_iam_instance_profile" "London_ecs_instance_profile_staging" {
-  name = "London-ecs-instance-profile-staging"
-  path = "/"
-  role = "London-ecs-instance-role-staging"
-}
-
 resource "aws_iam_instance_profile" "London_ecs_instance_profile_wifi" {
   name = "London-ecs-instance-profile-wifi"
   path = "/"
@@ -38,12 +32,6 @@ resource "aws_iam_instance_profile" "London_frontend_ecs_instance_profile_wifi" 
   name = "London-frontend-ecs-instance-profile-wifi"
   path = "/"
   role = "London-frontend-ecs-instance-role-wifi"
-}
-
-resource "aws_iam_instance_profile" "London_staging_backend_bastion_instance_profile" {
-  name = "London-staging-backend-bastion-instance-profile"
-  path = "/"
-  role = "London-staging-backend-bastion-instance-role"
 }
 
 resource "aws_iam_instance_profile" "London_wifi_backend_bastion_instance_profile" {

--- a/govwifi-account/iam-policy.tf
+++ b/govwifi-account/iam-policy.tf
@@ -58,44 +58,6 @@ POLICY
 
 }
 
-resource "aws_iam_policy" "ITHC_Staging_Cyberis_Policy" {
-  name        = "ITHC-Staging-Cyberis-Policy"
-  path        = "/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "VisualEditor0",
-      "Effect": "Deny",
-      "Action": "*",
-      "Resource": "*",
-      "Condition": {
-        "NotIpAddress": {
-          "aws:SourceIp": [
-            "90.155.48.192/26",
-            "81.2.127.144/28",
-            "88.97.60.11/24",
-            "3.10.4.97/24",
-            "213.86.153.212/32",
-            "213.86.153.213/32",
-            "213.86.153.214/32",
-            "213.86.153.235/32",
-            "213.86.153.236/32",
-            "213.86.153.237/32",
-            "85.133.67.244/32"
-          ]
-        }
-      }
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_policy" "CloudTrailPolicyForCloudWatchLogs_dab06026_75de_4ad1_a922_e4fc41e01568" {
   name        = "CloudTrailPolicyForCloudWatchLogs_dab06026-75de-4ad1-a922-e4fc41e01568"
   path        = "/service-role/"
@@ -227,89 +189,6 @@ POLICY
 
 }
 
-resource "aws_iam_policy" "s3crr_kms_for_govwifi_staging_london_tfstate_to_govwifi_staging_dublin_tfstate" {
-  name        = "s3crr_kms_for_govwifi-staging-london-tfstate_to_govwifi-staging-dublin-tfstate"
-  path        = "/service-role/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetReplicationConfiguration",
-        "s3:GetObjectVersionForReplication",
-        "s3:GetObjectVersionAcl"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-london-tfstate",
-        "arn:aws:s3:::govwifi-staging-london-tfstate/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete",
-        "s3:ReplicateTags",
-        "s3:GetObjectVersionTagging"
-      ],
-      "Effect": "Allow",
-      "Condition": {
-        "StringLikeIfExists": {
-          "s3:x-amz-server-side-encryption": [
-            "aws:kms",
-            "AES256"
-          ],
-          "s3:x-amz-server-side-encryption-aws-kms-key-id": [
-            "arn:aws:kms:eu-west-1:${var.aws-account-id}:key/a6535eb7-ca94-4abc-8ecb-94b8650be41a"
-          ]
-        }
-      },
-      "Resource": "arn:aws:s3:::govwifi-staging-dublin-tfstate/*"
-    },
-    {
-      "Action": [
-        "kms:Decrypt"
-      ],
-      "Effect": "Allow",
-      "Condition": {
-        "StringLike": {
-          "kms:ViaService": "s3.eu-west-2.amazonaws.com",
-          "kms:EncryptionContext:aws:s3:arn": [
-            "arn:aws:s3:::govwifi-staging-london-tfstate/*"
-          ]
-        }
-      },
-      "Resource": [
-        "arn:aws:kms:eu-west-2:${var.aws-account-id}:key/1d262f07-6e60-423a-b1e6-61fb6d95eca3"
-      ]
-    },
-    {
-      "Action": [
-        "kms:Encrypt"
-      ],
-      "Effect": "Allow",
-      "Condition": {
-        "StringLike": {
-          "kms:ViaService": "s3.eu-west-1.amazonaws.com",
-          "kms:EncryptionContext:aws:s3:arn": [
-            "arn:aws:s3:::govwifi-staging-dublin-tfstate/*"
-          ]
-        }
-      },
-      "Resource": [
-        "arn:aws:kms:eu-west-1:${var.aws-account-id}:key/a6535eb7-ca94-4abc-8ecb-94b8650be41a"
-      ]
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_policy" "GovWifi_Admin" {
   name        = "GovWifi-Admin"
   path        = "/"
@@ -328,128 +207,6 @@ resource "aws_iam_policy" "GovWifi_Admin" {
           "ec2:ResourceTag/Product": "GovWifi"
         }
       }
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_policy" "s3crr_for_govwifi_staging_dublin_tfstate_to_govwifi_staging_london_tfstate" {
-  name        = "s3crr_for_govwifi-staging-dublin-tfstate_to_govwifi-staging-london-tfstate"
-  path        = "/service-role/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:Get*",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-dublin-tfstate",
-        "arn:aws:s3:::govwifi-staging-dublin-tfstate/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete",
-        "s3:ReplicateTags",
-        "s3:GetObjectVersionTagging"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::govwifi-staging-london-tfstate/*"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_policy" "govwifi_staging_london_accesslogs_replication_policy" {
-  name        = "govwifi-staging-london-accesslogs-replication-policy"
-  path        = "/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetReplicationConfiguration",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-london-accesslogs"
-      ]
-    },
-    {
-      "Action": [
-        "s3:GetObjectVersion",
-        "s3:GetObjectVersionAcl"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-london-accesslogs/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::govwifi-staging-dublin-accesslogs/*"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_policy" "govwifi_staging_dublin_accesslogs_replication_policy" {
-  name        = "govwifi-staging-dublin-accesslogs-replication-policy"
-  path        = "/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetReplicationConfiguration",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-dublin-accesslogs"
-      ]
-    },
-    {
-      "Action": [
-        "s3:GetObjectVersion",
-        "s3:GetObjectVersionAcl"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-dublin-accesslogs/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::govwifi-staging-london-accesslogs/*"
     }
   ]
 }
@@ -564,42 +321,6 @@ resource "aws_iam_policy" "govwifi_wifi_dublin_tfstate_replication_policy" {
       ],
       "Effect": "Allow",
       "Resource": "arn:aws:s3:::govwifi-wifi-london-tfstate/*"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_policy" "s3crr_for_govwifi_staging_london_tfstate_to_govwifi_staging_dublin_tfstate" {
-  name        = "s3crr_for_govwifi-staging-london-tfstate_to_govwifi-staging-dublin-tfstate"
-  path        = "/service-role/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:Get*",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-london-tfstate",
-        "arn:aws:s3:::govwifi-staging-london-tfstate/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete",
-        "s3:ReplicateTags",
-        "s3:GetObjectVersionTagging"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::govwifi-staging-dublin-tfstate/*"
     }
   ]
 }
@@ -741,89 +462,6 @@ POLICY
 
 }
 
-resource "aws_iam_policy" "s3crr_kms_for_govwifi_staging_dublin_tfstate_to_govwifi_staging_london_tfstate" {
-  name        = "s3crr_kms_for_govwifi-staging-dublin-tfstate_to_govwifi-staging-london-tfstate"
-  path        = "/service-role/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetReplicationConfiguration",
-        "s3:GetObjectVersionForReplication",
-        "s3:GetObjectVersionAcl"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-dublin-tfstate",
-        "arn:aws:s3:::govwifi-staging-dublin-tfstate/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete",
-        "s3:ReplicateTags",
-        "s3:GetObjectVersionTagging"
-      ],
-      "Effect": "Allow",
-      "Condition": {
-        "StringLikeIfExists": {
-          "s3:x-amz-server-side-encryption": [
-            "aws:kms",
-            "AES256"
-          ],
-          "s3:x-amz-server-side-encryption-aws-kms-key-id": [
-            "arn:aws:kms:eu-west-2:${var.aws-account-id}:key/1d262f07-6e60-423a-b1e6-61fb6d95eca3"
-          ]
-        }
-      },
-      "Resource": "arn:aws:s3:::govwifi-staging-london-tfstate/*"
-    },
-    {
-      "Action": [
-        "kms:Decrypt"
-      ],
-      "Effect": "Allow",
-      "Condition": {
-        "StringLike": {
-          "kms:ViaService": "s3.eu-west-1.amazonaws.com",
-          "kms:EncryptionContext:aws:s3:arn": [
-            "arn:aws:s3:::govwifi-staging-dublin-tfstate/*"
-          ]
-        }
-      },
-      "Resource": [
-        "arn:aws:kms:eu-west-1:${var.aws-account-id}:key/a6535eb7-ca94-4abc-8ecb-94b8650be41a"
-      ]
-    },
-    {
-      "Action": [
-        "kms:Encrypt"
-      ],
-      "Effect": "Allow",
-      "Condition": {
-        "StringLike": {
-          "kms:ViaService": "s3.eu-west-2.amazonaws.com",
-          "kms:EncryptionContext:aws:s3:arn": [
-            "arn:aws:s3:::govwifi-staging-london-tfstate/*"
-          ]
-        }
-      },
-      "Resource": [
-        "arn:aws:kms:eu-west-2:${var.aws-account-id}:key/1d262f07-6e60-423a-b1e6-61fb6d95eca3"
-      ]
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_policy" "govwifi_wifi_london_tfstate_replication_policy" {
   name        = "govwifi-wifi-london-tfstate-replication-policy"
   path        = "/"
@@ -910,42 +548,6 @@ POLICY
 
 }
 
-resource "aws_iam_policy" "s3crr_for_govwifi_staging_london_accesslogs_to_govwifi_staging_ireland_accesslogs" {
-  name        = "s3crr_for_govwifi-staging-london-accesslogs_to_govwifi-staging-ireland-accesslogs"
-  path        = "/service-role/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:Get*",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-london-accesslogs",
-        "arn:aws:s3:::govwifi-staging-london-accesslogs/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete",
-        "s3:ReplicateTags",
-        "s3:GetObjectVersionTagging"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::govwifi-staging-ireland-accesslogs/*"
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_policy" "LambdaUpdateFunctionCode" {
   name        = "LambdaUpdateFunctionCode"
   path        = "/"
@@ -960,49 +562,6 @@ resource "aws_iam_policy" "LambdaUpdateFunctionCode" {
       "Effect": "Allow",
       "Action": "lambda:UpdateFunctionCode",
       "Resource": "arn:aws:lambda:*:*:function:*"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_policy" "govwifi_staging_london_tfstate_replication_policy" {
-  name        = "govwifi-staging-london-tfstate-replication-policy"
-  path        = "/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetReplicationConfiguration",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-london-tfstate"
-      ]
-    },
-    {
-      "Action": [
-        "s3:GetObjectVersion",
-        "s3:GetObjectVersionAcl"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-london-tfstate/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::govwifi-staging-dublin-tfstate/*"
     }
   ]
 }
@@ -1046,49 +605,6 @@ resource "aws_iam_policy" "govwifi_wifi_london_accesslogs_replication_policy" {
       ],
       "Effect": "Allow",
       "Resource": "arn:aws:s3:::govwifi-wifi-dublin-accesslogs/*"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_policy" "govwifi_staging_dublin_tfstate_replication_policy" {
-  name        = "govwifi-staging-dublin-tfstate-replication-policy"
-  path        = "/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetReplicationConfiguration",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-dublin-tfstate"
-      ]
-    },
-    {
-      "Action": [
-        "s3:GetObjectVersion",
-        "s3:GetObjectVersionAcl"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-dublin-tfstate/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::govwifi-staging-london-tfstate/*"
     }
   ]
 }
@@ -1204,42 +720,6 @@ resource "aws_iam_policy" "GovWifi_Admin_S3_Policy" {
         "arn:aws:s3:::govwifi-staging-dublin-tfstate",
         "arn:aws:s3:::govwifi-staging-london-tfstate"
       ]
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_policy" "s3crr_for_govwifi_staging_ireland_accesslogs_to_govwifi_staging_london_accesslogs" {
-  name        = "s3crr_for_govwifi-staging-ireland-accesslogs_to_govwifi-staging-london-accesslogs"
-  path        = "/service-role/"
-  description = ""
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:Get*",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-ireland-accesslogs",
-        "arn:aws:s3:::govwifi-staging-ireland-accesslogs/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete",
-        "s3:ReplicateTags",
-        "s3:GetObjectVersionTagging"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::govwifi-staging-london-accesslogs/*"
     }
   ]
 }
@@ -1468,33 +948,6 @@ resource "aws_iam_policy" "GovWifi_Support" {
           "ec2:ResourceTag/Product": "GovWifi"
         }
       }
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_policy" "govwifi_staging_tfstate_nodelete" {
-  name        = "govwifi-staging-tfstate-nodelete"
-  path        = "/"
-  description = "Prevents accidental deletion of objects in all tfstate buckets"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "VisualEditor0",
-      "Effect": "Deny",
-      "Action": [
-        "s3:DeleteObject",
-        "s3:DeleteBucket"
-      ],
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-dublin-tfstate",
-        "arn:aws:s3:::govwifi-staging-london-tfstate"
-      ]
     }
   ]
 }

--- a/govwifi-account/iam-roles.tf
+++ b/govwifi-account/iam-roles.tf
@@ -544,28 +544,6 @@ POLICY
 
 }
 
-resource "aws_iam_role" "ecsTaskExecutionRole_staging_London" {
-  name = "ecsTaskExecutionRole-staging-London"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ecs-tasks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_role" "flowlogsRole" {
   name = "flowlogsRole"
   path = "/"
@@ -885,28 +863,6 @@ POLICY
 
 }
 
-resource "aws_iam_role" "London_ecs_instance_role_staging" {
-  name = "London-ecs-instance-role-staging"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_role" "London_ecs_instance_role_wifi" {
   name = "London-ecs-instance-role-wifi"
   path = "/"
@@ -920,28 +876,6 @@ resource "aws_iam_role" "London_ecs_instance_role_wifi" {
       "Effect": "Allow",
       "Principal": {
         "Service": "ec2.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role" "London_ecs_service_role_staging" {
-  name = "London-ecs-service-role-staging"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ecs.amazonaws.com"
       },
       "Action": "sts:AssumeRole"
     }
@@ -1008,50 +942,6 @@ resource "aws_iam_role" "London_frontend_ecs_task_role_wifi" {
       "Effect": "Allow",
       "Principal": {
         "Service": "ecs-tasks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role" "London_staging_backend_bastion_instance_role" {
-  name = "London-staging-backend-bastion-instance-role"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role" "London_staging_rds_monitoring_role" {
-  name = "London-staging-rds-monitoring-role"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "monitoring.rds.amazonaws.com"
       },
       "Action": "sts:AssumeRole"
     }
@@ -1265,138 +1155,6 @@ resource "aws_iam_role" "SNSSuccessFeedback" {
       "Effect": "Allow",
       "Principal": {
         "Service": "sns.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role" "staging_logging_api_task_role" {
-  name = "staging-logging-api-task-role"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ecs-tasks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role" "staging_logging_scheduled_task_role" {
-  name = "staging-logging-scheduled-task-role"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "events.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role" "staging_safe_restart_scheduled_task_role" {
-  name = "staging-safe-restart-scheduled-task-role"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "events.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role" "staging_safe_restart_task_role" {
-  name = "staging-safe-restart-task-role"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ecs-tasks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role" "staging_user_signup_api_task_role" {
-  name = "staging-user-signup-api-task-role"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ecs-tasks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role" "staging_user_signup_scheduled_task_role" {
-  name = "staging-user-signup-scheduled-task-role"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "events.amazonaws.com"
       },
       "Action": "sts:AssumeRole"
     }
@@ -2056,61 +1814,6 @@ POLICY
 
 }
 
-resource "aws_iam_role_policy" "London_ecs_instance_role_staging_London_ecs_instance_policy_staging" {
-  name = "London-ecs-instance-policy-staging"
-  role = "London-ecs-instance-role-staging"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ecs:CreateCluster",
-        "ecs:DeregisterContainerInstance",
-        "ecs:DiscoverPollEndpoint",
-        "ecs:Poll",
-        "ecs:RegisterContainerInstance",
-        "ecs:StartTelemetrySession",
-        "ecs:Submit*",
-        "ecr:GetAuthorizationToken",
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:BatchGetImage"
-      ],
-      "Resource": [
-        "*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:DescribeLogStreams"
-      ],
-      "Resource": [
-        "arn:aws:logs:*:*:*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "cloudwatch:PutMetricData",
-        "cloudwatch:GetMetricStatistics",
-        "cloudwatch:ListMetrics",
-        "ec2:DescribeTags"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_role_policy" "London_ecs_instance_role_wifi_London_ecs_instance_policy_wifi" {
   name = "London-ecs-instance-policy-wifi"
   role = "London-ecs-instance-role-wifi"
@@ -2159,42 +1862,6 @@ resource "aws_iam_role_policy" "London_ecs_instance_role_wifi_London_ecs_instanc
         "ec2:DescribeTags"
       ],
       "Resource": "*"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "London_ecs_service_role_staging_London_ecs_service_policy_staging" {
-  name = "London-ecs-service-policy-staging"
-  role = "London-ecs-service-role-staging"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:AuthorizeSecurityGroupIngress",
-        "ec2:Describe*"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-        "elasticloadbalancing:Describe*",
-        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-        "elasticloadbalancing:RegisterTargets",
-        "elasticloadbalancing:DeregisterTargets"
-      ],
-      "Resource": [
-        "arn:aws:elasticloadbalancing:eu-west-2:${var.aws-account-id}:loadbalancer/wifi-backend-elb-staging",
-        "*"
-      ]
     }
   ]
 }
@@ -2367,70 +2034,6 @@ POLICY
 
 }
 
-resource "aws_iam_role_policy" "London_staging_backend_bastion_instance_role_London_staging_backend_bastion_instance_policy" {
-  name = "London-staging-backend-bastion-instance-policy"
-  role = "London-staging-backend-bastion-instance-role"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:DescribeLogStreams"
-      ],
-      "Resource": [
-        "arn:aws:logs:*:*:*"
-      ]
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "London_staging_rds_monitoring_role_London_staging_rds_monitoring_policy" {
-  name = "London-staging-rds-monitoring-policy"
-  role = "London-staging-rds-monitoring-role"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogGroups",
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:PutRetentionPolicy"
-      ],
-      "Resource": [
-        "arn:aws:logs:*:*:log-group:RDS*"
-      ]
-    },
-    {
-      "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogStreams",
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:DescribeLogStreams",
-        "logs:GetLogEvents"
-      ],
-      "Resource": [
-        "arn:aws:logs:*:*:log-group:RDS*:log-stream:*"
-      ]
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_role_policy" "London_wifi_backend_bastion_instance_role_London_wifi_backend_bastion_instance_policy" {
   name = "London-wifi-backend-bastion-instance-policy"
   role = "London-wifi-backend-bastion-instance-role"
@@ -2546,161 +2149,6 @@ resource "aws_iam_role_policy" "SNSSuccessFeedback_oneClick_SNSSuccessFeedback_1
       "Resource": [
         "*"
       ]
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "staging_logging_scheduled_task_role_staging_logging_scheduled_task_policy" {
-  name = "staging-logging-scheduled-task-policy"
-  role = "staging-logging-scheduled-task-role"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "ecs:RunTask",
-      "Resource": "arn:aws:ecs:eu-west-2:${var.aws-account-id}:task-definition/logging-api-scheduled-task-staging:*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iam:PassRole",
-      "Resource": [
-        "*"
-      ],
-      "Condition": {
-        "StringLike": {
-          "iam:PassedToService": "ecs-tasks.amazonaws.com"
-        }
-      }
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "staging_safe_restart_scheduled_task_role_staging_safe_restart_scheduled_task_policy" {
-  name = "staging-safe-restart-scheduled-task-policy"
-  role = "staging-safe-restart-scheduled-task-role"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "ecs:RunTask",
-      "Resource": "arn:aws:ecs:eu-west-2:${var.aws-account-id}:task-definition/safe-restart-task-staging:*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iam:PassRole",
-      "Resource": [
-        "*"
-      ],
-      "Condition": {
-        "StringLike": {
-          "iam:PassedToService": "ecs-tasks.amazonaws.com"
-        }
-      }
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "staging_safe_restart_task_role_staging_safe_restart_task_policy" {
-  name = "staging-safe-restart-task-policy"
-  role = "staging-safe-restart-task-role"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ecs:ListClusters",
-        "ecs:ListTasks",
-        "ecs:StopTask",
-        "route53:ListHealthChecks",
-        "route53:GetHealthCheckStatus"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "staging_user_signup_api_task_role_staging_user_signup_api_task_policy" {
-  name = "staging-user-signup-api-task-policy"
-  role = "staging-user-signup-api-task-role"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Resource": "arn:aws:s3:::staging-emailbucket/*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::govwifi-staging-admin/signup-whitelist.conf"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Resource": "arn:aws:s3:::govwifi-staging-metrics-bucket/*"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "staging_user_signup_scheduled_task_role_staging_user_signup_scheduled_task_policy" {
-  name = "staging-user-signup-scheduled-task-policy"
-  role = "staging-user-signup-scheduled-task-role"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "ecs:RunTask",
-      "Resource": "arn:aws:ecs:eu-west-2:${var.aws-account-id}:task-definition/user-signup-api-scheduled-task-staging:*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iam:PassRole",
-      "Resource": [
-        "*"
-      ],
-      "Condition": {
-        "StringLike": {
-          "iam:PassedToService": "ecs-tasks.amazonaws.com"
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
### What
Remove Old Staging IAM Resources from govwifi-account module.

### Why
IAM resources related to the API and Backend modules in the old staging
environment are no longer needed.

Link to Trello card (if applicable): https://trello.com/c/0PuXy2Ov/1630-destroy-staging-components-in-the-primary-account
