### PR TITLE
Change how subnets are handled in govwifi-frontend

### DIFF
--- a/govwifi-frontend/frontend.tf
+++ b/govwifi-frontend/frontend.tf
@@ -26,17 +26,17 @@ resource "aws_route" "internet_access" {
   gateway_id             = aws_internet_gateway.wifi_frontend.id
 }
 
-# CREATE SUBNET IN EACH AZ
+data "aws_availability_zones" "zones" {}
 
 resource "aws_subnet" "wifi_frontend_subnet" {
-  count                   = var.zone_count
+  for_each = toset(data.aws_availability_zones.zones.names)
+
   vpc_id                  = aws_vpc.wifi_frontend.id
-  availability_zone       = var.zone_names[format("zone%d", count.index)]
-  cidr_block              = var.zone_subnets[format("zone%d", count.index)]
+  availability_zone       = each.key
+  cidr_block              = "${join(".", slice(split(".", var.vpc_cidr_block), 0, 2))}.${index(data.aws_availability_zones.zones.names, each.key) + 1}.0/24"
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "${var.env_name} Frontend - AZ: ${var.zone_names[format("zone%d", count.index)]} - GovWifi subnet"
+    Name = "${var.env_name} Frontend - AZ: ${each.key} - GovWifi subnet"
   }
 }
