### PR TITLE
Move Staging GovWifi Email Module To London (eu-west-2 region)

### DIFF
--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -122,27 +122,6 @@ module "backend" {
   db_storage_alarm_threshold = 19327342936
 }
 
-# Emails ======================================================================
-module "emails" {
-  providers = {
-    aws = aws.main
-  }
-
-  source = "../../govwifi-emails"
-
-  product_name             = local.product_name
-  env_name                 = local.env_name
-  env_subdomain            = local.env_subdomain
-  aws_account_id           = local.aws_account_id
-  route53_zone_id          = data.aws_route53_zone.main.zone_id
-  aws_region               = var.aws_region
-  aws_region_name          = var.aws_region_name
-  mail_exchange_server     = "10 inbound-smtp.eu-west-1.amazonaws.com"
-  devops_notifications_arn = module.notifications.topic_arn
-
-  user_signup_notifications_endpoint = "https://user-signup-api.${local.env_subdomain}.service.gov.uk:8443/user-signup/email-notification"
-}
-
 module "govwifi_keys" {
   providers = {
     aws = aws.main

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -414,3 +414,24 @@ module "govwifi_datasync" {
   aws_region = var.aws_region
   rack_env   = "staging"
 }
+
+# Emails ======================================================================
+module "emails" {
+  providers = {
+    aws = aws.main
+  }
+
+  source = "../../govwifi-emails"
+
+  product_name             = local.product_name
+  env_name                 = local.env_name
+  env_subdomain            = local.env_subdomain
+  aws_account_id           = local.aws_account_id
+  route53_zone_id          = data.aws_route53_zone.main.zone_id
+  aws_region               = var.aws_region
+  aws_region_name          = var.aws_region_name
+  mail_exchange_server     = "10 inbound-smtp.eu-west-1.amazonaws.com"
+  devops_notifications_arn = module.notifications.topic_arn
+
+  user_signup_notifications_endpoint = "https://user-signup-api.${local.env_subdomain}.service.gov.uk:8443/user-signup/email-notification"
+}


### PR DESCRIPTION
### What
Move Staging GovWifi Email Module To London (eu-west-2 region)

### Why
This same change will be rolled out in production shortly.

The reasons for this change are:

- Most of GovWifi's critical infrastructure is in the London region already. It
  is jarring that SES and SNS resources are in Ireland. When the original
designers of GovWifi set up the infrastructure, they started building it in
Ireland but when Brexit occurred they switched the critical components to the
London region (the plan was to only use resources in Ireland as a backup if for
some reason the London region went down). At the moment the SES and SNS
resources only exist in Ireland (they are acting as primary resources not
backups). This is not inline with the pattern of the rest of our
infrastructure.

- Currently our AWS, SES and SNS resources are in the Ireland region of AWS. In
  order to complete this https://trello.com/c/QSO59546/1889-lockdown-requests-coming-into-the-user-signup
we need them to be in the London region.

Link to Trello card (if applicable): https://trello.com/c/i8dTYqJD/1929-migrate-govwifi-emails-sns-resources-to-london-region
