### PR TITLE
Allow logging_api_task_policy ecs task to write to export-data-bucket

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -237,6 +237,8 @@ resource "aws_iam_role_policy" "logging_api_task_policy" {
       "Resource": [
         "arn:aws:s3:::${var.metrics-bucket-name}",
         "arn:aws:s3:::${var.metrics-bucket-name}/*"
+        "arn:aws:s3:::${var.export-data-bucket-name}",
+        "arn:aws:s3:::${var.export-data-bucket-name}/*"
       ]
     }
   ]


### PR DESCRIPTION
### What
Allow logging_api_task_policy ecs task to write to export-data-bucket S3 bucket

### Why
The scheduled sync_s3_to_data_bucket task requires write access to the export-data-bucket S3 bucket
