### PR TITLE
Change the name of the frontend certs buckets

### DIFF
--- a/govwifi-frontend/certs.tf
+++ b/govwifi-frontend/certs.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "frontend_cert_bucket" {
-  bucket = var.is_production_aws_account ? "govwifi-${var.rack_env}-${lower(var.aws_region_name)}-frontend-cert" : "govwifi-${var.env_subdomain}-${lower(var.aws_region_name)}-frontend-cert"
-  acl    = "private"
+  bucket_prefix = "frontend-cert-${lower(var.aws_region_name)}-"
+  acl           = "private"
 
   tags = {
     Name        = "${title(var.env_name)} Frontend certs"

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -90,7 +90,3 @@ variable "prometheus_ip_london" {
 
 variable "prometheus_ip_ireland" {
 }
-
-variable "is_production_aws_account" {
-  default = true
-}

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -167,10 +167,9 @@ module "frontend" {
     aws.us_east_1 = aws.us_east_1
   }
 
-  source                    = "../../govwifi-frontend"
-  env_name                  = local.env_name
-  env_subdomain             = local.env_subdomain
-  is_production_aws_account = false
+  source        = "../../govwifi-frontend"
+  env_name      = local.env_name
+  env_subdomain = local.env_subdomain
 
   # AWS VPC setup -----------------------------------------
   aws_region         = var.aws_region

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -128,10 +128,9 @@ module "frontend" {
     aws.us_east_1 = aws.us_east_1
   }
 
-  source                    = "../../govwifi-frontend"
-  env_name                  = local.env_name
-  env_subdomain             = local.env_subdomain
-  is_production_aws_account = false
+  source        = "../../govwifi-frontend"
+  env_name      = local.env_name
+  env_subdomain = local.env_subdomain
 
   # AWS VPC setup -----------------------------------------
   # LONDON


### PR DESCRIPTION
### What
Change the name of the frontend certs buckets

### Why
Cleanup from the staging migration.


Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account