### PR TITLE
Change how subnets are handling in govwifi-backend

### DIFF
--- a/govwifi-backend/db-parameters.tf
+++ b/govwifi-backend/db-parameters.tf
@@ -1,7 +1,7 @@
 resource "aws_db_subnet_group" "db_subnets" {
   name        = "wifi-${var.env_name}-subnets"
   description = "GovWifi ${var.env_name} backend subnets"
-  subnet_ids  = aws_subnet.wifi_backend_subnet.*.id
+  subnet_ids  = [for subnet in aws_subnet.wifi_backend_subnet : subnet.id]
 
   tags = {
     Name = "wifi-${var.env_name}-subnets"

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -4,7 +4,7 @@ resource "aws_instance" "management" {
   ami           = var.bastion_ami
   instance_type = var.bastion_instance_type
   key_name      = var.bastion_ssh_key_name
-  subnet_id     = aws_subnet.wifi_backend_subnet[0].id
+  subnet_id     = aws_subnet.wifi_backend_subnet[data.aws_availability_zones.zones.names[0]].id
 
   vpc_security_group_ids = [
     aws_security_group.be_vpn_in.id,

--- a/govwifi-backend/outputs.tf
+++ b/govwifi-backend/outputs.tf
@@ -3,7 +3,7 @@ output "backend_vpc_id" {
 }
 
 output "backend_subnet_ids" {
-  value = aws_subnet.wifi_backend_subnet.*.id
+  value = [for subnet in aws_subnet.wifi_backend_subnet : subnet.id]
 }
 
 output "ecs_instance_profile_id" {

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -28,17 +28,6 @@ variable "administrator_ips" {
 variable "frontend_radius_ips" {
 }
 
-variable "zone_count" {
-}
-
-variable "zone_names" {
-  type = map(string)
-}
-
-variable "zone_subnets" {
-  type = map(string)
-}
-
 variable "enable_bastion" {
   default = 1
 }

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -74,14 +74,6 @@ module "backend" {
   route53_zone_id = local.route53_zone_id
   aws_region_name = var.aws_region_name
   vpc_cidr_block  = "10.104.0.0/16"
-  zone_count      = var.zone_count
-  zone_names      = var.zone_names
-
-  zone_subnets = {
-    zone0 = "10.104.1.0/24"
-    zone1 = "10.104.2.0/24"
-    zone2 = "10.104.3.0/24"
-  }
 
   administrator_ips   = var.administrator_ips
   frontend_radius_ips = local.frontend_radius_ips

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -81,14 +81,6 @@ module "backend" {
   route53_zone_id = local.route53_zone_id
   aws_region_name = var.aws_region_name
   vpc_cidr_block  = "10.106.0.0/16"
-  zone_count      = var.zone_count
-  zone_names      = var.zone_names
-
-  zone_subnets = {
-    zone0 = "10.106.1.0/24"
-    zone1 = "10.106.2.0/24"
-    zone2 = "10.106.3.0/24"
-  }
 
   administrator_ips   = var.administrator_ips
   frontend_radius_ips = local.frontend_radius_ips

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -92,14 +92,6 @@ module "backend" {
   aws_region_name = var.aws_region_name
   route53_zone_id = local.route53_zone_id
   vpc_cidr_block  = "10.84.0.0/16"
-  zone_count      = var.zone_count
-  zone_names      = var.zone_names
-
-  zone_subnets = {
-    zone0 = "10.84.1.0/24"
-    zone1 = "10.84.2.0/24"
-    zone2 = "10.84.3.0/24"
-  }
 
   administrator_ips   = var.administrator_ips
   frontend_radius_ips = local.frontend_radius_ips

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -90,14 +90,6 @@ module "backend" {
   aws_region_name = var.aws_region_name
   route53_zone_id = local.route53_zone_id
   vpc_cidr_block  = "10.42.0.0/16"
-  zone_count      = var.zone_count
-  zone_names      = var.zone_names
-
-  zone_subnets = {
-    zone0 = "10.42.1.0/24"
-    zone1 = "10.42.2.0/24"
-    zone2 = "10.42.3.0/24"
-  }
 
   administrator_ips   = var.administrator_ips
   frontend_radius_ips = local.frontend_radius_ips


### PR DESCRIPTION
### What
Change how subnets are handling in govwifi-backend

Rather than passing in the zone_count, zone_names and zone_subnets,
lookup the availability zone details from AWS, and derive the subnet
blocks for the VPC CIDR block.

### Why
I think there are a few advantages to this. There are less variables
to manage, which simplifies the configuration, instead values looked
up or derived from the appropriate place. This is important in
Terraform because it informs resource dependencies.

Applying this without re-creating the subnets will require moving the
old subnets to the new places in the statefiles.


Link to Trello card: https://trello.com/c/ho25aGlC/1855-change-how-subnets-are-handling-in-the-govwifi-backend-terraform-module-in-govwifi-terraform