### PR TITLE
Change var.backup_mysql_rds to local.backup_mysql_rds

### DIFF
--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -295,7 +295,7 @@ module "api" {
   metrics_bucket_name     = module.govwifi_dashboard.metrics_bucket_name
   export_data_bucket_name = module.govwifi_dashboard.export_data_bucket_name
 
-  backup_mysql_rds        = var.backup_mysql_rds
+  backup_mysql_rds        = local.backup_mysql_rds
   rds_mysql_backup_bucket = module.backend.rds_mysql_backup_bucket
 
   low_cpu_threshold = 10


### PR DESCRIPTION
### What
Change var.backup_mysql_rds to local.backup_mysql_rds

### Why
In the wifi-london environment. This was missed in
871d7c83c31f231955a6601d1358eb7ff818da52.


Link to Trello card: https://trello.com/c/ZdQrfyg7/1898-backupmysqlrds-refactoring-in-govwifi-terraform