### PR TITLE
Try using the aws region datasource

### DIFF
--- a/govwifi-prometheus/data.tf
+++ b/govwifi-prometheus/data.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/govwifi-prometheus/iam-roles.tf
+++ b/govwifi-prometheus/iam-roles.tf
@@ -1,10 +1,10 @@
 resource "aws_iam_instance_profile" "prometheus_instance_profile" {
-  name = "${var.aws_region}-${var.env_name}-prometheus-instance-profile"
+  name = "${data.aws_region.current.name}-${var.env_name}-prometheus-instance-profile"
   role = aws_iam_role.prometheus_instance_role.name
 }
 
 resource "aws_iam_role" "prometheus_instance_role" {
-  name = "${var.aws_region}-${var.env_name}-prometheus-instance-role"
+  name = "${data.aws_region.current.name}-${var.env_name}-prometheus-instance-role"
   path = "/"
 
   assume_role_policy = <<EOF
@@ -26,7 +26,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "prometheus_instance_policy" {
-  name = "${var.aws_region}-${var.env_name}-prometheus-instance-policy"
+  name = "${data.aws_region.current.name}-${var.env_name}-prometheus-instance-policy"
   role = aws_iam_role.prometheus_instance_role.id
 
   policy = <<EOF

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -78,7 +78,7 @@ resource "aws_instance" "prometheus_instance" {
 resource "aws_ebs_volume" "prometheus_ebs" {
   size              = 40
   encrypted         = true
-  availability_zone = "${var.aws_region}a"
+  availability_zone = aws_instance.prometheus_instance.availability_zone
 
   tags = {
     Name = "${var.env_name} Prometheus volume"

--- a/govwifi-prometheus/variables.tf
+++ b/govwifi-prometheus/variables.tf
@@ -1,9 +1,6 @@
 variable "env_name" {
 }
 
-variable "aws_region" {
-}
-
 variable "prometheus_volume_size" {
   default = "40"
 }

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -366,9 +366,8 @@ module "govwifi_prometheus" {
     aws = aws.main
   }
 
-  source     = "../../govwifi-prometheus"
-  env_name   = var.env_name
-  aws_region = var.aws_region
+  source   = "../../govwifi-prometheus"
+  env_name = var.env_name
 
   ssh_key_name = var.ssh_key_name
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -407,9 +407,8 @@ module "govwifi_prometheus" {
     aws = aws.main
   }
 
-  source     = "../../govwifi-prometheus"
-  env_name   = var.env_name
-  aws_region = var.aws_region
+  source   = "../../govwifi-prometheus"
+  env_name = var.env_name
 
   ssh_key_name = var.ssh_key_name
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -383,9 +383,8 @@ module "govwifi_prometheus" {
     aws = aws.main
   }
 
-  source     = "../../govwifi-prometheus"
-  env_name   = var.env_name
-  aws_region = var.aws_region
+  source   = "../../govwifi-prometheus"
+  env_name = var.env_name
 
   ssh_key_name = var.ssh_key_name
 


### PR DESCRIPTION
### What
Remove the aws_region variable from the govwifi-prometheus module, and make the required changes to allow this.

### Why
I think that in most cases, passing round the AWS region as a variable is bad practice. It probably should be looked up from the provider instead (which is often simpler and provides more of a guarantee that it's correct), or the region should not be used at all (because it's being used as part of working around some other bad thing, like duplicating IAM resources in every region). 


Link to Trello card: https://trello.com/c/AiWK7pke/1790-try-using-the-aws-region-datasource-in-govwifi-terraform