### PR TITLE
Don't use a secret for the elasticsearch endpoint

### DIFF
--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -35,7 +35,6 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.users_db.arn,
       data.aws_secretsmanager_secret.session_db.arn,
       data.aws_secretsmanager_secret.admin_db.arn,
-      data.aws_secretsmanager_secret.volumetrics_elasticsearch_endpoint.arn,
       data.aws_secretsmanager_secret.notify_api_key.arn,
       data.aws_secretsmanager_secret.notify_bearer_token.arn,
       data.aws_secretsmanager_secret.database_s3_encryption.arn

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -74,6 +74,9 @@ resource "aws_ecs_task_definition" "logging_api_task" {
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
+        },{
+          "name": "VOLUMETRICS_ENDPOINT",
+          "valueFrom": "${var.elasticsearch_endpoint}"
         }
       ],
       "secrets": [
@@ -89,9 +92,6 @@ resource "aws_ecs_task_definition" "logging_api_task" {
         },{
           "name": "USER_DB_USER",
           "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
-        },{
-          "name": "VOLUMETRICS_ENDPOINT",
-          "valueFrom": "${data.aws_secretsmanager_secret_version.volumetrics_elasticsearch_endpoint.arn}:endpoint::"
         }
       ],
       "links": null,

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -514,6 +514,9 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
         },{
           "name": "S3_METRICS_BUCKET",
           "value": "${var.metrics_bucket_name}"
+        },{
+          "name": "VOLUMETRICS_ENDPOINT",
+          "valueFrom": "${var.elasticsearch_endpoint}"
         }
       ],
       "secrets": [
@@ -529,9 +532,6 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
         },{
           "name": "USER_DB_USER",
           "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
-        },{
-          "name": "VOLUMETRICS_ENDPOINT",
-          "valueFrom": "${data.aws_secretsmanager_secret_version.volumetrics_elasticsearch_endpoint.arn}:endpoint::"
         }
       ],
       "links": null,

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -14,14 +14,6 @@ data "aws_secretsmanager_secret" "users_db" {
   name = "rds/users-db/credentials"
 }
 
-data "aws_secretsmanager_secret_version" "volumetrics_elasticsearch_endpoint" {
-  secret_id = data.aws_secretsmanager_secret.volumetrics_elasticsearch_endpoint.id
-}
-
-data "aws_secretsmanager_secret" "volumetrics_elasticsearch_endpoint" {
-  name = "logging-api/volumetrics-elasticsearch-endpoint"
-}
-
 data "aws_secretsmanager_secret_version" "notify_api_key" {
   secret_id = data.aws_secretsmanager_secret.notify_api_key.id
 }

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -175,3 +175,8 @@ variable "is_production_aws_account" {
 
 variable "rds_mysql_backup_bucket" {
 }
+
+variable "elasticsearch_endpoint" {
+  type    = string
+  default = ""
+}

--- a/govwifi-elasticsearch/outputs.tf
+++ b/govwifi-elasticsearch/outputs.tf
@@ -1,0 +1,3 @@
+output "endpoint" {
+  value = aws_elasticsearch_domain.govwifi_elasticsearch.endpoint
+}

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -296,6 +296,7 @@ module "api" {
 
   low_cpu_threshold = 0.3
 
+  elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
 }
 
 module "notifications" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -304,6 +304,8 @@ module "api" {
   rds_mysql_backup_bucket = module.backend.rds_mysql_backup_bucket
 
   low_cpu_threshold = 10
+
+  elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
 }
 
 module "critical_notifications" {


### PR DESCRIPTION
### What
Don't use a secret for the elasticsearch endpoint

### Why
Just have Terraform set the value instead. This means Terraform will
set the correct value, rather than relying on people manually updating
the secret when the value changes.

This was something that came up when rebuilding the new staging
environment, since the secret still had temp in it.


Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account