### PR TITLE
Fix an issue with the Logging API task definition

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -76,7 +76,7 @@ resource "aws_ecs_task_definition" "logging_api_task" {
           "value": "ips-and-locations.json"
         },{
           "name": "VOLUMETRICS_ENDPOINT",
-          "valueFrom": "${var.elasticsearch_endpoint}"
+          "value": "${var.elasticsearch_endpoint}"
         }
       ],
       "secrets": [

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -516,7 +516,7 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
           "value": "${var.metrics_bucket_name}"
         },{
           "name": "VOLUMETRICS_ENDPOINT",
-          "valueFrom": "${var.elasticsearch_endpoint}"
+          "value": "${var.elasticsearch_endpoint}"
         }
       ],
       "secrets": [


### PR DESCRIPTION
### What
Fix an issue with the Logging API task definition

### Why
The change in 2e68072df39f596175aff35fc0e54b8c0453f25c was wrong, the
VOLUMETRICS_ENDPOINT value can't be valueFrom, since it's now not a
secret.