### PR TITLE
Simplify the handling of the Route53 zones

### DIFF
--- a/govwifi-admin/acm.tf
+++ b/govwifi-admin/acm.tf
@@ -6,7 +6,7 @@ resource "aws_acm_certificate" "admin_cert" {
 resource "aws_route53_record" "admin_cert_validation" {
   name    = one(aws_acm_certificate.admin_cert.domain_validation_options).resource_record_name
   type    = one(aws_acm_certificate.admin_cert.domain_validation_options).resource_record_type
-  zone_id = data.aws_route53_zone.zone.id
+  zone_id = var.route53_zone_id
   records = [one(aws_acm_certificate.admin_cert.domain_validation_options).resource_record_value]
   ttl     = 60
 }

--- a/govwifi-admin/route53.tf
+++ b/govwifi-admin/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "admin" {
-  zone_id = data.aws_route53_zone.zone.id
+  zone_id = var.route53_zone_id
   name    = "admin.${var.env_subdomain}.service.gov.uk"
   type    = "A"
 
@@ -11,14 +11,9 @@ resource "aws_route53_record" "admin" {
 }
 
 resource "aws_route53_record" "www" {
-  zone_id = data.aws_route53_zone.zone.id
+  zone_id = var.route53_zone_id
   name    = "www.${var.env_subdomain}.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
   records = ["d2j0ojhs7n2cwa.cloudfront.net"]
-}
-
-data "aws_route53_zone" "zone" {
-  name         = var.is_production_aws_account ? "wifi.service.gov.uk." : "${var.env_subdomain}.service.gov.uk."
-  private_zone = false
 }

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -36,6 +36,10 @@ variable "vpc_id" {
   description = "VPC ID used for placing the ALB into"
 }
 
+variable "route53_zone_id" {
+  description = "Route53 zone to use for the domain name"
+}
+
 variable "instance_count" {
   description = "Number of EC2 hosts and ECS containers to be running"
 }

--- a/govwifi-grafana/acm.tf
+++ b/govwifi-grafana/acm.tf
@@ -8,7 +8,7 @@ resource "aws_acm_certificate" "grafana_cert" {
 resource "aws_route53_record" "grafana_cert_validation" {
   name    = one(aws_acm_certificate.grafana_cert.domain_validation_options).resource_record_name
   type    = one(aws_acm_certificate.grafana_cert.domain_validation_options).resource_record_type
-  zone_id = data.aws_route53_zone.zone.id
+  zone_id = var.route53_zone_id
 
   records = [one(aws_acm_certificate.grafana_cert.domain_validation_options).resource_record_value]
   ttl     = 60

--- a/govwifi-grafana/route53.tf
+++ b/govwifi-grafana/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "grafana_route53_record" {
-  zone_id = data.aws_route53_zone.zone.id
+  zone_id = var.route53_zone_id
   name    = "grafana.${var.env_subdomain}.service.gov.uk"
   type    = "A"
 
@@ -8,9 +8,4 @@ resource "aws_route53_record" "grafana_route53_record" {
     zone_id                = aws_lb.grafana_alb.zone_id
     evaluate_target_health = true
   }
-}
-
-data "aws_route53_zone" "zone" {
-  name         = var.is_production_aws_account ? "wifi.service.gov.uk." : "${var.env_subdomain}.service.gov.uk."
-  private_zone = false
 }

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -35,6 +35,11 @@ variable "vpc_id" {
   type        = string
 }
 
+variable "route53_zone_id" {
+  description = "ID of the Route53 zone to use"
+  type        = string
+}
+
 variable "bastion_ip" {
   description = "The IP address of the bastion machine."
   type        = string
@@ -70,7 +75,4 @@ variable "grafana_docker_version" {
 variable "critical_notifications_arn" {
   description = "Arn of the critical-nofications sns topic"
   type        = string
-}
-
-variable "is_production_aws_account" {
 }

--- a/govwifi/staging-dublin/data.tf
+++ b/govwifi/staging-dublin/data.tf
@@ -1,0 +1,4 @@
+# TODO This should probably be managed by Terraform at some point
+data "aws_route53_zone" "main" {
+  name = "${var.env_subdomain}.service.gov.uk."
+}

--- a/govwifi/staging-dublin/locals.tf
+++ b/govwifi/staging-dublin/locals.tf
@@ -7,10 +7,6 @@ locals {
 }
 
 locals {
-  route53_zone_id = jsondecode(data.aws_secretsmanager_secret_version.route53_zone_id.secret_string)["route53-zone-id"]
-}
-
-locals {
   frontend_radius_ips = concat(var.london_radius_ip_addresses, var.dublin_radius_ip_addresses)
 }
 

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -71,7 +71,7 @@ module "backend" {
 
   # AWS VPC setup -----------------------------------------
   aws_region      = var.aws_region
-  route53_zone_id = local.route53_zone_id
+  route53_zone_id = data.aws_route53_zone.main.zone_id
   aws_region_name = var.aws_region_name
   vpc_cidr_block  = "10.104.0.0/16"
   zone_count      = var.zone_count
@@ -148,7 +148,7 @@ module "emails" {
   env_name                  = var.env_name
   env_subdomain             = var.env_subdomain
   aws_account_id            = local.aws_account_id
-  route53_zone_id           = local.route53_zone_id
+  route53_zone_id           = data.aws_route53_zone.main.zone_id
   aws_region                = var.aws_region
   aws_region_name           = var.aws_region_name
   mail_exchange_server      = "10 inbound-smtp.eu-west-1.amazonaws.com"
@@ -193,7 +193,7 @@ module "frontend" {
   # AWS VPC setup -----------------------------------------
   aws_region         = var.aws_region
   aws_region_name    = var.aws_region_name
-  route53_zone_id    = local.route53_zone_id
+  route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.105.0.0/16"
   zone_count         = var.zone_count
   zone_names         = var.zone_names
@@ -254,7 +254,7 @@ module "api" {
   aws_account_id         = local.aws_account_id
   aws_region_name        = var.aws_region_name
   aws_region             = var.aws_region
-  route53_zone_id        = local.route53_zone_id
+  route53_zone_id        = data.aws_route53_zone.main.zone_id
   vpc_id                 = module.backend.backend_vpc_id
 
   user_signup_enabled  = 0

--- a/govwifi/staging-dublin/secrets-manager.tf
+++ b/govwifi/staging-dublin/secrets-manager.tf
@@ -13,11 +13,3 @@ data "aws_secretsmanager_secret_version" "docker_image_path" {
 data "aws_secretsmanager_secret" "docker_image_path" {
   name = "aws/ecr/docker-image-path/govwifi"
 }
-
-data "aws_secretsmanager_secret_version" "route53_zone_id" {
-  secret_id = data.aws_secretsmanager_secret.route53_zone_id.id
-}
-
-data "aws_secretsmanager_secret" "route53_zone_id" {
-  name = "aws/route53/zone-id"
-}

--- a/govwifi/staging-london/data.tf
+++ b/govwifi/staging-london/data.tf
@@ -1,0 +1,4 @@
+# TODO This should probably be managed by Terraform at some point
+data "aws_route53_zone" "main" {
+  name = "${var.env_subdomain}.service.gov.uk."
+}

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -7,10 +7,6 @@ locals {
 }
 
 locals {
-  route53_zone_id = jsondecode(data.aws_secretsmanager_secret_version.route53_zone_id.secret_string)["route53-zone-id"]
-}
-
-locals {
   frontend_radius_ips = concat(var.london_radius_ip_addresses, var.dublin_radius_ip_addresses)
 }
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -78,7 +78,7 @@ module "backend" {
 
   # AWS VPC setup -----------------------------------------
   aws_region      = var.aws_region
-  route53_zone_id = local.route53_zone_id
+  route53_zone_id = data.aws_route53_zone.main.zone_id
   aws_region_name = var.aws_region_name
   vpc_cidr_block  = "10.106.0.0/16"
   zone_count      = var.zone_count
@@ -151,7 +151,7 @@ module "frontend" {
   aws_region = var.aws_region
 
   aws_region_name    = var.aws_region_name
-  route53_zone_id    = local.route53_zone_id
+  route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.102.0.0/16"
   zone_count         = var.zone_count
   zone_names         = var.zone_names
@@ -211,6 +211,8 @@ module "govwifi_admin" {
   vpc_id          = module.backend.backend_vpc_id
   instance_count  = 1
 
+  route53_zone_id = data.aws_route53_zone.main.zone_id
+
   admin_docker_image   = format("%s/admin:staging", local.docker_image_path)
   rack_env             = "staging"
   sentry_current_env   = "secondary-staging"
@@ -267,7 +269,7 @@ module "api" {
   aws_account_id         = local.aws_account_id
   aws_region_name        = var.aws_region_name
   aws_region             = var.aws_region
-  route53_zone_id        = local.route53_zone_id
+  route53_zone_id        = data.aws_route53_zone.main.zone_id
   vpc_id                 = module.backend.backend_vpc_id
   safe_restart_enabled   = 1
 
@@ -389,8 +391,8 @@ module "govwifi_grafana" {
   env_subdomain              = var.env_subdomain
   aws_region                 = var.aws_region
   critical_notifications_arn = module.notifications.topic_arn
-  is_production_aws_account  = var.is_production_aws_account
 
+  route53_zone_id = data.aws_route53_zone.main.zone_id
 
   ssh_key_name = var.ssh_key_name
 

--- a/govwifi/staging-london/secrets-manager.tf
+++ b/govwifi/staging-london/secrets-manager.tf
@@ -13,11 +13,3 @@ data "aws_secretsmanager_secret_version" "docker_image_path" {
 data "aws_secretsmanager_secret" "docker_image_path" {
   name = "aws/ecr/docker-image-path/govwifi"
 }
-
-data "aws_secretsmanager_secret_version" "route53_zone_id" {
-  secret_id = data.aws_secretsmanager_secret.route53_zone_id.id
-}
-
-data "aws_secretsmanager_secret" "route53_zone_id" {
-  name = "aws/route53/zone-id"
-}

--- a/govwifi/wifi-london/data.tf
+++ b/govwifi/wifi-london/data.tf
@@ -1,0 +1,4 @@
+# TODO This should probably be managed by Terraform at some point
+data "aws_route53_zone" "main" {
+  name = "${var.env_subdomain}.service.gov.uk."
+}

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -7,10 +7,6 @@ locals {
 }
 
 locals {
-  route53_zone_id = jsondecode(data.aws_secretsmanager_secret_version.route53_zone_id.secret_string)["route53-zone-id"]
-}
-
-locals {
   frontend_radius_ips = concat(var.london_radius_ip_addresses, var.dublin_radius_ip_addresses)
 }
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -90,7 +90,7 @@ module "backend" {
   # AWS VPC setup -----------------------------------------
   aws_region      = var.aws_region
   aws_region_name = var.aws_region_name
-  route53_zone_id = local.route53_zone_id
+  route53_zone_id = data.aws_route53_zone.main.zone_id
   vpc_cidr_block  = "10.84.0.0/16"
   zone_count      = var.zone_count
   zone_names      = var.zone_names
@@ -164,7 +164,7 @@ module "frontend" {
   aws_region = var.aws_region
 
   aws_region_name    = var.aws_region_name
-  route53_zone_id    = local.route53_zone_id
+  route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.85.0.0/16"
   zone_count         = var.zone_count
   zone_names         = var.zone_names
@@ -224,6 +224,8 @@ module "govwifi_admin" {
   vpc_id          = module.backend.backend_vpc_id
   instance_count  = 2
 
+  route53_zone_id = data.aws_route53_zone.main.zone_id
+
   admin_docker_image   = format("%s/admin:production", local.docker_image_path)
   rack_env             = "production"
   sentry_current_env   = "production"
@@ -280,7 +282,7 @@ module "api" {
   aws_account_id         = local.aws_account_id
   aws_region_name        = var.aws_region_name
   aws_region             = var.aws_region
-  route53_zone_id        = local.route53_zone_id
+  route53_zone_id        = data.aws_route53_zone.main.zone_id
   vpc_id                 = module.backend.backend_vpc_id
 
   devops_notifications_arn = module.devops_notifications.topic_arn
@@ -441,7 +443,8 @@ module "govwifi_grafana" {
   env_subdomain              = var.env_subdomain
   aws_region                 = var.aws_region
   critical_notifications_arn = module.critical_notifications.topic_arn
-  is_production_aws_account  = var.is_production_aws_account
+
+  route53_zone_id = data.aws_route53_zone.main.zone_id
 
   ssh_key_name = var.ssh_key_name
 

--- a/govwifi/wifi-london/secrets-manager.tf
+++ b/govwifi/wifi-london/secrets-manager.tf
@@ -14,14 +14,6 @@ data "aws_secretsmanager_secret" "docker_image_path" {
   name = "aws/ecr/docker-image-path/govwifi"
 }
 
-data "aws_secretsmanager_secret_version" "route53_zone_id" {
-  secret_id = data.aws_secretsmanager_secret.route53_zone_id.id
-}
-
-data "aws_secretsmanager_secret" "route53_zone_id" {
-  name = "aws/route53/zone-id"
-}
-
 data "aws_secretsmanager_secret" "pagerduty_config" {
   name = "pagerduty/config"
 }

--- a/govwifi/wifi/data.tf
+++ b/govwifi/wifi/data.tf
@@ -1,0 +1,4 @@
+# TODO This should probably be managed by Terraform at some point
+data "aws_route53_zone" "main" {
+  name = "${local.env_subdomain}.service.gov.uk."
+}

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -14,10 +14,6 @@ locals {
 }
 
 locals {
-  route53_zone_id = jsondecode(data.aws_secretsmanager_secret_version.route53_zone_id.secret_string)["route53-zone-id"]
-}
-
-locals {
   pagerduty_https_endpoint = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_config.secret_string)["integration-url"]
 }
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -88,7 +88,7 @@ module "backend" {
   # AWS VPC setup -----------------------------------------
   aws_region      = var.aws_region
   aws_region_name = var.aws_region_name
-  route53_zone_id = local.route53_zone_id
+  route53_zone_id = data.aws_route53_zone.main.zone_id
   vpc_cidr_block  = "10.42.0.0/16"
   zone_count      = var.zone_count
   zone_names      = var.zone_names
@@ -159,7 +159,7 @@ module "emails" {
   env_name                  = local.env_name
   env_subdomain             = local.env_subdomain
   aws_account_id            = local.aws_account_id
-  route53_zone_id           = local.route53_zone_id
+  route53_zone_id           = data.aws_route53_zone.main.zone_id
   aws_region                = var.aws_region
   aws_region_name           = var.aws_region_name
   mail_exchange_server      = "10 inbound-smtp.eu-west-1.amazonaws.com"
@@ -188,7 +188,7 @@ module "dns" {
 
   source             = "../../global-dns"
   env_subdomain      = local.env_subdomain
-  route53_zone_id    = local.route53_zone_id
+  route53_zone_id    = data.aws_route53_zone.main.zone_id
   status_page_domain = "bl6klm1cjshh.stspg-customer.com"
 }
 
@@ -208,7 +208,7 @@ module "frontend" {
   # AWS VPC setup -----------------------------------------
   aws_region         = var.aws_region
   aws_region_name    = var.aws_region_name
-  route53_zone_id    = local.route53_zone_id
+  route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.43.0.0/16"
   zone_count         = var.zone_count
   zone_names         = var.zone_names
@@ -270,7 +270,7 @@ module "api" {
   aws_account_id          = local.aws_account_id
   aws_region_name         = lower(var.aws_region_name)
   aws_region              = var.aws_region
-  route53_zone_id         = local.route53_zone_id
+  route53_zone_id         = data.aws_route53_zone.main.zone_id
   vpc_id                  = module.backend.backend_vpc_id
 
   user_signup_enabled  = 0

--- a/govwifi/wifi/secrets-manager.tf
+++ b/govwifi/wifi/secrets-manager.tf
@@ -14,14 +14,6 @@ data "aws_secretsmanager_secret" "docker_image_path" {
   name = "aws/ecr/docker-image-path/govwifi"
 }
 
-data "aws_secretsmanager_secret_version" "route53_zone_id" {
-  secret_id = data.aws_secretsmanager_secret.route53_zone_id.id
-}
-
-data "aws_secretsmanager_secret" "route53_zone_id" {
-  name = "aws/route53/zone-id"
-}
-
 data "aws_secretsmanager_secret" "pagerduty_config" {
   name = "pagerduty/config"
 }


### PR DESCRIPTION
### What
Simplify the handling of the Route53 zones

### Why
Currently the zone is created by hand, and not managed through
Terraform. The zone ID is discovered in two different ways, either
through a data source, or a secret.

This is quite confusing as it makes it hard to see where the zone is
used, and makes it difficult to use a Terraform resource to manage it.

I think managing the zone with a resource is a good end goal, this
commit just uses one single data source to lookup the zone ID, and
then passes this around to where it's needed. The secrets can then be
deleted.


Link to Trello card: https://trello.com/c/dTha9YbB/1853-simplify-handling-of-route53-zones-in-govwifi-terraform