### PR TITLE
Add https:// to the VOLUMETRICS_ENDPOINT for the Logging API

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -76,7 +76,7 @@ resource "aws_ecs_task_definition" "logging_api_task" {
           "value": "ips-and-locations.json"
         },{
           "name": "VOLUMETRICS_ENDPOINT",
-          "value": "${var.elasticsearch_endpoint}"
+          "value": "https://${var.elasticsearch_endpoint}"
         }
       ],
       "secrets": [

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -516,7 +516,7 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
           "value": "${var.metrics_bucket_name}"
         },{
           "name": "VOLUMETRICS_ENDPOINT",
-          "value": "${var.elasticsearch_endpoint}"
+          "value": "https://${var.elasticsearch_endpoint}"
         }
       ],
       "secrets": [


### PR DESCRIPTION
### What
Add https:// to the VOLUMETRICS_ENDPOINT for the Logging API

### Why
This not having https:// was a regression introduced in
2e68072df39f596175aff35fc0e54b8c0453f25c when this was set via
Terraform directly, rather than having the task use a value from a
secret.

Not including a protocol can work, but it seems like it's necessary in
this case to get the Elasticsearch client to use port 443 to talk to
the endpoint.


Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account