### PR TITLE
Update documentation around confirming SNS subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ make <ENV> init-backend
 make <ENV> plan
 ```
 
-Example ENVs are: `wifi`, `wifi-london`, `staging-london-temp`, and `staging-dublin-temp`
+Example ENVs are: `wifi`, `wifi-london`, `staging-london`, and `staging-dublin`
 
 ## Running terraform
 
@@ -187,7 +187,7 @@ make <environment-name> terraform terraform_cmd="import <name_of_terraform_resou
 At present confirming SNS subscriptions needs to be done manually. To do this follow the steps below:
 1. Ensure you have fully created the infrastructure for the [Logging API](https://github.com/alphagov/govwifi-logging-api).
 1. Ensure the Logging API app has been deployed to the new environment via our [CI/CD pipeline](https://govwifi-dev-docs.cloudapps.digital/infrastructure/continuous-delivery.html#govwifi-concourse).
-1. Login to the AWS Console and navigate to the Cloudwatch section. Locate the Logging API logs group (this will be named <environment-name>-logging-api-docker-log-group).
+1. Login to the AWS Console and navigate to the Cloudwatch section. Locate the User API logs.
 1. Search the logs for the word "SubscriptionConfirmation"
 1. The result will be a long string which begins similarly to:
 ```


### PR DESCRIPTION
### What
Update documentation around confirming SNS subscriptions

Also remove references to "temp", now staging-london-temp and
staging-dublin-temp environments have been removed.

### Why
Documentation referenced the wrong log group. Now fixed.

Link to Trello card (if applicable): https://trello.com/c/BdeRMbFs/1820-practice-bringing-up-a-new-account-from-scratch-in-dr-account
