### PR TITLE
Tweak logging api resources

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -24,6 +24,7 @@ resource "aws_ecs_task_definition" "logging_api_task" {
 [
     {
       "volumesFrom": [],
+      "cpu": 0,
       "memory": 512,
       "extraHosts": null,
       "dnsServers": null,
@@ -108,7 +109,6 @@ resource "aws_ecs_task_definition" "logging_api_task" {
           "awslogs-stream-prefix": "${var.env_name}-logging-api-docker-logs"
         }
       },
-      "cpu": 0,
       "privileged": null,
       "expanded": true
     }

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -16,16 +16,16 @@ resource "aws_ecs_task_definition" "logging_api_task" {
   task_role_arn            = aws_iam_role.logging_api_task_role[0].arn
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
-  memory                   = 512
-  cpu                      = "256"
+  memory                   = 1024
+  cpu                      = "512"
   network_mode             = "awsvpc"
 
   container_definitions = <<EOF
 [
     {
       "volumesFrom": [],
-      "cpu": 0,
-      "memory": 512,
+      "cpu": 512,
+      "memory": 1024,
       "extraHosts": null,
       "dnsServers": null,
       "disableNetworking": null,


### PR DESCRIPTION
### What
Increase the CPU to 512 (1/2 a vCPU) and increase the memory
accordingly to the lowest possible value (1024).

### Why
The intent here is to increase the CPU resource available, in the hope
that this makes the service more stable and scalable.

Link to Trello card: https://trello.com/c/uIz8eiyU/1788-give-the-logging-api-tasks-more-cpu-resources-at-least-of-a-vcpu