### PR TITLE
Make data export bucket publicly accessible [wait for Cyber 👍 before merging]

### DIFF
--- a/govwifi-dashboard/s3.tf
+++ b/govwifi-dashboard/s3.tf
@@ -25,3 +25,18 @@ resource "aws_s3_bucket" "export_data_bucket" {
     enabled = false
   }
 }
+
+resource "aws_s3_bucket_policy" "export_data_bucket" {
+  bucket = aws_s3_bucket.export_data_bucket.id
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression's result to valid JSON syntax.
+  policy = jsonencode(
+    {
+      "Sid" : "AllowPublicAccessToExportDataBucket",
+      "Effect" : "Allow",
+      "Principal" : "*",
+      "Action" : "s3:GetObject",
+      "Resource" : "${aws_s3_bucket.export_data_bucket.arn}/*"
+  })
+}


### PR DESCRIPTION
### What
make govwifi-<environment>-export-data-bucket buckets publicly readable

### Why
Our performance metric data needs to be made public through data.gov.uk
which means that the S3 bucket containing our data must be made
publicly readable.

Link to Trello card (if applicable): https://trello.com/c/7XXcjgKz/1645-write-aws-lambda-to-create-metrics-file-in-s3
