### PR TITLE
Enable AWS Insights on ECS Clusters

### DIFF
--- a/govwifi-api/cluster.tf
+++ b/govwifi-api/cluster.tf
@@ -1,4 +1,8 @@
 resource "aws_ecs_cluster" "api_cluster" {
   name = "${var.env_name}-api-cluster"
-}
 
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -2,6 +2,11 @@
 
 resource "aws_ecs_cluster" "frontend_cluster" {
   name = "${var.env_name}-frontend-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "frontend_log_group" {


### PR DESCRIPTION
### What
Enable AWS Insights on ECS Clusters

### Why
This will help us when diagnosing issues. You can find more information on ECS
Insights here:
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-cluster.html

