### PR TITLE
Tighten up the health checks for the API service ALBs

### DIFF
--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -148,9 +148,9 @@ resource "aws_alb_target_group" "alb_target_group" {
   }
 
   health_check {
-    healthy_threshold   = 3
-    unhealthy_threshold = 10
-    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 4
     interval            = 10
     path                = "/authorize/user/HEALTH"
   }

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -162,9 +162,9 @@ resource "aws_alb_target_group" "logging_api_tg" {
   }
 
   health_check {
-    healthy_threshold   = 3
-    unhealthy_threshold = 10
-    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 4
     interval            = 10
     path                = "/healthcheck"
   }

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -215,9 +215,9 @@ resource "aws_alb_target_group" "user_signup_api_tg" {
   }
 
   health_check {
-    healthy_threshold   = 3
-    unhealthy_threshold = 10
-    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 4
     interval            = 10
     path                = "/healthcheck"
   }


### PR DESCRIPTION
### What
Tighten up the health checks for the API service ALBs

### Why
Having a ALB instance wait for 10 consecutive failures at intervals of
10 seconds is far too long, that would mean that a target would still
be used for up to 100 seconds after it started timing out.

I think 2 consecutive failures is a much better value, as that should
result in unhealthy targets being removed faster. Decrease the timeout
as well, 4 seconds is probably still too high, but I just wanted to
decrease it a bit.


Link to Trello card: https://trello.com/c/5ZDLJmvE/1823-tighten-up-the-timeouts-for-the-api-services