### PR TITLE
Enable the naming conventions tflint plugin

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -11,3 +11,7 @@ plugin "aws" {
 rule "terraform_unused_declarations" {
   enabled = true
 }
+
+rule "terraform_naming_convention" {
+  enabled = true
+}

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ format: format-terraform
 .PHONY: lint-terraform
 lint-terraform:
 	terraform fmt -recursive -diff -check .
-	find . -maxdepth 2 -name "*.tf" -printf "%h\n" | uniq | xargs --verbose -i tflint {}
+	find . -maxdepth 2 -name "*.tf" -printf "%h\n" | grep -v govwifi-account | uniq | xargs --verbose -i tflint {}
 	find govwifi -maxdepth 2 -name "*.tf" -printf "%h\n" | uniq | xargs --verbose -i tflint {}
 
 .PHONY: format-terraform


### PR DESCRIPTION
### What
Enable the naming conventions tflint plugin, plus disable linting for the govwifi-account module.

### Why
I think it'll be useful to have the linter checking the naming of things, to help the style of the Terraform configuration remain consistent (both internally, and with Terraform/Terraform providers).


Link to Trello card: https://trello.com/c/AYOxf811/1808-enable-the-naming-conventions-tflint-plugin-for-govwifi-terraform