### PR TITLE
Drop the min_capacity for the Authentication API down to 2

### DIFF
--- a/govwifi-api/scaling-policy.tf
+++ b/govwifi-api/scaling-policy.tf
@@ -2,7 +2,7 @@ resource "aws_appautoscaling_target" "auth_ecs_target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.authorisation_api_service.name}"
   max_capacity       = 20
-  min_capacity       = 5
+  min_capacity       = 2
   scalable_dimension = "ecs:service:DesiredCount"
 }
 


### PR DESCRIPTION
### What
Drop the min_capacity for the Authentication API down to 2

### Why
Now that the Authentication API is running with more threads, I think
it can process more requests in parallel, removing the need to run so
many tasks.


Link to Trello card: https://trello.com/c/80hoHxer/1881-use-more-threads-for-the-authentication-api-and-less-tasks