### PR TITLE
Retrieve a Github access token and pass to environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,5 @@ jobs:
           brew install tfenv tflint findutils
           tfenv install $(cat .terraform-version)
           tfenv use $(cat .terraform-version)
-          tflint --init
+          GITHUB_TOKEN=${{ secrets.GH_TOKEN }} tflint --init
           PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH" make lint


### PR DESCRIPTION
to avoid rate limiting when calling tflint.

### What

Retrieves a Github access token stored in the repo's secrets and passes to environment variable.

### Why

To avoid rate limiting when running tflint.

