### PR TITLE
Remove references to "temp" in staging

### DIFF
--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -307,7 +307,7 @@ module "notifications" {
 
   source = "../../sns-notification"
 
-  topic_name = "govwifi-staging-temp"
+  topic_name = "govwifi-staging"
   emails     = [var.notification_email]
 }
 
@@ -318,6 +318,6 @@ module "route53-notifications" {
 
   source = "../../sns-notification"
 
-  topic_name = "govwifi-staging-dublin-temp"
+  topic_name = "govwifi-staging-dublin"
   emails     = [var.notification_email]
 }

--- a/govwifi/staging-dublin-temp/variables.tf
+++ b/govwifi/staging-dublin-temp/variables.tf
@@ -1,6 +1,6 @@
 variable "env_name" {
   type    = string
-  default = "staging-temp"
+  default = "staging"
 }
 
 variable "product_name" {
@@ -10,7 +10,7 @@ variable "product_name" {
 
 variable "env_subdomain" {
   type        = string
-  default     = "staging-temp.wifi"
+  default     = "staging.wifi"
   description = "Environment-specific subdomain to use under the service domain."
 }
 
@@ -62,19 +62,19 @@ variable "ami" {
 variable "london_api_base_url" {
   type        = string
   description = "Base URL for authentication, user signup and logging APIs"
-  default     = "https://api-elb.london.staging-temp.wifi.service.gov.uk:8443"
+  default     = "https://api-elb.london.staging.wifi.service.gov.uk:8443"
 }
 
 variable "dublin_api_base_url" {
   type        = string
   description = "Base URL for authentication, user signup and logging APIs"
-  default     = "https://api-elb.dublin.staging-temp.wifi.service.gov.uk:8443"
+  default     = "https://api-elb.dublin.staging.wifi.service.gov.uk:8443"
 }
 
 variable "user_rr_hostname" {
   type        = string
   description = "User details read replica hostname"
-  default     = "users-rr.dublin.staging-temp.wifi.service.gov.uk"
+  default     = "users-rr.dublin.staging.wifi.service.gov.uk"
 }
 
 variable "auth_sentry_dsn" {

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -229,7 +229,7 @@ module "govwifi_admin" {
   db_backup_window         = "03:42-04:42"
   db_monitoring_interval   = 60
 
-  rr_db_host = "db.london.staging-temp.wifi.service.gov.uk"
+  rr_db_host = "db.london.staging.wifi.service.gov.uk"
   rr_db_name = "govwifi_staging"
 
   user_db_host = var.user_db_hostname
@@ -329,7 +329,7 @@ module "notifications" {
 
   source = "../../sns-notification"
 
-  topic_name = "govwifi-staging-temp"
+  topic_name = "govwifi-staging"
   emails     = [var.notification_email]
 }
 
@@ -340,7 +340,7 @@ module "route53-notifications" {
 
   source = "../../sns-notification"
 
-  topic_name = "govwifi-staging-london-temp"
+  topic_name = "govwifi-staging-london"
   emails     = [var.notification_email]
 }
 

--- a/govwifi/staging-london-temp/variables.tf
+++ b/govwifi/staging-london-temp/variables.tf
@@ -1,6 +1,6 @@
 variable "env_name" {
   type    = string
-  default = "staging-temp"
+  default = "staging"
 }
 
 variable "product_name" {
@@ -10,7 +10,7 @@ variable "product_name" {
 
 variable "env_subdomain" {
   type        = string
-  default     = "staging-temp.wifi"
+  default     = "staging.wifi"
   description = "Environment-specific subdomain to use under the service domain."
 }
 
@@ -88,13 +88,13 @@ variable "admin_sentry_dsn" {
 variable "user_db_hostname" {
   type        = string
   description = "User details database hostname"
-  default     = "users-db.london.staging-temp.wifi.service.gov.uk"
+  default     = "users-db.london.staging.wifi.service.gov.uk"
 }
 
 variable "user_rr_hostname" {
   type        = string
   description = "User details read replica hostname"
-  default     = "users-rr.london.staging-temp.wifi.service.gov.uk"
+  default     = "users-rr.london.staging.wifi.service.gov.uk"
 }
 
 variable "zendesk_api_user" {
@@ -115,7 +115,7 @@ variable "dublin_radius_ip_addresses" {
 variable "london_api_base_url" {
   type        = string
   description = "Base URL for authentication, user signup and logging APIs"
-  default     = "https://api-elb.london.staging-temp.wifi.service.gov.uk:8443"
+  default     = "https://api-elb.london.staging.wifi.service.gov.uk:8443"
 }
 
 variable "notification_email" {


### PR DESCRIPTION
### What
Update staging main.tf and variables.tf files to remove references to temp
Leave the key and directory names as they are for
now, they will be changed in a later commit to avoid breaking things.

### Why
The "temp" suffix was a useful distinguisher when we had two staging environments, it is now no longer necessary.

Link to Trello card (if applicable): https://trello.com/c/LZDJ09Om/1776-update-references-to-staging-temp
