### PR TITLE
Move the wordlist bucket

### DIFF
--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -92,7 +92,7 @@ resource "aws_iam_policy" "read_wordlist_policy" {
         "s3:GetBucketVersioning",
         "s3:ListBucket"
       ],
-      "Resource": "arn:aws:s3:::govwifi-${var.env_subdomain}-wordlist"
+      "Resource": "${aws_s3_bucket.wordlist[0].arn}"
     },
     {
       "Sid": "readWordListPolicy1",
@@ -104,7 +104,7 @@ resource "aws_iam_policy" "read_wordlist_policy" {
         "s3:GetObjectVersion",
         "s3:PutObjectVersionAcl"
       ],
-      "Resource": "arn:aws:s3:::govwifi-${var.env_subdomain}-wordlist/*"
+      "Resource": "${aws_s3_bucket.wordlist[0].arn}/*"
     }
   ]
 }

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -170,10 +170,6 @@ variable "low_cpu_threshold" {
   type        = number
 }
 
-variable "is_production_aws_account" {
-  default = true
-}
-
 variable "rds_mysql_backup_bucket" {
 }
 

--- a/govwifi-api/wordlist.tf
+++ b/govwifi-api/wordlist.tf
@@ -1,10 +1,12 @@
 resource "aws_s3_bucket" "wordlist" {
-  bucket = var.is_production_aws_account ? "govwifi-wordlist" : "govwifi-${var.env_name}-wordlist"
-  count  = var.create_wordlist_bucket ? 1 : 0
-  acl    = "private"
+  count = var.create_wordlist_bucket ? 1 : 0
+
+  bucket_prefix = "wordlist"
+  acl           = "private"
 
   tags = {
-    Name = var.is_production_aws_account ? "wordlist-bucket" : "wordlist-${var.env_name}-bucket"
+    Name = "wordlist"
+    Env  = title(var.env_name)
   }
 
   versioning {

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -216,11 +216,10 @@ module "api" {
     aws = aws.main
   }
 
-  source                    = "../../govwifi-api"
-  env                       = "staging"
-  env_name                  = "staging"
-  env_subdomain             = local.env_subdomain
-  is_production_aws_account = false
+  source        = "../../govwifi-api"
+  env           = "staging"
+  env_name      = "staging"
+  env_subdomain = local.env_subdomain
 
   backend_elb_count      = 1
   backend_instance_count = 2

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -235,11 +235,10 @@ module "api" {
     aws = aws.main
   }
 
-  source                    = "../../govwifi-api"
-  env                       = "staging"
-  env_name                  = "staging"
-  env_subdomain             = local.env_subdomain
-  is_production_aws_account = false
+  source        = "../../govwifi-api"
+  env           = "staging"
+  env_name      = "staging"
+  env_subdomain = local.env_subdomain
 
   backend_elb_count      = 1
   backend_instance_count = 2


### PR DESCRIPTION
### What
Switch the wordlist bucket to use a bucket prefix.

### Why
This is a rigorous way of ensuring the buckets have different names in
different environments, without having to put the environment or
subdomain in to the bucket name.

This bucket is used in the deploy pipeline, so after this change is
applied, the pipeline will need updating with the name of the
bucket. This name will be a little ugly compared with the previous
name, but I think this is OK, the name shouldn't change regularly.



Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account
