### PR TITLE
Cleanup: Remove `use_env_prefix` conditional

### DIFF
--- a/govwifi-admin/secrets-manager.tf
+++ b/govwifi-admin/secrets-manager.tf
@@ -3,7 +3,7 @@ data "aws_secretsmanager_secret_version" "notify_api_key" {
 }
 
 data "aws_secretsmanager_secret" "notify_api_key" {
-  name = var.use_env_prefix ? "staging/admin-api/notify-api-key" : "admin-api/notify-api-key"
+  name = "admin-api/notify-api-key"
 }
 
 data "aws_secretsmanager_secret_version" "zendesk_api_token" {
@@ -11,7 +11,7 @@ data "aws_secretsmanager_secret_version" "zendesk_api_token" {
 }
 
 data "aws_secretsmanager_secret" "zendesk_api_token" {
-  name = var.use_env_prefix ? "staging/admin-api/zendesk-api-token" : "admin-api/zendesk-api-token"
+  name = "admin-api/zendesk-api-token"
 }
 
 data "aws_secretsmanager_secret_version" "key_base" {
@@ -19,7 +19,7 @@ data "aws_secretsmanager_secret_version" "key_base" {
 }
 
 data "aws_secretsmanager_secret" "key_base" {
-  name = var.use_env_prefix ? "staging/admin-api/secret-key-base" : "admin-api/secret-key-base"
+  name = "admin-api/secret-key-base"
 }
 
 data "aws_secretsmanager_secret_version" "otp_encryption_key" {
@@ -27,7 +27,7 @@ data "aws_secretsmanager_secret_version" "otp_encryption_key" {
 }
 
 data "aws_secretsmanager_secret" "otp_encryption_key" {
-  name = var.use_env_prefix ? "staging/admin-api/otp-secret-encryption-key" : "admin-api/otp-secret-encryption-key"
+  name = "admin-api/otp-secret-encryption-key"
 }
 
 data "aws_secretsmanager_secret_version" "session_db" {
@@ -35,7 +35,7 @@ data "aws_secretsmanager_secret_version" "session_db" {
 }
 
 data "aws_secretsmanager_secret" "session_db" {
-  name = var.use_env_prefix ? "staging/rds/session-db/credentials" : "rds/session-db/credentials"
+  name = "rds/session-db/credentials"
 }
 
 data "aws_secretsmanager_secret_version" "users_db" {
@@ -43,7 +43,7 @@ data "aws_secretsmanager_secret_version" "users_db" {
 }
 
 data "aws_secretsmanager_secret" "users_db" {
-  name = var.use_env_prefix ? "staging/rds/users-db/credentials" : "rds/users-db/credentials"
+  name = "rds/users-db/credentials"
 }
 
 data "aws_secretsmanager_secret_version" "admin_db" {
@@ -51,7 +51,7 @@ data "aws_secretsmanager_secret_version" "admin_db" {
 }
 
 data "aws_secretsmanager_secret" "admin_db" {
-  name = var.use_env_prefix ? "staging/rds/admin-db/credentials" : "rds/admin-db/credentials"
+  name = "rds/admin-db/credentials"
 }
 
 data "aws_secretsmanager_secret_version" "google_service_account_backup_credentials" {
@@ -61,4 +61,3 @@ data "aws_secretsmanager_secret_version" "google_service_account_backup_credenti
 data "aws_secretsmanager_secret" "google_service_account_backup_credentials" {
   name = "admin/google-service-account-backup-credentials"
 }
-

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -117,8 +117,5 @@ variable "public_google_api_key" {
 variable "bastion_server_ip" {
 }
 
-variable "use_env_prefix" {
-}
-
 variable "is_production_aws_account" {
 }

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -3,7 +3,7 @@ data "aws_secretsmanager_secret_version" "session_db" {
 }
 
 data "aws_secretsmanager_secret" "session_db" {
-  name = var.use_env_prefix ? "staging/rds/session-db/credentials" : "rds/session-db/credentials"
+  name = "rds/session-db/credentials"
 }
 
 data "aws_secretsmanager_secret_version" "users_db" {
@@ -11,7 +11,7 @@ data "aws_secretsmanager_secret_version" "users_db" {
 }
 
 data "aws_secretsmanager_secret" "users_db" {
-  name = var.use_env_prefix ? "staging/rds/users-db/credentials" : "rds/users-db/credentials"
+  name = "rds/users-db/credentials"
 }
 
 data "aws_secretsmanager_secret_version" "volumetrics_elasticsearch_endpoint" {
@@ -19,7 +19,7 @@ data "aws_secretsmanager_secret_version" "volumetrics_elasticsearch_endpoint" {
 }
 
 data "aws_secretsmanager_secret" "volumetrics_elasticsearch_endpoint" {
-  name = var.use_env_prefix ? "staging/logging-api/volumetrics-elasticsearch-endpoint" : "logging-api/volumetrics-elasticsearch-endpoint"
+  name = "logging-api/volumetrics-elasticsearch-endpoint"
 }
 
 data "aws_secretsmanager_secret_version" "notify_api_key" {
@@ -27,7 +27,7 @@ data "aws_secretsmanager_secret_version" "notify_api_key" {
 }
 
 data "aws_secretsmanager_secret" "notify_api_key" {
-  name = var.use_env_prefix ? "staging/admin-api/notify-api-key" : "admin-api/notify-api-key"
+  name = "admin-api/notify-api-key"
 }
 
 data "aws_secretsmanager_secret_version" "notify_bearer_token" {
@@ -35,7 +35,7 @@ data "aws_secretsmanager_secret_version" "notify_bearer_token" {
 }
 
 data "aws_secretsmanager_secret" "notify_bearer_token" {
-  name = var.use_env_prefix ? "staging/user-signup-api/notify-bearer-token" : "user-signup-api/notify-bearer-token"
+  name = "user-signup-api/notify-bearer-token"
 }
 
 data "aws_secretsmanager_secret_version" "admin_db" {
@@ -43,7 +43,7 @@ data "aws_secretsmanager_secret_version" "admin_db" {
 }
 
 data "aws_secretsmanager_secret" "admin_db" {
-  name = var.use_env_prefix ? "staging/rds/admin-db/credentials" : "rds/admin-db/credentials"
+  name = "rds/admin-db/credentials"
 }
 
 data "aws_secretsmanager_secret_version" "database_s3_encryption" {
@@ -51,5 +51,5 @@ data "aws_secretsmanager_secret_version" "database_s3_encryption" {
 }
 
 data "aws_secretsmanager_secret" "database_s3_encryption" {
-  name = var.use_env_prefix ? "staging/rds/database-s3-encryption" : "rds/database-s3-encryption"
+  name = "rds/database-s3-encryption"
 }

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -159,10 +159,6 @@ variable "export_data_bucket_name" {
   description = "Name of the bucket we use to export data to data.gov.uk"
 }
 
-variable "use_env_prefix" {
-
-}
-
 variable "backup_mysql_rds" {
   description = "Whether or not to create objects to and make backups of MySQL RDS data"
   default     = false

--- a/govwifi-backend/secrets-manager.tf
+++ b/govwifi-backend/secrets-manager.tf
@@ -3,7 +3,7 @@ data "aws_secretsmanager_secret_version" "session_db_credentials" {
 }
 
 data "aws_secretsmanager_secret" "session_db_credentials" {
-  name = var.use_env_prefix ? "staging/rds/session-db/credentials" : "rds/session-db/credentials"
+  name = "rds/session-db/credentials"
 }
 
 data "aws_secretsmanager_secret_version" "users_db_credentials" {
@@ -11,5 +11,5 @@ data "aws_secretsmanager_secret_version" "users_db_credentials" {
 }
 
 data "aws_secretsmanager_secret" "users_db_credentials" {
-  name = var.use_env_prefix ? "staging/rds/users-db/credentials" : "rds/users-db/credentials"
+  name = "rds/users-db/credentials"
 }

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -135,9 +135,6 @@ variable "prometheus_ip_ireland" {
 variable "grafana_ip" {
 }
 
-variable "use_env_prefix" {
-}
-
 variable "backup_mysql_rds" {
   description = "Whether or not to create objects to and make backups of MySQL RDS data"
   default     = false

--- a/govwifi-frontend/secrets-manager.tf
+++ b/govwifi-frontend/secrets-manager.tf
@@ -3,7 +3,7 @@ data "aws_secretsmanager_secret_version" "healthcheck" {
 }
 
 data "aws_secretsmanager_secret" "healthcheck" {
-  name = var.use_env_prefix ? "staging/radius/healthcheck" : "radius/healthcheck"
+  name = "radius/healthcheck"
 }
 
 data "aws_secretsmanager_secret_version" "shared_key" {
@@ -11,5 +11,5 @@ data "aws_secretsmanager_secret_version" "shared_key" {
 }
 
 data "aws_secretsmanager_secret" "shared_key" {
-  name = var.use_env_prefix ? "staging/radius/shared-key" : "radius/shared-key"
+  name = "radius/shared-key"
 }

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -106,8 +106,5 @@ variable "prometheus_ip_london" {
 variable "prometheus_ip_ireland" {
 }
 
-variable "use_env_prefix" {
-}
-
 variable "is_production_aws_account" {
 }

--- a/govwifi-grafana/secrets-manager.tf
+++ b/govwifi-grafana/secrets-manager.tf
@@ -3,5 +3,5 @@ data "aws_secretsmanager_secret_version" "grafana_credentials" {
 }
 
 data "aws_secretsmanager_secret" "grafana_credentials" {
-  name = var.use_env_prefix ? "staging/grafana/credentials" : "grafana/credentials"
+  name = "grafana/credentials"
 }

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -72,8 +72,5 @@ variable "critical_notifications_arn" {
   type        = string
 }
 
-variable "use_env_prefix" {
-}
-
 variable "is_production_aws_account" {
 }

--- a/govwifi/staging-dublin-temp/main.tf
+++ b/govwifi/staging-dublin-temp/main.tf
@@ -132,8 +132,6 @@ module "backend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
   grafana_ip            = var.grafana_ip
 
-  use_env_prefix = var.use_env_prefix
-
   db_storage_alarm_threshold = 19327342936
 }
 
@@ -238,8 +236,6 @@ module "frontend" {
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
 
-  use_env_prefix = var.use_env_prefix
-
 }
 
 module "api" {
@@ -295,8 +291,6 @@ module "api" {
   backend_sg_list = [
     module.backend.be_admin_in,
   ]
-
-  use_env_prefix = var.use_env_prefix
 
   low_cpu_threshold = 0.3
 }

--- a/govwifi/staging-dublin-temp/secrets-manager.tf
+++ b/govwifi/staging-dublin-temp/secrets-manager.tf
@@ -3,7 +3,7 @@ data "aws_secretsmanager_secret_version" "aws_account_id" {
 }
 
 data "aws_secretsmanager_secret" "aws_account_id" {
-  name = var.use_env_prefix ? "staging/aws/account-id" : "aws/account-id"
+  name = "aws/account-id"
 }
 
 data "aws_secretsmanager_secret_version" "docker_image_path" {
@@ -11,7 +11,7 @@ data "aws_secretsmanager_secret_version" "docker_image_path" {
 }
 
 data "aws_secretsmanager_secret" "docker_image_path" {
-  name = var.use_env_prefix ? "staging/aws/ecr/docker-image-path/govwifi" : "aws/ecr/docker-image-path/govwifi"
+  name = "aws/ecr/docker-image-path/govwifi"
 }
 
 data "aws_secretsmanager_secret_version" "route53_zone_id" {
@@ -19,5 +19,5 @@ data "aws_secretsmanager_secret_version" "route53_zone_id" {
 }
 
 data "aws_secretsmanager_secret" "route53_zone_id" {
-  name = var.use_env_prefix ? "staging/aws/route53/zone-id" : "aws/route53/zone-id"
+  name = "aws/route53/zone-id"
 }

--- a/govwifi/staging-dublin-temp/variables.tf
+++ b/govwifi/staging-dublin-temp/variables.tf
@@ -103,12 +103,6 @@ variable "dublin_radius_ip_addresses" {
 variable "grafana_ip" {
 }
 
-variable "use_env_prefix" {
-  default     = false
-  type        = bool
-  description = "Conditional to indicate whether to retrieve a secret with a env prefix in its name. For the secondary account the value can be set to false. The 'staging' prefix is redundant since the secondary account will be used for staging"
-}
-
 variable "is_production_aws_account" {
   description = "Conditional to indicate if the enviroment is production or not."
   default     = false

--- a/govwifi/staging-london-temp/main.tf
+++ b/govwifi/staging-london-temp/main.tf
@@ -129,7 +129,6 @@ module "backend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
   grafana_ip            = var.grafana_ip
 
-  use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
 
   db_storage_alarm_threshold = 19327342936
@@ -195,9 +194,6 @@ module "frontend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-
-  use_env_prefix = var.use_env_prefix
-
 }
 
 module "govwifi_admin" {
@@ -251,8 +247,6 @@ module "govwifi_admin" {
   zendesk_api_user     = var.zendesk_api_user
 
   bastion_server_ip = var.bastion_server_ip
-
-  use_env_prefix = var.use_env_prefix
 
   notification_arn = module.notifications.topic_arn
 }
@@ -315,7 +309,6 @@ module "api" {
   metrics_bucket_name     = module.govwifi_dashboard.metrics_bucket_name
   export_data_bucket_name = module.govwifi_dashboard.export_data_bucket_name
 
-  use_env_prefix          = var.use_env_prefix
   rds_mysql_backup_bucket = module.backend.rds_mysql_backup_bucket
   backup_mysql_rds        = var.backup_mysql_rds
 
@@ -415,7 +408,6 @@ module "govwifi_grafana" {
     var.prometheus_ip_ireland
   ]
 
-  use_env_prefix = var.use_env_prefix
 }
 
 module "govwifi_elasticsearch" {

--- a/govwifi/staging-london-temp/secrets-manager.tf
+++ b/govwifi/staging-london-temp/secrets-manager.tf
@@ -3,7 +3,7 @@ data "aws_secretsmanager_secret_version" "aws_account_id" {
 }
 
 data "aws_secretsmanager_secret" "aws_account_id" {
-  name = var.use_env_prefix ? "staging/aws/account-id" : "aws/account-id"
+  name = "aws/account-id"
 }
 
 data "aws_secretsmanager_secret_version" "docker_image_path" {
@@ -11,7 +11,7 @@ data "aws_secretsmanager_secret_version" "docker_image_path" {
 }
 
 data "aws_secretsmanager_secret" "docker_image_path" {
-  name = var.use_env_prefix ? "staging/aws/ecr/docker-image-path/govwifi" : "aws/ecr/docker-image-path/govwifi"
+  name = "aws/ecr/docker-image-path/govwifi"
 }
 
 data "aws_secretsmanager_secret_version" "route53_zone_id" {
@@ -19,5 +19,5 @@ data "aws_secretsmanager_secret_version" "route53_zone_id" {
 }
 
 data "aws_secretsmanager_secret" "route53_zone_id" {
-  name = var.use_env_prefix ? "staging/aws/route53/zone-id" : "aws/route53/zone-id"
+  name = "aws/route53/zone-id"
 }

--- a/govwifi/staging-london-temp/variables.tf
+++ b/govwifi/staging-london-temp/variables.tf
@@ -130,12 +130,6 @@ variable "prometheus_ip_ireland" {
 variable "grafana_ip" {
 }
 
-variable "use_env_prefix" {
-  default     = false
-  type        = bool
-  description = "Conditional to indicate whether to retrieve a secret with a env prefix in its name. For the secondary account the value can be set to false. The 'staging' prefix is redundant since the secondary account will be used for staging"
-}
-
 variable "backup_mysql_rds" {
   description = "Conditional to indicate whether to make artifacts for and run RDS MySQL backups."
   default     = true

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -142,7 +142,6 @@ module "backend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
   grafana_ip            = var.grafana_ip
 
-  use_env_prefix   = var.use_env_prefix
   backup_mysql_rds = var.backup_mysql_rds
 
   db_storage_alarm_threshold = 32212254720
@@ -208,8 +207,6 @@ module "frontend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-
-  use_env_prefix = var.use_env_prefix
 }
 
 module "govwifi_admin" {
@@ -265,8 +262,6 @@ module "govwifi_admin" {
   zendesk_api_user     = var.zendesk_api_user
 
   bastion_server_ip = var.bastion_server_ip
-
-  use_env_prefix = false
 }
 
 module "api" {
@@ -323,7 +318,6 @@ module "api" {
   metrics_bucket_name     = module.govwifi_dashboard.metrics_bucket_name
   export_data_bucket_name = module.govwifi_dashboard.export_data_bucket_name
 
-  use_env_prefix          = var.use_env_prefix
   backup_mysql_rds        = var.backup_mysql_rds
   rds_mysql_backup_bucket = module.backend.rds_mysql_backup_bucket
 
@@ -468,7 +462,6 @@ module "govwifi_grafana" {
     var.prometheus_ip_ireland
   ]
 
-  use_env_prefix = var.use_env_prefix
 }
 
 module "govwifi_slack_alerts" {

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -139,12 +139,6 @@ variable "prometheus_ip_ireland" {
 variable "grafana_ip" {
 }
 
-variable "use_env_prefix" {
-  default     = false
-  type        = bool
-  description = "Conditional to indicate whether to retrieve a secret with a env prefix in its name."
-}
-
 variable "backup_mysql_rds" {
   description = "Conditional to indicate whether to make artifacts for and run RDS MySQL backups."
   default     = true

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -143,8 +143,6 @@ module "backend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
   grafana_ip            = var.grafana_ip
 
-  use_env_prefix = var.use_env_prefix
-
   db_storage_alarm_threshold = 32212254720
 }
 
@@ -253,8 +251,6 @@ module "frontend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-
-  use_env_prefix = var.use_env_prefix
 }
 
 module "api" {
@@ -307,8 +303,6 @@ module "api" {
   backend_sg_list = [
     module.backend.be_admin_in,
   ]
-
-  use_env_prefix = var.use_env_prefix
 
   low_cpu_threshold = 10
 }

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -107,12 +107,6 @@ variable "prometheus_ip_ireland" {
 variable "grafana_ip" {
 }
 
-variable "use_env_prefix" {
-  default     = false
-  type        = bool
-  description = "Conditional to indicate whether to retrieve a secret with a env prefix in its name."
-}
-
 variable "is_production_aws_account" {
   description = "Conditional to indicate if the enviroment is production or not."
   default     = true


### PR DESCRIPTION
### What
Cleanup: Remove `use_env_prefix` conditional

### Why
The code is no longer necessary since the naming convention between the primary (production) and secondary (staging) AWS accounts are the same. The `use_env_prefix` variable was originally added to distinguish between secrets when our staging and production environments were in the same AWS account (they are now in separate AWS Accounts).

Testing: 
This should produce no changes when terraform plan is run in staging or production.

Trello:
https://trello.com/c/SfNTpuMo/1819-cleanup-remove-useenvprefix-from-terraform
