### PR TITLE
Remove an old SNS subscription

### DIFF
--- a/govwifi-emails/s3sns.tf
+++ b/govwifi-emails/s3sns.tf
@@ -189,16 +189,6 @@ EOF
 
 }
 
-# Subscription
-resource "aws_sns_topic_subscription" "email_notifications_target" {
-  topic_arn                       = aws_sns_topic.govwifi_email_notifications.arn
-  protocol                        = "https"
-  endpoint                        = var.sns_endpoint
-  endpoint_auto_confirms          = true
-  confirmation_timeout_in_minutes = 2
-  depends_on                      = [aws_sns_topic.govwifi_email_notifications]
-}
-
 # SNS topic to notify the new user-signup API when an email arrives
 resource "aws_sns_topic" "user_signup_notifications" {
   name         = "${var.env_name}-user-signup-notifications"

--- a/govwifi-emails/variables.tf
+++ b/govwifi-emails/variables.tf
@@ -22,9 +22,6 @@ variable "aws_region_name" {
 variable "mail_exchange_server" {
 }
 
-variable "sns_endpoint" {
-}
-
 variable "user_signup_notifications_endpoint" {
   description = "HTTP endpoint used by SNS to send user signup email notifications"
 }

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -141,10 +141,6 @@ module "emails" {
   devops_notifications_arn = module.notifications.topic_arn
 
   user_signup_notifications_endpoint = "https://user-signup-api.${local.env_subdomain}.service.gov.uk:8443/user-signup/email-notification"
-
-  // The SNS endpoint is disabled in the secondary AWS account
-  // We will conduct an SNS inventory (see this card: https://trello.com/c/EMeet3tl/315-investigate-and-inventory-sns-topics)
-  sns_endpoint = ""
 }
 
 module "govwifi_keys" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -154,8 +154,6 @@ module "emails" {
   mail_exchange_server     = "10 inbound-smtp.eu-west-1.amazonaws.com"
   devops_notifications_arn = module.devops_notifications.topic_arn
 
-  #sns-endpoint             = "https://elb.${lower(var.aws_region_name)}.${var.env_subdomain}.service.gov.uk/sns/"
-  sns_endpoint                       = "https://elb.london.${local.env_subdomain}.service.gov.uk/sns/"
   user_signup_notifications_endpoint = "https://user-signup-api.${local.env_subdomain}.service.gov.uk:8443/user-signup/email-notification"
 }
 


### PR DESCRIPTION
### What
Remove an old SNS subscription

The subscription exists in production, but doesn't look to have a
valid endpoint. It doesn't exist in staging.

### Why
I believe there was a transition to a new topic/subscription beginning
back in 2018 [1].

1: 184998c48748e3eaa22842cfc34a7a5ff3dbfead


Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account