-

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -5,7 +5,7 @@ resource "aws_instance" "radius" {
   ami           = var.ami
   instance_type = "t2.medium"
   key_name      = var.ssh_key_name
-  subnet_id     = element(aws_subnet.wifi_frontend_subnet.*.id, count.index)
+  subnet_id     = aws_subnet.wifi_frontend_subnet[data.aws_availability_zones.zones.names[0]].id
 
   vpc_security_group_ids = [
     aws_security_group.fe_ecs_out.id,

--- a/govwifi-frontend/outputs.tf
+++ b/govwifi-frontend/outputs.tf
@@ -3,7 +3,7 @@ output "frontend_vpc_id" {
 }
 
 output "frontend_subnet_id" {
-  value = aws_subnet.wifi_frontend_subnet.*.id
+  value = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
 }
 
 output "fe_admin_in" {

--- a/govwifi-frontend/outputs.tf
+++ b/govwifi-frontend/outputs.tf
@@ -25,8 +25,3 @@ output "fe_radius_out" {
 output "ecs_instance_profile" {
   value = aws_iam_instance_profile.ecs_instance_profile.id
 }
-
-output "wifi_frontend_subnet" {
-  value = aws_subnet.wifi_frontend_subnet.*.id
-}
-

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -16,17 +16,6 @@ variable "aws_region" {
 variable "aws_region_name" {
 }
 
-variable "zone_count" {
-}
-
-variable "zone_names" {
-  type = map(string)
-}
-
-variable "zone_subnets" {
-  type = map(string)
-}
-
 variable "radius_instance_count" {
 }
 

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -187,16 +187,8 @@ module "frontend" {
   aws_region_name    = var.aws_region_name
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.105.0.0/16"
-  zone_count         = var.zone_count
-  zone_names         = var.zone_names
   rack_env           = "staging"
   sentry_current_env = "secondary-staging"
-
-  zone_subnets = {
-    zone0 = "10.105.1.0/24"
-    zone1 = "10.105.2.0/24"
-    zone2 = "10.105.3.0/24"
-  }
 
   # Instance-specific setup -------------------------------
   radius_instance_count      = 3

--- a/govwifi/staging-dublin/variables.tf
+++ b/govwifi/staging-dublin/variables.tf
@@ -37,22 +37,6 @@ variable "backup_region_name" {
   default = "London"
 }
 
-variable "zone_count" {
-  type    = string
-  default = "3"
-}
-
-# Zone names and subnets MUST be static, can not be constructed from vars.
-variable "zone_names" {
-  type = map(any)
-
-  default = {
-    zone0 = "eu-west-1a"
-    zone1 = "eu-west-1b"
-    zone2 = "eu-west-1c"
-  }
-}
-
 variable "ami" {
   # eu-west-1, Amazon Linux AMI 2017.09.l x86_64 ECS HVM GP2
   default     = "ami-2d386654"

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -365,7 +365,7 @@ module "govwifi_prometheus" {
   fe_radius_in  = module.frontend.fe_radius_in
   fe_radius_out = module.frontend.fe_radius_out
 
-  wifi_frontend_subnet       = module.frontend.wifi_frontend_subnet
+  wifi_frontend_subnet       = module.frontend.frontend_subnet_id
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -145,16 +145,8 @@ module "frontend" {
   aws_region_name    = var.aws_region_name
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.102.0.0/16"
-  zone_count         = var.zone_count
-  zone_names         = var.zone_names
   rack_env           = "staging"
   sentry_current_env = "secondary-staging"
-
-  zone_subnets = {
-    zone0 = "10.102.1.0/24"
-    zone1 = "10.102.2.0/24"
-    zone2 = "10.102.3.0/24"
-  }
 
   # Instance-specific setup -------------------------------
   radius_instance_count      = 3

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -36,22 +36,6 @@ variable "backup_region_name" {
   default = "Dublin"
 }
 
-variable "zone_count" {
-  type    = string
-  default = "3"
-}
-
-# Zone names and subnets MUST be static, can not be constructed from vars.
-variable "zone_names" {
-  type = map(any)
-
-  default = {
-    zone0 = "eu-west-2a"
-    zone1 = "eu-west-2b"
-    zone2 = "eu-west-2c"
-  }
-}
-
 variable "ami" {
   # eu-west-2, Amazon Linux AMI 2017.09.l x86_64 ECS HVM GP2
   default     = "ami-2218f945"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -158,16 +158,8 @@ module "frontend" {
   aws_region_name    = var.aws_region_name
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.85.0.0/16"
-  zone_count         = var.zone_count
-  zone_names         = var.zone_names
   rack_env           = "production"
   sentry_current_env = "production"
-
-  zone_subnets = {
-    zone0 = "10.85.1.0/24"
-    zone1 = "10.85.2.0/24"
-    zone2 = "10.85.3.0/24"
-  }
 
   # Instance-specific setup -------------------------------
   radius_instance_count      = 3

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -417,7 +417,7 @@ module "govwifi_prometheus" {
   fe_radius_in  = module.frontend.fe_radius_in
   fe_radius_out = module.frontend.fe_radius_out
 
-  wifi_frontend_subnet       = module.frontend.wifi_frontend_subnet
+  wifi_frontend_subnet       = module.frontend.frontend_subnet_id
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -36,22 +36,6 @@ variable "backup_region_name" {
   default = "Dublin"
 }
 
-variable "zone_count" {
-  type    = string
-  default = "3"
-}
-
-# Zone names and subnets MUST be static, can not be constructed from vars.
-variable "zone_names" {
-  type = map(string)
-
-  default = {
-    zone0 = "eu-west-2a"
-    zone1 = "eu-west-2b"
-    zone2 = "eu-west-2c"
-  }
-}
-
 variable "ami" {
   # eu-west-2, Amazon Linux AMI 2.0.20210819 x86_64 ECS HVM GP2
   default     = "ami-0820c1f2c6fc9dff1"

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -369,7 +369,7 @@ module "govwifi_prometheus" {
   fe_radius_in  = module.frontend.fe_radius_in
   fe_radius_out = module.frontend.fe_radius_out
 
-  wifi_frontend_subnet       = module.frontend.wifi_frontend_subnet
+  wifi_frontend_subnet       = module.frontend.frontend_subnet_id
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -202,17 +202,8 @@ module "frontend" {
   aws_region_name    = var.aws_region_name
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.43.0.0/16"
-  zone_count         = var.zone_count
-  zone_names         = var.zone_names
   rack_env           = "production"
   sentry_current_env = "production"
-
-
-  zone_subnets = {
-    zone0 = "10.43.1.0/24"
-    zone1 = "10.43.2.0/24"
-    zone2 = "10.43.3.0/24"
-  }
 
   # Instance-specific setup -------------------------------
   radius_instance_count      = 3

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -20,22 +20,6 @@ variable "backup_region_name" {
   default = "London"
 }
 
-variable "zone_count" {
-  type    = string
-  default = "3"
-}
-
-# Zone names and subnets MUST be static, can not be constructed from vars.
-variable "zone_names" {
-  type = map(string)
-
-  default = {
-    zone0 = "eu-west-1a"
-    zone1 = "eu-west-1b"
-    zone2 = "eu-west-1c"
-  }
-}
-
 variable "ami" {
   # eu-west-1, Amazon Linux AMI 2.0.20210819 x86_64 ECS HVM GP2
   default     = "ami-0edfed61b9e44e914"


### PR DESCRIPTION
### What
Rather than passing in the zone_count, zone_names and zone_subnets,
lookup the availability zone details from AWS, and derive the subnet
blocks for the VPC CIDR block.

These are basically the same changes as
b3e62eebe8edcb35cb039fda37fec8cb554f2b40, plus removing the
environment level zone_ variables, since they're no longer needed.

Applying this without re-creating the subnets will require moving the
old subnets to the new places in the statefiles.


### Why
I think there are a few advantages to this. There are less variables
to manage, which simplifies the configuration, instead values looked
up or derived from the appropriate place. This is important in
Terraform because it informs resource dependencies.


Link to Trello card: https://trello.com/c/dom8wPSj/1868-change-how-subnets-are-handled-in-govwifi-frontend-in-govwifi-terraform
