### PR TITLE
Drop the min_capacity for the Logging API down to 2

### DIFF
--- a/govwifi-api/logging-scaling-policy.tf
+++ b/govwifi-api/logging-scaling-policy.tf
@@ -3,7 +3,7 @@ resource "aws_appautoscaling_target" "logging_ecs_target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.logging_api_service[0].name}"
   max_capacity       = 20
-  min_capacity       = 5
+  min_capacity       = 2
   scalable_dimension = "ecs:service:DesiredCount"
 }
 


### PR DESCRIPTION
### What
Drop the min_capacity for the Logging API down to 2

### Why
Now that the Logging API is running with more threads, I think it can
process more requests in parallel, removing the need to run so many
tasks.


Link to Trello card: https://trello.com/c/0Qjq8a5b/1879-drop-the-mincapacity-for-the-logging-api-down-to-2