### PR TITLE
Use Secrets Manager secrets for Sentry DSNs

### DIFF
--- a/govwifi/staging-dublin/locals.tf
+++ b/govwifi/staging-dublin/locals.tf
@@ -6,6 +6,11 @@ locals {
 }
 
 locals {
+  authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
+  safe_restarter_sentry_dsn     = data.aws_secretsmanager_secret_version.safe_restarter_sentry_dsn.secret_string
+}
+
+locals {
   aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
 }
 

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -251,8 +251,8 @@ module "api" {
   rack_env                  = "staging"
   sentry_current_env        = "secondary-staging"
   radius_server_ips         = local.frontend_radius_ips
-  authentication_sentry_dsn = var.auth_sentry_dsn
-  safe_restart_sentry_dsn   = ""
+  authentication_sentry_dsn = local.authentication_api_sentry_dsn
+  safe_restart_sentry_dsn   = local.safe_restarter_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids
   rds_mysql_backup_bucket   = module.backend.rds_mysql_backup_bucket
 

--- a/govwifi/staging-dublin/secrets-manager.tf
+++ b/govwifi/staging-dublin/secrets-manager.tf
@@ -13,3 +13,21 @@ data "aws_secretsmanager_secret_version" "docker_image_path" {
 data "aws_secretsmanager_secret" "docker_image_path" {
   name = "aws/ecr/docker-image-path/govwifi"
 }
+
+# Sentry
+
+data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
+  name = "sentry/authentication_api_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
+}
+
+data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
+  name = "sentry/safe_restarter_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "safe_restarter_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.id
+}

--- a/govwifi/staging-dublin/variables.tf
+++ b/govwifi/staging-dublin/variables.tf
@@ -45,10 +45,6 @@ variable "user_rr_hostname" {
   default     = "users-rr.dublin.staging.wifi.service.gov.uk"
 }
 
-variable "auth_sentry_dsn" {
-  type = string
-}
-
 variable "notification_email" {
 }
 

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -8,6 +8,14 @@ locals {
 }
 
 locals {
+  authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
+  safe_restarter_sentry_dsn     = data.aws_secretsmanager_secret_version.safe_restarter_sentry_dsn.secret_string
+  user_signup_api_sentry_dsn    = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
+  logging_api_sentry_dsn        = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
+  admin_sentry_dsn              = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
+}
+
+locals {
   aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
 }
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -217,7 +217,7 @@ module "govwifi_admin" {
 
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
-  sentry_dsn                 = var.admin_sentry_dsn
+  sentry_dsn                 = local.admin_sentry_dsn
   logging_api_search_url     = "https://api-elb.london.${local.env_subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
   public_google_api_key      = var.public_google_api_key
 
@@ -270,10 +270,10 @@ module "api" {
   rack_env                  = "staging"
   sentry_current_env        = "secondary-staging"
   radius_server_ips         = local.frontend_radius_ips
-  authentication_sentry_dsn = var.auth_sentry_dsn
-  safe_restart_sentry_dsn   = var.safe_restart_sentry_dsn
-  user_signup_sentry_dsn    = var.user_signup_sentry_dsn
-  logging_sentry_dsn        = var.logging_sentry_dsn
+  authentication_sentry_dsn = local.authentication_api_sentry_dsn
+  safe_restart_sentry_dsn   = local.safe_restarter_sentry_dsn
+  user_signup_sentry_dsn    = local.user_signup_api_sentry_dsn
+  logging_sentry_dsn        = local.logging_api_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids
   user_signup_api_is_public = 1
 

--- a/govwifi/staging-london/secrets-manager.tf
+++ b/govwifi/staging-london/secrets-manager.tf
@@ -13,3 +13,45 @@ data "aws_secretsmanager_secret_version" "docker_image_path" {
 data "aws_secretsmanager_secret" "docker_image_path" {
   name = "aws/ecr/docker-image-path/govwifi"
 }
+
+# Sentry
+
+data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
+  name = "sentry/authentication_api_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
+}
+
+data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
+  name = "sentry/safe_restarter_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "safe_restarter_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.id
+}
+
+data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
+  name = "sentry/user_signup_api_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "user_signup_api_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.id
+}
+
+data "aws_secretsmanager_secret" "logging_api_sentry_dsn" {
+  name = "sentry/logging_api_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "logging_api_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.logging_api_sentry_dsn.id
+}
+
+data "aws_secretsmanager_secret" "admin_sentry_dsn" {
+  name = "sentry/admin_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "admin_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.admin_sentry_dsn.id
+}

