### PR TITLE
Redirect HTTP to HTTPS for the admin site

### DIFF
--- a/govwifi-admin/loadbalancer.tf
+++ b/govwifi-admin/loadbalancer.tf
@@ -28,3 +28,18 @@ resource "aws_alb_listener" "alb_listener" {
   }
 }
 
+resource "aws_alb_listener" "http" {
+  load_balancer_arn = aws_lb.admin_alb.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}

--- a/govwifi-admin/security_groups.tf
+++ b/govwifi-admin/security_groups.tf
@@ -13,6 +13,13 @@ resource "aws_security_group" "admin_alb_in" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 resource "aws_security_group" "admin_alb_out" {


### PR DESCRIPTION
### What
Redirect HTTP to HTTPS for the admin site

I noticed this wasn't a feature when looking at why the smoke tests
were failing on staging. The smoke tests first try to access the admin
site over http, and this was failing as you'd expect given the load
balancer doesn't listen on port 80.

### Why
I've got no idea why the smoke tests were passing in production, but I
think it's worthwhile to support redirecting from HTTP to HTTPS both
for the smoke tests and for any users accessing the admin site first
over HTTP.


Link to Trello card: https://trello.com/c/t4cZcYfr/1807-investigate-why-staging-smoke-tests-are-failing