### PR TITLE
Use the radius_eips resource when associating RADIUS EIPs

### DIFF
--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -177,5 +177,5 @@ DATA
 resource "aws_eip_association" "eip_assoc" {
   count       = var.radius_instance_count
   instance_id = element(aws_instance.radius.*.id, count.index)
-  public_ip   = element(var.elastic_ip_list, count.index)
+  public_ip   = aws_eip.radius_eips[count.index].public_ip
 }

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -52,10 +52,6 @@ variable "logging_api_base_url" {
 variable "auth_api_base_url" {
 }
 
-variable "elastic_ip_list" {
-  type = list(string)
-}
-
 variable "enable_detailed_monitoring" {
 }
 

--- a/govwifi/staging-dublin/locals.tf
+++ b/govwifi/staging-dublin/locals.tf
@@ -13,7 +13,3 @@ locals {
 locals {
   frontend_radius_ips = concat(var.london_radius_ip_addresses, var.dublin_radius_ip_addresses)
 }
-
-locals {
-  frontend_region_ips = var.dublin_radius_ip_addresses
-}

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -214,7 +214,6 @@ module "frontend" {
   # where N = this base + 1 + server#
   dns_numbering_base = 0
 
-  elastic_ip_list       = local.frontend_region_ips
   ami                   = var.ami
   ssh_key_name          = var.ssh_key_name
   frontend_docker_image = format("%s/frontend:staging", local.docker_image_path)

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -13,7 +13,3 @@ locals {
 locals {
   frontend_radius_ips = concat(var.london_radius_ip_addresses, var.dublin_radius_ip_addresses)
 }
-
-locals {
-  frontend_region_ips = var.london_radius_ip_addresses
-}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -172,7 +172,6 @@ module "frontend" {
   # where N = this base + 1 + server#
   dns_numbering_base = 3
 
-  elastic_ip_list       = local.frontend_region_ips
   ami                   = var.ami
   ssh_key_name          = var.ssh_key_name
   frontend_docker_image = format("%s/frontend:staging", local.docker_image_path)

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -13,7 +13,3 @@ locals {
 locals {
   frontend_radius_ips = concat(var.london_radius_ip_addresses, var.dublin_radius_ip_addresses)
 }
-
-locals {
-  frontend_region_ips = var.london_radius_ip_addresses
-}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -185,7 +185,6 @@ module "frontend" {
   # where N = this base + 1 + server#
   dns_numbering_base = 3
 
-  elastic_ip_list       = local.frontend_region_ips
   ami                   = var.ami
   ssh_key_name          = var.ssh_key_name
   frontend_docker_image = format("%s/frontend:production", local.docker_image_path)

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -24,7 +24,3 @@ locals {
 locals {
   frontend_radius_ips = concat(var.london_radius_ip_addresses, var.dublin_radius_ip_addresses)
 }
-
-locals {
-  frontend_region_ips = var.dublin_radius_ip_addresses
-}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -230,7 +230,6 @@ module "frontend" {
   # where N = this base + 1 + server#
   dns_numbering_base = 0
 
-  elastic_ip_list       = local.frontend_region_ips
   ami                   = var.ami
   ssh_key_name          = var.ssh_key_name
   frontend_docker_image = format("%s/frontend:production", local.docker_image_path)


### PR DESCRIPTION
### What
Use the radius_eips resource when associating RADIUS EIPs

### Why
Rather than passing through a list of IP addresses for this
purpose. This simplifies the Terraform, and makes it clearer where the
resource dependencies are.


Link to Trello card: https://trello.com/c/yoM4tarP/1861-use-the-radiuseips-resource-when-associating-radius-eips-in-govwifi-terraform