### PR TITLE
Manage the composite alarms with terraform

### DIFF
--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -87,6 +87,10 @@ variable "us_east_1_critical_notifications_arn" {
   type = string
 }
 
+variable "us_east_1_pagerduty_notifications_arn" {
+  type = string
+}
+
 variable "admin_app_data_s3_bucket_name" {
   type = string
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -198,8 +198,9 @@ module "frontend" {
   logging_api_base_url = var.london_api_base_url
   auth_api_base_url    = var.london_api_base_url
 
-  critical_notifications_arn           = module.critical-notifications.topic_arn
-  us_east_1_critical_notifications_arn = module.route53-critical-notifications.topic_arn
+  critical_notifications_arn            = module.critical-notifications.topic_arn
+  us_east_1_critical_notifications_arn  = module.route53-critical-notifications.topic_arn
+  us_east_1_pagerduty_notifications_arn = module.us_east_1_pagerduty.topic_arn
 
   bastion_server_ip = var.bastion_server_ip
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -387,6 +387,16 @@ module "region_pagerduty" {
   sns_topic_subscription_https_endpoint = local.pagerduty_https_endpoint
 }
 
+module "us_east_1_pagerduty" {
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  source = "../../govwifi-pagerduty-integration"
+
+  sns_topic_subscription_https_endpoint = local.pagerduty_https_endpoint
+}
+
 module "govwifi_dashboard" {
   providers = {
     aws = aws.main

--- a/govwifi/wifi-london/outputs.tf
+++ b/govwifi/wifi-london/outputs.tf
@@ -1,3 +1,7 @@
 output "admin_app_data_s3_bucket_name" {
   value = module.govwifi_admin.app_data_s3_bucket_name
 }
+
+output "us_east_1_pagerduty_topic_arn" {
+  value = module.us_east_1_pagerduty_topic_arn
+}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -243,8 +243,9 @@ module "frontend" {
   logging_api_base_url = var.london_api_base_url
   auth_api_base_url    = var.dublin_api_base_url
 
-  critical_notifications_arn           = module.critical-notifications.topic_arn
-  us_east_1_critical_notifications_arn = module.route53-critical-notifications.topic_arn
+  critical_notifications_arn            = module.critical-notifications.topic_arn
+  us_east_1_critical_notifications_arn  = module.route53-critical-notifications.topic_arn
+  us_east_1_pagerduty_notifications_arn = data.terraform_remote_state.london.outputs.us_east_1_pagerduty_topic_arn
 
   bastion_server_ip = var.bastion_server_ip
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -366,18 +366,6 @@ module "region_pagerduty" {
   sns_topic_subscription_https_endpoint = local.pagerduty_https_endpoint
 }
 
-# This is used for the alarms connected to the Route 53 healthchecks
-# in this region
-module "us_east_1_pagerduty" {
-  providers = {
-    aws = aws.us_east_1
-  }
-
-  source = "../../govwifi-pagerduty-integration"
-
-  sns_topic_subscription_https_endpoint = local.pagerduty_https_endpoint
-}
-
 module "govwifi_prometheus" {
   providers = {
     aws = aws.main


### PR DESCRIPTION
### What
Manage the composite alarms with Terraform. Previously the configuration was there, but commented out.

### Why
Having these alarms being manually created risks them changing or disappearing unexpectedly, and can also cause issues when deploying other changes using Terraform.


Link to Trello card: https://trello.com/c/RmuNbaKm/1789-manage-the-composite-alarms-with-terraform