### PR TITLE
Remove references to deleted environments from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,6 @@ staging-dublin:
 	$(eval export DEPLOY_ENV=staging-dublin)
 	$(eval export REPO=staging)
 	$(eval export AWS_REGION=eu-west-1)
-staging-london-temp:
-	$(eval export DEPLOY_ENV=staging-london-temp)
-	$(eval export REPO=staging)
-	$(eval export AWS_REGION=eu-west-2)
-staging-dublin-temp:
-	$(eval export DEPLOY_ENV=staging-dublin-temp)
-	$(eval export REPO=staging)
-	$(eval export AWS_REGION=eu-west-1)
 wifi-london:
 	$(eval export DEPLOY_ENV=wifi-london)
 	$(eval export REPO=latest)


### PR DESCRIPTION
### What
Remove references to deleted environments from Makefile

### Why
The `staging-london-temp` and `staging-dublin-temp` environments have been
destroyed.

Link to Trello card (if applicable): https://trello.com/c/BdeRMbFs/1820-practice-bringing-up-a-new-account-from-scratch-in-dr-account
