### PR TITLE
Rename some locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Terraform's formatting tool takes care of much of the style, but there are some 
 
 #### Naming
 
-When naming resources, data sources, variables and outputs, only use underscores to separate words. For example:
+When naming resources, data sources, variables, locals and outputs, only use underscores to separate words. For example:
 
 ```terraform
 resource "aws_iam_user_policy" "backup_s3_read_buckets" {

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -66,10 +66,10 @@ data "template_file" "grafana_user_data" {
 
   vars = {
     grafana-log-group       = "${var.env_name}-grafana-log-group"
-    grafana_admin           = local.grafana-admin
-    google_client_secret    = local.google-client-secret
-    google_client_id        = local.google-client-id
-    grafana_server_root_url = local.grafana-server-root-url
+    grafana_admin           = local.grafana_admin
+    google_client_secret    = local.google_client_secret
+    google_client_id        = local.google_client_id
+    grafana_server_root_url = local.grafana_server_root_url
     grafana_device_name     = var.grafana_device_name
     grafana_docker_version  = var.grafana_docker_version
   }

--- a/govwifi-grafana/locals.tf
+++ b/govwifi-grafana/locals.tf
@@ -1,15 +1,15 @@
 locals {
-  grafana-admin = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["admin-pass"]
+  grafana_admin = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["admin-pass"]
 }
 
 locals {
-  grafana-server-root-url = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["url"]
+  grafana_server_root_url = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["url"]
 }
 
 locals {
-  google-client-id = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["id"]
+  google_client_id = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["id"]
 }
 
 locals {
-  google-client-secret = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["secret"]
+  google_client_secret = jsondecode(data.aws_secretsmanager_secret_version.grafana_credentials.secret_string)["secret"]
 }

--- a/govwifi-slack-alerts/locals.tf
+++ b/govwifi-slack-alerts/locals.tf
@@ -1,7 +1,7 @@
 locals {
-  slack-workplace-id = jsondecode(data.aws_secretsmanager_secret_version.slack_credentials.secret_string)["workspace-id"]
+  slack_workplace_id = jsondecode(data.aws_secretsmanager_secret_version.slack_credentials.secret_string)["workspace-id"]
 }
 
 locals {
-  slack-channel-id = jsondecode(data.aws_secretsmanager_secret_version.slack_credentials.secret_string)["channel-id"]
+  slack_channel_id = jsondecode(data.aws_secretsmanager_secret_version.slack_credentials.secret_string)["channel-id"]
 }

--- a/govwifi-slack-alerts/main.tf
+++ b/govwifi-slack-alerts/main.tf
@@ -39,8 +39,8 @@ resource "aws_cloudformation_stack" "aws_slack_chatbot" {
           "ConfigurationName" : "govwifi-monitoring-chat-configuration",
           "IamRoleArn" : "${aws_iam_role.govwifi_wifi_london_aws_chatbot_role.arn}",
           "LoggingLevel" : "NONE",
-          "SlackChannelId" : "${local.slack-channel-id}",
-          "SlackWorkspaceId" : "${local.slack-workplace-id}",
+          "SlackChannelId" : "${local.slack_channel_id}",
+          "SlackWorkspaceId" : "${local.slack_workplace_id}",
           "SnsTopicArns" : [ "${var.critical_notifications_topic_arn}","${var.capacity_notifications_topic_arn}","${var.route53_critical_notifications_topic_arn}" ]
         }
       }

--- a/sns-notification/locals.tf
+++ b/sns-notification/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  enable-emails = length(var.emails) > 0 ? 1 : 0
+  enable_emails = length(var.emails) > 0 ? 1 : 0
 }
 

--- a/sns-notification/main.tf
+++ b/sns-notification/main.tf
@@ -36,7 +36,7 @@ STACK
 }
 
 resource "aws_cloudformation_stack" "email" {
-  count = local.enable-emails
+  count = local.enable_emails
   name  = "${var.topic_name}-subscriptions"
 
   template_body = <<-STACK


### PR DESCRIPTION
### What
Use underscores for locals names, and amend the README.md to mention this when talking about underscores.

### Why
This is more consistent with Terraform itself, and something that the tflint naming plugin checks.


Link to Trello card: https://trello.com/c/XuYh7Hg9/1784-use-underscores-for-locals-names-in-govwifi-terraform