### PR TITLE
Re-add some policies to the deploy smoketest user

### DIFF
--- a/govwifi-account/iam-users.tf
+++ b/govwifi-account/iam-users.tf
@@ -75,3 +75,20 @@ resource "aws_iam_user" "monitoring_stats_user" {
   path          = "/"
   force_destroy = false
 }
+
+# User policy attachments
+
+resource "aws_iam_user_policy_attachment" "deploy_smoketest_container_service_events_role" {
+  user       = aws_iam_user.govwifi_pipeline_deploy_smoketest.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole"
+}
+
+resource "aws_iam_user_policy_attachment" "deploy_smoketest_ec2_container_registry_power_user" {
+  user       = aws_iam_user.govwifi_pipeline_deploy_smoketest.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
+resource "aws_iam_user_policy_attachment" "deploy_smoketest_read_wordlist" {
+  user       = aws_iam_user.govwifi_pipeline_deploy_smoketest.name
+  policy_arn = "arn:aws:iam::${var.aws_account_id}:policy/read-wordlist-policy"
+}


### PR DESCRIPTION
### What
These were removed from the GovWifi-Pipeline group in [1], which the
govwifi-pipeline-deploy-smoketest user is a member, which broke the
push-to-ecr bit of the smoke-tests pipeline in Concourse.

1: 17d908d852ab353bfae34b14a65364be747ca214

### Why
I've added these back, but attached specificly to the user, rather
than the group. This makes it much clearer where they are needed.

Hopefully in the long term, this stuff related to smoke-tests can be
extracted in to an isolated bit of Terraform, maybe a module.


Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account