### PR TITLE
Set health_check_grace_period_seconds for API ECS services

### DIFF
--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -100,6 +100,8 @@ resource "aws_ecs_service" "authorisation_api_service" {
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
 
+  health_check_grace_period_seconds = 20
+
   network_configuration {
     security_groups = concat(
       var.backend_sg_list,

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -126,6 +126,8 @@ resource "aws_ecs_service" "logging_api_service" {
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
 
+  health_check_grace_period_seconds = 20
+
   network_configuration {
     security_groups = concat(
       var.backend_sg_list,

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -183,6 +183,8 @@ resource "aws_ecs_service" "user_signup_api_service" {
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
 
+  health_check_grace_period_seconds = 20
+
   network_configuration {
     security_groups = concat(
       var.backend_sg_list,


### PR DESCRIPTION
### What
Set health_check_grace_period_seconds for API ECS services

### Why
I was looking at this when there were issues in Production for the
Logging and Authorisation APIs, tasks kept coming and going, and I
think the lack of a grace period for the health check may have led to
this behaviour.

The value of 20 seconds is just an initial guess.


Link to Trello card: https://trello.com/c/qY5EUtU9/1822-set-a-health-check-grace-period-for-the-api-services