### PR TITLE
Backup mysql rds refactoring

### DIFF
--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -260,7 +260,6 @@ module "api" {
   authentication_sentry_dsn = var.auth_sentry_dsn
   safe_restart_sentry_dsn   = ""
   subnet_ids                = module.backend.backend_subnet_ids
-  backup_mysql_rds          = false
   rds_mysql_backup_bucket   = module.backend.rds_mysql_backup_bucket
 
   admin_app_data_s3_bucket_name = data.terraform_remote_state.london.outputs.admin_app_data_s3_bucket_name

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -3,6 +3,8 @@ locals {
   env_subdomain = "staging.wifi" # Environment specific subdomain to use under the service domain
 
   product_name = "GovWifi"
+
+  backup_mysql_rds = true
 }
 
 locals {

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -116,7 +116,7 @@ module "backend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
   grafana_ip            = var.grafana_ip
 
-  backup_mysql_rds = var.backup_mysql_rds
+  backup_mysql_rds = local.backup_mysql_rds
 
   db_storage_alarm_threshold = 19327342936
 }
@@ -289,7 +289,7 @@ module "api" {
   export_data_bucket_name = module.govwifi_dashboard.export_data_bucket_name
 
   rds_mysql_backup_bucket = module.backend.rds_mysql_backup_bucket
-  backup_mysql_rds        = var.backup_mysql_rds
+  backup_mysql_rds        = local.backup_mysql_rds
 
   low_cpu_threshold = 0.3
 

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -97,9 +97,3 @@ variable "prometheus_ip_ireland" {
 
 variable "grafana_ip" {
 }
-
-variable "backup_mysql_rds" {
-  description = "Conditional to indicate whether to make artifacts for and run RDS MySQL backups."
-  default     = true
-  type        = bool
-}

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -3,6 +3,8 @@ locals {
   env_subdomain = "wifi" # Environment specific subdomain to use under the service domain
 
   product_name = "GovWifi"
+
+  backup_mysql_rds = true
 }
 
 locals {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -129,7 +129,7 @@ module "backend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
   grafana_ip            = var.grafana_ip
 
-  backup_mysql_rds = var.backup_mysql_rds
+  backup_mysql_rds = local.backup_mysql_rds
 
   db_storage_alarm_threshold = 32212254720
 }

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -106,9 +106,3 @@ variable "prometheus_ip_ireland" {
 
 variable "grafana_ip" {
 }
-
-variable "backup_mysql_rds" {
-  description = "Conditional to indicate whether to make artifacts for and run RDS MySQL backups."
-  default     = true
-  type        = bool
-}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -264,7 +264,6 @@ module "api" {
   subnet_ids                = module.backend.backend_subnet_ids
   user_db_hostname          = var.user_db_hostname
   user_rr_hostname          = var.user_rr_hostname
-  backup_mysql_rds          = false
   rds_mysql_backup_bucket   = module.backend.rds_mysql_backup_bucket
 
   backend_sg_list = [


### PR DESCRIPTION
### What
Don't specify defaults, and use local rather than a variable.

### Why
Just neatening things up, less Terraform is better.


Link to Trello card: https://trello.com/c/ZdQrfyg7/1898-backupmysqlrds-refactoring-in-govwifi-terraform