### PR TITLE
Convert some variables to locals

### DIFF
--- a/govwifi/staging-dublin/locals.tf
+++ b/govwifi/staging-dublin/locals.tf
@@ -1,4 +1,11 @@
 locals {
+  env_name      = "staging"
+  env_subdomain = "staging.wifi" # Environment specific subdomain to use under the service domain
+
+  product_name = "GovWifi"
+}
+
+locals {
   aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
 }
 

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -4,8 +4,8 @@ module "tfstate" {
   }
 
   source             = "../../terraform-state"
-  product_name       = var.product_name
-  env_name           = var.env_name
+  product_name       = local.product_name
+  env_name           = local.env_name
   aws_account_id     = local.aws_account_id
   aws_region_name    = var.aws_region_name
   backup_region_name = var.backup_region_name
@@ -20,7 +20,7 @@ terraform {
 
   backend "s3" {
     # Interpolation is not allowed here.
-    #bucket = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-tfstate"
+    #bucket = "${lower(local.product_name)}-${lower(local.env_name)}-${lower(var.aws_region_name)}-tfstate"
     #key    = "${lower(var.aws_region_name)}-tfstate"
     #region = "${var.aws_region}"
     bucket = "govwifi-staging-dublin-tfstate"
@@ -64,8 +64,8 @@ module "backend" {
 
   source                    = "../../govwifi-backend"
   env                       = "staging"
-  env_name                  = var.env_name
-  env_subdomain             = var.env_subdomain
+  env_name                  = local.env_name
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
 
@@ -144,9 +144,9 @@ module "emails" {
   source = "../../govwifi-emails"
 
   is_production_aws_account = var.is_production_aws_account
-  product_name              = var.product_name
-  env_name                  = var.env_name
-  env_subdomain             = var.env_subdomain
+  product_name              = local.product_name
+  env_name                  = local.env_name
+  env_subdomain             = local.env_subdomain
   aws_account_id            = local.aws_account_id
   route53_zone_id           = local.route53_zone_id
   aws_region                = var.aws_region
@@ -154,7 +154,7 @@ module "emails" {
   mail_exchange_server      = "10 inbound-smtp.eu-west-1.amazonaws.com"
   devops_notifications_arn  = module.notifications.topic_arn
 
-  user_signup_notifications_endpoint = "https://user-signup-api.${var.env_subdomain}.service.gov.uk:8443/user-signup/email-notification"
+  user_signup_notifications_endpoint = "https://user-signup-api.${local.env_subdomain}.service.gov.uk:8443/user-signup/email-notification"
 
   // The SNS endpoint is disabled in the secondary AWS account
   // We will conduct an SNS inventory (see this card: https://trello.com/c/EMeet3tl/315-investigate-and-inventory-sns-topics)
@@ -186,8 +186,8 @@ module "frontend" {
   }
 
   source                    = "../../govwifi-frontend"
-  env_name                  = var.env_name
-  env_subdomain             = var.env_subdomain
+  env_name                  = local.env_name
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
   # AWS VPC setup -----------------------------------------
@@ -246,7 +246,7 @@ module "api" {
   source                    = "../../govwifi-api"
   env                       = "staging"
   env_name                  = "staging"
-  env_subdomain             = var.env_subdomain
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
   backend_elb_count      = 1

--- a/govwifi/staging-dublin/variables.tf
+++ b/govwifi/staging-dublin/variables.tf
@@ -1,19 +1,3 @@
-variable "env_name" {
-  type    = string
-  default = "staging"
-}
-
-variable "product_name" {
-  type    = string
-  default = "GovWifi"
-}
-
-variable "env_subdomain" {
-  type        = string
-  default     = "staging.wifi"
-  description = "Environment-specific subdomain to use under the service domain."
-}
-
 variable "ssh_key_name" {
   type    = string
   default = "staging-ec2-instances-20200717"

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -1,4 +1,11 @@
 locals {
+  env_name      = "staging"
+  env_subdomain = "staging.wifi" # Environment specific subdomain to use under the service domain
+
+  product_name = "GovWifi"
+}
+
+locals {
   aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
 }
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -4,8 +4,8 @@ module "tfstate" {
   }
 
   source             = "../../terraform-state"
-  product_name       = var.product_name
-  env_name           = var.env_name
+  product_name       = local.product_name
+  env_name           = local.env_name
   aws_account_id     = local.aws_account_id
   aws_region_name    = var.aws_region_name
   backup_region_name = var.backup_region_name
@@ -20,7 +20,7 @@ terraform {
 
   backend "s3" {
     # Interpolation is not allowed here.
-    #bucket = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-tfstate"
+    #bucket = "${lower(local.product_name)}-${lower(local.env_name)}-${lower(var.aws_region_name)}-tfstate"
     #key    = "${lower(var.aws_region_name)}-tfstate"
     #region = "${var.aws_region}"
     bucket = "govwifi-staging-london-tfstate"
@@ -71,8 +71,8 @@ module "backend" {
 
   source                    = "../../govwifi-backend"
   env                       = "staging"
-  env_name                  = var.env_name
-  env_subdomain             = var.env_subdomain
+  env_name                  = local.env_name
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
 
@@ -142,8 +142,8 @@ module "frontend" {
   }
 
   source                    = "../../govwifi-frontend"
-  env_name                  = var.env_name
-  env_subdomain             = var.env_subdomain
+  env_name                  = local.env_name
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
   # AWS VPC setup -----------------------------------------
@@ -202,8 +202,8 @@ module "govwifi_admin" {
   }
 
   source                    = "../../govwifi-admin"
-  env_name                  = var.env_name
-  env_subdomain             = var.env_subdomain
+  env_name                  = local.env_name
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
   aws_region      = var.aws_region
@@ -240,7 +240,7 @@ module "govwifi_admin" {
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
   sentry_dsn                 = var.admin_sentry_dsn
-  logging_api_search_url     = "https://api-elb.london.${var.env_subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
+  logging_api_search_url     = "https://api-elb.london.${local.env_subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
   public_google_api_key      = var.public_google_api_key
 
   zendesk_api_endpoint = "https://govuk.zendesk.com/api/v2/"
@@ -259,7 +259,7 @@ module "api" {
   source                    = "../../govwifi-api"
   env                       = "staging"
   env_name                  = "staging"
-  env_subdomain             = var.env_subdomain
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
   backend_elb_count      = 1
@@ -284,7 +284,7 @@ module "api" {
   wordlist_file_path    = "../wordlist-short"
   ecr_repository_count  = 1
 
-  db_hostname = "db.${lower(var.aws_region_name)}.${var.env_subdomain}.service.gov.uk"
+  db_hostname = "db.${lower(var.aws_region_name)}.${local.env_subdomain}.service.gov.uk"
 
   user_db_hostname = var.user_db_hostname
 
@@ -344,7 +344,7 @@ module "govwifi_dashboard" {
   }
 
   source   = "../../govwifi-dashboard"
-  env_name = var.env_name
+  env_name = local.env_name
 }
 
 /*
@@ -361,7 +361,7 @@ module "govwifi_prometheus" {
   }
 
   source   = "../../govwifi-prometheus"
-  env_name = var.env_name
+  env_name = local.env_name
 
   ssh_key_name = var.ssh_key_name
 
@@ -385,8 +385,8 @@ module "govwifi_grafana" {
   }
 
   source                     = "../../govwifi-grafana"
-  env_name                   = var.env_name
-  env_subdomain              = var.env_subdomain
+  env_name                   = local.env_name
+  env_subdomain              = local.env_subdomain
   aws_region                 = var.aws_region
   critical_notifications_arn = module.notifications.topic_arn
   is_production_aws_account  = var.is_production_aws_account
@@ -416,8 +416,8 @@ module "govwifi_elasticsearch" {
   }
 
   source         = "../../govwifi-elasticsearch"
-  domain_name    = "${var.env_name}-elasticsearch"
-  env_name       = var.env_name
+  domain_name    = "${local.env_name}-elasticsearch"
+  env_name       = local.env_name
   aws_region     = var.aws_region
   aws_account_id = local.aws_account_id
   vpc_id         = module.backend.backend_vpc_id

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -1,19 +1,3 @@
-variable "env_name" {
-  type    = string
-  default = "staging"
-}
-
-variable "product_name" {
-  type    = string
-  default = "GovWifi"
-}
-
-variable "env_subdomain" {
-  type        = string
-  default     = "staging.wifi"
-  description = "Environment-specific subdomain to use under the service domain."
-}
-
 variable "ssh_key_name" {
   type    = string
   default = "staging-ec2-instances-20200717"

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -1,4 +1,11 @@
 locals {
+  env_name      = "wifi"
+  env_subdomain = "wifi" # Environment specific subdomain to use under the service domain
+
+  product_name = "GovWifi"
+}
+
+locals {
   aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
 }
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -4,8 +4,8 @@ module "tfstate" {
   }
 
   source             = "../../terraform-state"
-  product_name       = var.product_name
-  env_name           = var.env_name
+  product_name       = local.product_name
+  env_name           = local.env_name
   aws_account_id     = local.aws_account_id
   aws_region_name    = var.aws_region_name
   backup_region_name = var.backup_region_name
@@ -20,7 +20,7 @@ terraform {
 
   backend "s3" {
     # Interpolation is not allowed here.
-    #bucket = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-tfstate"
+    #bucket = "${lower(local.product_name)}-${lower(local.env_name)}-${lower(var.aws_region_name)}-tfstate"
     #key    = "${lower(var.aws_region_name)}-tfstate"
     #region = "${var.aws_region}"
     bucket = "govwifi-wifi-london-tfstate"
@@ -82,8 +82,8 @@ module "backend" {
 
   source                    = "../../govwifi-backend"
   env                       = "production"
-  env_name                  = var.env_name
-  env_subdomain             = var.env_subdomain
+  env_name                  = local.env_name
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
 
@@ -155,8 +155,8 @@ module "frontend" {
   }
 
   source                    = "../../govwifi-frontend"
-  env_name                  = var.env_name
-  env_subdomain             = var.env_subdomain
+  env_name                  = local.env_name
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
   # AWS VPC setup -----------------------------------------
@@ -215,8 +215,8 @@ module "govwifi_admin" {
   }
 
   source                    = "../../govwifi-admin"
-  env_name                  = var.env_name
-  env_subdomain             = var.env_subdomain
+  env_name                  = local.env_name
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
   aws_region      = var.aws_region
@@ -256,7 +256,7 @@ module "govwifi_admin" {
   sentry_dsn                 = var.admin_sentry_dsn
   public_google_api_key      = var.public_google_api_key
 
-  logging_api_search_url = "https://api-elb.london.${var.env_subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
+  logging_api_search_url = "https://api-elb.london.${local.env_subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
 
   zendesk_api_endpoint = "https://govuk.zendesk.com/api/v2/"
   zendesk_api_user     = var.zendesk_api_user
@@ -271,8 +271,8 @@ module "api" {
 
   source                    = "../../govwifi-api"
   env                       = "production"
-  env_name                  = var.env_name
-  env_subdomain             = var.env_subdomain
+  env_name                  = local.env_name
+  env_subdomain             = local.env_subdomain
   is_production_aws_account = var.is_production_aws_account
 
   backend_elb_count      = 1
@@ -296,7 +296,7 @@ module "api" {
   wordlist_file_path    = "../wordlist-short"
   ecr_repository_count  = 1
 
-  db_hostname               = "db.${lower(var.aws_region_name)}.${var.env_subdomain}.service.gov.uk"
+  db_hostname               = "db.${lower(var.aws_region_name)}.${local.env_subdomain}.service.gov.uk"
   rack_env                  = "production"
   sentry_current_env        = "production"
   radius_server_ips         = local.frontend_radius_ips
@@ -398,7 +398,7 @@ module "govwifi_dashboard" {
   }
 
   source   = "../../govwifi-dashboard"
-  env_name = var.env_name
+  env_name = local.env_name
 }
 
 /*
@@ -413,7 +413,7 @@ module "govwifi_prometheus" {
   }
 
   source   = "../../govwifi-prometheus"
-  env_name = var.env_name
+  env_name = local.env_name
 
   ssh_key_name = var.ssh_key_name
 
@@ -437,8 +437,8 @@ module "govwifi_grafana" {
   }
 
   source                     = "../../govwifi-grafana"
-  env_name                   = var.env_name
-  env_subdomain              = var.env_subdomain
+  env_name                   = local.env_name
+  env_subdomain              = local.env_subdomain
   aws_region                 = var.aws_region
   critical_notifications_arn = module.critical_notifications.topic_arn
   is_production_aws_account  = var.is_production_aws_account
@@ -482,8 +482,8 @@ module "govwifi_elasticsearch" {
   }
 
   source         = "../../govwifi-elasticsearch"
-  domain_name    = "${var.env_name}-elasticsearch"
-  env_name       = var.env_name
+  domain_name    = "${local.env_name}-elasticsearch"
+  env_name       = local.env_name
   aws_region     = var.aws_region
   aws_account_id = local.aws_account_id
   vpc_id         = module.backend.backend_vpc_id

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -1,19 +1,3 @@
-variable "env_name" {
-  type    = string
-  default = "wifi"
-}
-
-variable "product_name" {
-  type    = string
-  default = "GovWifi"
-}
-
-variable "env_subdomain" {
-  type        = string
-  default     = "wifi"
-  description = "Environment-specific subdomain to use under the service domain."
-}
-
 variable "ssh_key_name" {
   type    = string
   default = "govwifi-key-20180530"


### PR DESCRIPTION
### What
Convert some variables to locals

### Why
For three variables that don't (and shouldn't) vary. This commit
covers wifi-london and both staging environments, wifi was already
changed in ca71b7b0c9dc4f673d0c27e403b6c05af3ffa24f.

Variables form part of the interface for Terraform configuration, and
as is in the name, they're usually used for things that vary. The
env_name, env_subdomain and product_name for the wifi environment
Terraform configuration aren't things that vary, so I think it's
clearer to make them locals, rather than variables.


Link to Trello card: https://trello.com/c/x0yzOMIW/1854-convert-more-non-varying-variables-to-locals-in-govwifi-terraform