### PR TITLE
Handle no encrypted secrets in unencrypt-secrets.sh

### DIFF
--- a/scripts/unencrypt-secrets.sh
+++ b/scripts/unencrypt-secrets.sh
@@ -9,7 +9,10 @@ command="$1"
 
 # Find all file paths of .gpg files in the .private/passwords/secrets-to-copy directory
 # Exclude any filename secrets*.gpg since the values have been migrated to Secrets Manager
-files=$(find .private/passwords/secrets-to-copy -type f -name '*.gpg' ! -name '*secrets*.gpg')
+files=""
+if [ -d ".private/passwords/secrets-to-copy" ]; then
+    files=$(find .private/passwords/secrets-to-copy -type f -name '*.gpg' ! -name '*secrets*.gpg')
+fi
 
 # Iterate over the all the .gpg files in .private/passwords/secrets-to-copy
 for FILE in $files; do


### PR DESCRIPTION
### What
Handle no encrypted secrets in unencrypt-secrets.sh. This script actually handles encrypted and non-encrypted secrets. I believe that there's no longer a need for the encrypted secrets, so I'm looking to move/remove them in govwifi-build. 

### Why
To avoid breaking this script when this happens, cope with the .private/passwords/secrets-to-copy directory not existing.

Link to Trello card: https://trello.com/c/kzBw3DOt/1782-cleanup-last-encrypted-secrets
