### PR TITLE
Remove the region from the frontend certs bucket parameter name

### DIFF
--- a/govwifi-frontend/certs.tf
+++ b/govwifi-frontend/certs.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket" "frontend_cert_bucket" {
 }
 
 resource "aws_ssm_parameter" "frontend_cert_bucket" {
-  name        = "/govwifi-terraform/frontend-certs-${var.aws_region_name}-bucket"
+  name        = "/govwifi-terraform/frontend-certs-bucket"
   description = "Name of the frontend-certs bucket for ${var.aws_region_name}"
   type        = "String"
   value       = aws_s3_bucket.frontend_cert_bucket.bucket


### PR DESCRIPTION
### What
Remove the region from the frontend certs bucket parameter name

### Why
This is London or Dublin, which I now see is both redundant, and
doesn't really match the styling for the rest of the name.

Since the parameters just exist in one region, don't include the
region in the name.



Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account