--- a/govwifi/staging-london/variables.tf
+++ b/govwifi/staging-london/variables.tf
@@ -28,29 +28,9 @@ variable "ami" {
 
 # Secrets
 
-variable "auth_sentry_dsn" {
-  type = string
-}
-
-variable "safe_restart_sentry_dsn" {
-  type = string
-}
-
 variable "public_google_api_key" {
   type    = string
   default = "xxxxxxxxxxxxxxxxxxxxx"
-}
-
-variable "user_signup_sentry_dsn" {
-  type = string
-}
-
-variable "logging_sentry_dsn" {
-  type = string
-}
-
-variable "admin_sentry_dsn" {
-  type = string
 }
 
 variable "user_db_hostname" {

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -8,6 +8,14 @@ locals {
 }
 
 locals {
+  authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
+  safe_restarter_sentry_dsn     = data.aws_secretsmanager_secret_version.safe_restarter_sentry_dsn.secret_string
+  user_signup_api_sentry_dsn    = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
+  logging_api_sentry_dsn        = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
+  admin_sentry_dsn              = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
+}
+
+locals {
   aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
 }
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -231,7 +231,7 @@ module "govwifi_admin" {
 
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
-  sentry_dsn                 = var.admin_sentry_dsn
+  sentry_dsn                 = local.admin_sentry_dsn
   public_google_api_key      = var.public_google_api_key
 
   logging_api_search_url = "https://api-elb.london.${local.env_subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
@@ -277,10 +277,10 @@ module "api" {
   rack_env                  = "production"
   sentry_current_env        = "production"
   radius_server_ips         = local.frontend_radius_ips
-  authentication_sentry_dsn = var.auth_sentry_dsn
-  safe_restart_sentry_dsn   = var.safe_restart_sentry_dsn
-  user_signup_sentry_dsn    = var.user_signup_sentry_dsn
-  logging_sentry_dsn        = var.logging_sentry_dsn
+  authentication_sentry_dsn = local.authentication_api_sentry_dsn
+  safe_restart_sentry_dsn   = local.safe_restarter_sentry_dsn
+  user_signup_sentry_dsn    = local.user_signup_api_sentry_dsn
+  logging_sentry_dsn        = local.logging_api_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids
   user_db_hostname          = var.user_db_hostname
   user_rr_hostname          = var.user_rr_hostname

--- a/govwifi/wifi-london/secrets-manager.tf
+++ b/govwifi/wifi-london/secrets-manager.tf
@@ -21,3 +21,45 @@ data "aws_secretsmanager_secret" "pagerduty_config" {
 data "aws_secretsmanager_secret_version" "pagerduty_config" {
   secret_id = data.aws_secretsmanager_secret.pagerduty_config.id
 }
+
+# Sentry
+
+data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
+  name = "sentry/authentication_api_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
+}
+
+data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
+  name = "sentry/safe_restarter_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "safe_restarter_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.id
+}
+
+data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
+  name = "sentry/user_signup_api_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "user_signup_api_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.id
+}
+
+data "aws_secretsmanager_secret" "logging_api_sentry_dsn" {
+  name = "sentry/logging_api_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "logging_api_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.logging_api_sentry_dsn.id
+}
+
+data "aws_secretsmanager_secret" "admin_sentry_dsn" {
+  name = "sentry/admin_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "admin_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.admin_sentry_dsn.id
+}

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -28,29 +28,9 @@ variable "ami" {
 
 # Secrets
 
-variable "auth_sentry_dsn" {
-  type = string
-}
-
-variable "safe_restart_sentry_dsn" {
-  type = string
-}
-
 variable "public_google_api_key" {
   type    = string
   default = "AIzaSyCz1cPYKamsA_ZJCygL9EY0Zq6stkazTco"
-}
-
-variable "user_signup_sentry_dsn" {
-  type = string
-}
-
-variable "logging_sentry_dsn" {
-  type = string
-}
-
-variable "admin_sentry_dsn" {
-  type = string
 }
 
 variable "user_db_hostname" {

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -6,6 +6,11 @@ locals {
 }
 
 locals {
+  authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
+  safe_restarter_sentry_dsn     = data.aws_secretsmanager_secret_version.safe_restarter_sentry_dsn.secret_string
+}
+
+locals {
   aws_account_id = jsondecode(data.aws_secretsmanager_secret_version.aws_account_id.secret_string)["account-id"]
 }
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -256,8 +256,8 @@ module "api" {
   rack_env                  = "production"
   sentry_current_env        = "production"
   radius_server_ips         = local.frontend_radius_ips
-  authentication_sentry_dsn = var.auth_sentry_dsn
-  safe_restart_sentry_dsn   = var.safe_restart_sentry_dsn
+  authentication_sentry_dsn = local.authentication_api_sentry_dsn
+  safe_restart_sentry_dsn   = local.safe_restarter_sentry_dsn
   user_signup_docker_image  = ""
   subnet_ids                = module.backend.backend_subnet_ids
   user_db_hostname          = var.user_db_hostname

--- a/govwifi/wifi/secrets-manager.tf
+++ b/govwifi/wifi/secrets-manager.tf
@@ -21,3 +21,21 @@ data "aws_secretsmanager_secret" "pagerduty_config" {
 data "aws_secretsmanager_secret_version" "pagerduty_config" {
   secret_id = data.aws_secretsmanager_secret.pagerduty_config.id
 }
+
+# Sentry
+
+data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
+  name = "sentry/authentication_api_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
+}
+
+data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
+  name = "sentry/safe_restarter_dsn"
+}
+
+data "aws_secretsmanager_secret_version" "safe_restarter_sentry_dsn" {
+  secret_id = data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.id
+}

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -38,14 +38,6 @@ variable "dublin_radius_ip_addresses" {
   description = "Frontend RADIUS server IP addresses - Dublin"
 }
 
-variable "auth_sentry_dsn" {
-  type = string
-}
-
-variable "safe_restart_sentry_dsn" {
-  type = string
-}
-
 variable "london_api_base_url" {
   type        = string
   description = "Base URL for authentication, user signup and logging APIs"


### PR DESCRIPTION
### What
Use Secrets Manager secrets for Sentry DSNs

### Why
I think this is neater, consolidating secrets in AWS rather than
keeping some in govwifi-build.

I'm looking at this as I'm interested in removing the dependency on
govwifi-build for running Terraform.

Deploying this will require manually creating the relevant secrets in
AWS.
