### PR TITLE
Add a dash to the wordlist bucket prefix

### DIFF
--- a/govwifi-api/wordlist.tf
+++ b/govwifi-api/wordlist.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "wordlist" {
   count = var.create_wordlist_bucket ? 1 : 0
 
-  bucket_prefix = "wordlist"
+  bucket_prefix = "wordlist-"
   acl           = "private"
 
   tags = {


### PR DESCRIPTION
### What
Add a dash to the wordlist bucket prefix

### Why
As this makes the bucket name easier to read.

It'll be like `wordlist-20211214152444697600000001` rather than `wordlist20211214152444697600000001`.


Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account
