### PR TITLE
Remove profile/role suffixes from respective names

### DIFF
--- a/govwifi-grafana/iam.tf
+++ b/govwifi-grafana/iam.tf
@@ -16,12 +16,12 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
 }
 
 resource "aws_iam_instance_profile" "grafana_instance_profile" {
-  name = "${var.aws_region}-${var.env_name}-grafana-instance-profile"
+  name = "${var.aws_region}-${var.env_name}-grafana-instance"
   role = aws_iam_role.grafana_instance_role.name
 }
 
 resource "aws_iam_role" "grafana_instance_role" {
-  name = "${var.aws_region}-${var.env_name}-grafana-instance-role"
+  name = "${var.aws_region}-${var.env_name}-grafana-instance"
   path = "/"
 
   assume_role_policy = <<EOF


### PR DESCRIPTION
### What

Remove 'role' and 'profile' suffix names from grafana roles and profiles.

### Why

Meet AWS's expectations for roles/profiles which should be implicitly linked.


Link to Trello card (if applicable): 
