### PR TITLE
Change wifi-frontend-subnet to wifi_frontend_subnet

### DIFF
--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -378,7 +378,7 @@ module "govwifi_prometheus" {
   fe_radius_in  = module.frontend.fe_radius_in
   fe_radius_out = module.frontend.fe_radius_out
 
-  wifi-frontend-subnet       = module.frontend.wifi-frontend-subnet
+  wifi_frontend_subnet       = module.frontend.wifi_frontend_subnet
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 


### PR DESCRIPTION
### What
Change wifi-frontend-subnet to wifi_frontend_subnet

### Why
This issue crept in as part of
e77b8f335d90da0d7528f8900977673a6b897085.
