### PR TITLE
Tweak the frontend certs bucket

### DIFF
--- a/govwifi-account/iam-roles.tf
+++ b/govwifi-account/iam-roles.tf
@@ -434,28 +434,6 @@ POLICY
 
 }
 
-resource "aws_iam_role" "Dublin_frontend_ecs_task_role_wifi" {
-  name = "Dublin-frontend-ecs-task-role-wifi"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ecs-tasks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_role" "Dublin_wifi_backend_bastion_instance_role" {
   name = "Dublin-wifi-backend-bastion-instance-role"
   path = "/"
@@ -920,28 +898,6 @@ resource "aws_iam_role" "London_frontend_ecs_instance_role_wifi" {
       "Effect": "Allow",
       "Principal": {
         "Service": "ec2.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role" "London_frontend_ecs_task_role_wifi" {
-  name = "London-frontend-ecs-task-role-wifi"
-  path = "/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ecs-tasks.amazonaws.com"
       },
       "Action": "sts:AssumeRole"
     }
@@ -1546,80 +1502,6 @@ POLICY
 
 }
 
-resource "aws_iam_role_policy" "Dublin_frontend_ecs_task_role_wifi_Dublin_frontend_admin_bucket_wifi" {
-  name = "Dublin-frontend-admin-bucket-wifi"
-  role = "Dublin-frontend-ecs-task-role-wifi"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::govwifi-production-admin/*",
-        "arn:aws:s3:::govwifi-production-admin"
-      ]
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "Dublin_frontend_ecs_task_role_wifi_Dublin_frontend_cert_bucket_wifi" {
-  name = "Dublin-frontend-cert-bucket-wifi"
-  role = "Dublin-frontend-ecs-task-role-wifi"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::govwifi-production-dublin-frontend-cert/*",
-        "arn:aws:s3:::govwifi-production-dublin-frontend-cert"
-      ]
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "Dublin_frontend_ecs_task_role_wifi_Dublin_frontend_ecs_service_policy_wifi" {
-  name = "Dublin-frontend-ecs-service-policy-wifi"
-  role = "Dublin-frontend-ecs-task-role-wifi"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:AuthorizeSecurityGroupIngress",
-        "ec2:Describe*"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-POLICY
-
-}
-
 resource "aws_iam_role_policy" "Dublin_wifi_backend_bastion_instance_role_Dublin_wifi_backend_bastion_instance_policy" {
   name = "Dublin-wifi-backend-bastion-instance-policy"
   role = "Dublin-wifi-backend-bastion-instance-role"
@@ -1951,80 +1833,6 @@ resource "aws_iam_role_policy" "London_frontend_ecs_instance_role_wifi_London_fr
         "cloudwatch:GetMetricStatistics",
         "cloudwatch:ListMetrics",
         "ec2:DescribeTags"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "London_frontend_ecs_task_role_wifi_London_frontend_admin_bucket_wifi" {
-  name = "London-frontend-admin-bucket-wifi"
-  role = "London-frontend-ecs-task-role-wifi"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::govwifi-production-admin/*",
-        "arn:aws:s3:::govwifi-production-admin"
-      ]
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "London_frontend_ecs_task_role_wifi_London_frontend_cert_bucket_wifi" {
-  name = "London-frontend-cert-bucket-wifi"
-  role = "London-frontend-ecs-task-role-wifi"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::govwifi-production-london-frontend-cert/*",
-        "arn:aws:s3:::govwifi-production-london-frontend-cert"
-      ]
-    }
-  ]
-}
-POLICY
-
-}
-
-resource "aws_iam_role_policy" "London_frontend_ecs_task_role_wifi_London_frontend_ecs_service_policy_wifi" {
-  name = "London-frontend-ecs-service-policy-wifi"
-  role = "London-frontend-ecs-task-role-wifi"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:AuthorizeSecurityGroupIngress",
-        "ec2:Describe*"
       ],
       "Resource": "*"
     }

--- a/govwifi-frontend/certs.tf
+++ b/govwifi-frontend/certs.tf
@@ -20,3 +20,10 @@ resource "aws_s3_bucket" "frontend_cert_bucket" {
     enabled = true
   }
 }
+
+resource "aws_ssm_parameter" "frontend_cert_bucket" {
+  name        = "/govwifi-terraform/frontend-certs-${var.aws_region_name}-bucket"
+  description = "Name of the frontend-certs bucket for ${var.aws_region_name}"
+  type        = "String"
+  value       = aws_s3_bucket.frontend_cert_bucket.bucket
+}

--- a/govwifi-frontend/certs.tf
+++ b/govwifi-frontend/certs.tf
@@ -1,5 +1,4 @@
 resource "aws_s3_bucket" "frontend_cert_bucket" {
-  count  = 1
   bucket = var.is_production_aws_account ? "govwifi-${var.rack_env}-${lower(var.aws_region_name)}-frontend-cert" : "govwifi-${var.env_subdomain}-${lower(var.aws_region_name)}-frontend-cert"
   acl    = "private"
 

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -150,7 +150,7 @@ resource "aws_ecs_task_definition" "radius_task" {
         "value": "s3://${var.admin_app_data_s3_bucket_name}"
       },{
         "name": "CERT_STORE_BUCKET",
-        "value": "s3://${aws_s3_bucket.frontend_cert_bucket[0].bucket}"
+        "value": "s3://${aws_s3_bucket.frontend_cert_bucket.bucket}"
       }
     ],
     "image": "${var.raddb_docker_image}",

--- a/govwifi-frontend/iam-roles.tf
+++ b/govwifi-frontend/iam-roles.tf
@@ -139,8 +139,8 @@ data "aws_iam_policy_document" "cert_bucket_policy" {
     ]
 
     resources = [
-      aws_s3_bucket.frontend_cert_bucket[0].arn,
-      "${aws_s3_bucket.frontend_cert_bucket[0].arn}/*",
+      aws_s3_bucket.frontend_cert_bucket.arn,
+      "${aws_s3_bucket.frontend_cert_bucket.arn}/*",
     ]
   }
 }


### PR DESCRIPTION
### What

 - Remove a redundant count from the bucket resource
 - Remove related duplicated IAM bits
 - Add a parameter that contains the name of the bucket

### Why
Cleanup, plus creating the parameters necessary to make the changes in https://github.com/alphagov/govwifi-build/pull/517 work.


Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account