### PR TITLE
Fix the frontend cert bucket access for govwifi-deploy-pipeline

### DIFF
--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -50,30 +50,6 @@ resource "aws_iam_user" "govwifi_deploy_pipeline" {
   force_destroy = false
 }
 
-resource "aws_iam_policy" "govwifi_sync_cert_access" {
-  count       = var.create_wordlist_bucket ? 1 : 0
-  name        = "govwifi-sync-cert-access"
-  path        = "/"
-  description = "Allows deploy pipeline to access S3 buckets containing SSL certificates"
-
-  policy = <<POLICY
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "govwifiSyncCertAccess",
-            "Effect": "Allow",
-            "Action": "s3:PutObject",
-            "Resource": [
-                "arn:aws:s3:::govwifi-${var.env_subdomain}-london-frontend-cert/*",
-                "arn:aws:s3:::govwifi-${var.env_subdomain}-dublin-frontend-cert/*"
-            ]
-        }
-    ]
-}
-POLICY
-}
-
 resource "aws_iam_policy" "read_wordlist_policy" {
   count       = var.create_wordlist_bucket ? 1 : 0
   name        = "read-wordlist-policy"
@@ -136,12 +112,6 @@ resource "aws_iam_policy" "read_ssm_parameters" {
 }
 POLICY
 
-}
-
-resource "aws_iam_user_policy_attachment" "govwifi_sync_cert_access_policy_attachment" {
-  count      = var.create_wordlist_bucket ? 1 : 0
-  user       = aws_iam_user.govwifi_deploy_pipeline[0].name
-  policy_arn = aws_iam_policy.govwifi_sync_cert_access[0].arn
 }
 
 resource "aws_iam_user_policy_attachment" "govwifi_read_wordlist_policy_attachment" {

--- a/govwifi-frontend/certs.tf
+++ b/govwifi-frontend/certs.tf
@@ -27,3 +27,31 @@ resource "aws_ssm_parameter" "frontend_cert_bucket" {
   type        = "String"
   value       = aws_s3_bucket.frontend_cert_bucket.bucket
 }
+
+resource "aws_iam_policy" "govwifi_frontend_cert_bucket_access" {
+  name = "govwifi-sync-cert-access-${lower(var.aws_region_name)}"
+
+  path        = "/"
+  description = "Allows govwifi-deploy-pipeline to write to the cert bucket."
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "govwifiSyncCertAccess",
+            "Effect": "Allow",
+            "Action": "s3:PutObject",
+            "Resource": [
+                "${aws_s3_bucket.frontend_cert_bucket.arn}/*"
+            ]
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_user_policy_attachment" "govwifi_sync_cert_access_policy_attachment" {
+  user       = "govwifi-deploy-pipeline" # TODO This should reference the resource
+  policy_arn = aws_iam_policy.govwifi_frontend_cert_bucket_access.arn
+}


### PR DESCRIPTION
### What
Fix the frontend cert bucket access for govwifi-deploy-pipeline

### Why
Rather than assuming this is not production and building the bucket
ARN with the env_subdomain, move the policy to the govwifi-frontend
module so that the actual ARN for the bucket can be easily accessed.

This probably should be in neither module, and something associated
with the pipelines, but that doesn't exist yet.


Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account