### PR TITLE
Add Pipeline related IAM Resources To New Staging

### DIFF
--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -120,7 +120,7 @@ variable "ecr_repository_count" {
 }
 
 variable "wordlist_bucket_count" {
-  default     = 0
+  default     = false
   description = "Whether or not to create wordlist bucket"
 }
 

--- a/govwifi-api/wordlist.tf
+++ b/govwifi-api/wordlist.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "wordlist" {
   bucket = var.is_production_aws_account ? "govwifi-wordlist" : "govwifi-${var.env_name}-wordlist"
-  count  = var.wordlist_bucket_count
+  count  = var.wordlist_bucket_count ? 1 : 0
   acl    = "private"
 
   tags = {
@@ -14,7 +14,7 @@ resource "aws_s3_bucket" "wordlist" {
 
 resource "aws_s3_bucket_object" "wordlist" {
   bucket = aws_s3_bucket.wordlist[0].bucket
-  count  = var.wordlist_bucket_count
+  count  = var.wordlist_bucket_count ? 1 : 0
   key    = "wordlist-short"
   source = var.wordlist_file_path
   etag   = filemd5(var.wordlist_file_path)

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -286,7 +286,7 @@ module "api" {
   safe_restart_docker_image     = format("%s/safe-restarter:staging", local.docker_image_path)
   backup_rds_to_s3_docker_image = format("%s/database-backup:staging", local.docker_image_path)
 
-  wordlist_bucket_count = 1
+  wordlist_bucket_count = true
   wordlist_file_path    = "../wordlist-short"
   ecr_repository_count  = 1
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -297,7 +297,7 @@ module "api" {
   safe_restart_docker_image     = format("%s/safe-restarter:production", local.docker_image_path)
   backup_rds_to_s3_docker_image = format("%s/database-backup:production", local.docker_image_path)
 
-  wordlist_bucket_count = 1
+  wordlist_bucket_count = true
   wordlist_file_path    = "../wordlist-short"
   ecr_repository_count  = 1
 


### PR DESCRIPTION
### What
These IAM resources had been created manually in the new staging environment.
This commit adds them to terraform. This is also the first stage of migrating
all IAM resources out of the govwifi-account module and including them in their
related modules (e.g. govwifi-backend). These resources have been added with a
conditional so they are only created by the govwifi-api module in staging (this
avoids duplication in production).

### Why
All resources should be in terraform.


