### PR TITLE
Staging cleanup

### DIFF
--- a/govwifi-emails/s3sns.tf
+++ b/govwifi-emails/s3sns.tf
@@ -1,6 +1,6 @@
 # S3 bucket to store the emails
 resource "aws_s3_bucket" "emailbucket" {
-  bucket        = "${var.env_name}-emailbucket"
+  bucket        = var.is_production_aws_account ? "${var.env_name}-emailbucket" : "${var.env_subdomain}-emailbucket"
   force_destroy = true
 
   policy = <<EOF
@@ -13,7 +13,7 @@ resource "aws_s3_bucket" "emailbucket" {
           "Service": "ses.amazonaws.com"
         },
         "Action": "s3:PutObject",
-        "Resource": "arn:aws:s3:::${var.env_name}-emailbucket/*",
+        "Resource": "arn:aws:s3:::${var.is_production_aws_account ? var.env_name : var.env_subdomain}-emailbucket/*",
         "Condition": {
           "StringEquals": {
             "aws:Referer": "${var.aws_account_id}"
@@ -26,14 +26,14 @@ resource "aws_s3_bucket" "emailbucket" {
                 "Service": "s3.amazonaws.com"
             },
             "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::${var.env_name}-emailbucket/*",
+            "Resource": "arn:aws:s3:::${var.is_production_aws_account ? var.env_name : var.env_subdomain}-emailbucket/*",
             "Condition": {
                 "StringEquals": {
                     "aws:SourceAccount": "${var.aws_account_id}",
                     "s3:x-amz-acl": "bucket-owner-full-control"
                 },
                 "ArnLike": {
-                    "aws:SourceArn": "arn:aws:s3:::${var.env_name}-emailbucket"
+                    "aws:SourceArn": "arn:aws:s3:::${var.is_production_aws_account ? var.env_name : var.env_subdomain}-emailbucket"
                 }
             }
     }]


### PR DESCRIPTION
### What
Remove conditional from govwifi-keys module, this is no longer needed.
Update email bucket name to use subdomain in new environments.
Update bucket name to be dynamic rather than hardcoded

### Why
Describe why the change was necessary
AWS requires the bucket name to be unique. Using the subdomain instead of the
environment name ensures this always happens.

Link to Trello card (if applicable): 
https://trello.com/c/LZDJ09Om/1776-update-references-to-staging-temp
