### PR TITLE
Allow to use trusted Administrator IPs in the CIDR format

### DIFF
--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -95,7 +95,7 @@ resource "aws_security_group" "be_vpn_in" {
     to_port   = 22
     protocol  = "tcp"
 
-    cidr_blocks = [for ip in var.administrator_ips : "${ip}/32"]
+    cidr_blocks = var.administrator_cidrs
   }
 }
 

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -22,7 +22,7 @@ variable "aws_region" {
 variable "aws_region_name" {
 }
 
-variable "administrator_ips" {
+variable "administrator_cidrs" {
 }
 
 variable "frontend_radius_ips" {

--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "grafana_alb_in" {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = [for ip in var.administrator_ips : "${ip}/32"]
+    cidr_blocks = var.administrator_cidrs
   }
 }
 

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -56,7 +56,7 @@ variable "subnet_ids" {
   type        = list(string)
 }
 
-variable "administrator_ips" {
+variable "administrator_cidrs" {
   description = "IPs associated with the GDS/CDIO VPN to allow access"
 }
 

--- a/govwifi/staging-dublin/firewall-variables.tf
+++ b/govwifi/staging-dublin/firewall-variables.tf
@@ -1,4 +1,4 @@
-variable "administrator_ips" {
+variable "administrator_cidrs" {
 }
 
 variable "bastion_server_ip" {

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -73,7 +73,7 @@ module "backend" {
   aws_region_name = var.aws_region_name
   vpc_cidr_block  = "10.104.0.0/16"
 
-  administrator_ips   = var.administrator_ips
+  administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
 
   # Instance-specific setup -------------------------------

--- a/govwifi/staging-london/firewall-variables.tf
+++ b/govwifi/staging-london/firewall-variables.tf
@@ -1,5 +1,5 @@
 variable "bastion_server_ip" {
 }
 
-variable "administrator_ips" {
+variable "administrator_cidrs" {
 }

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -80,7 +80,7 @@ module "backend" {
   aws_region_name = var.aws_region_name
   vpc_cidr_block  = "10.106.0.0/16"
 
-  administrator_ips   = var.administrator_ips
+  administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
 
   bastion_ami                = "ami-096cb92bb3580c759"
@@ -380,7 +380,7 @@ module "govwifi_grafana" {
 
   bastion_ip = var.bastion_server_ip
 
-  administrator_ips = var.administrator_ips
+  administrator_cidrs = var.administrator_cidrs
   prometheus_ips = [
     var.prometheus_ip_london,
     var.prometheus_ip_ireland

--- a/govwifi/wifi-london/firewall-variables.tf
+++ b/govwifi/wifi-london/firewall-variables.tf
@@ -1,5 +1,5 @@
 variable "bastion_server_ip" {
 }
 
-variable "administrator_ips" {
+variable "administrator_cidrs" {
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -91,7 +91,7 @@ module "backend" {
   route53_zone_id = data.aws_route53_zone.main.zone_id
   vpc_cidr_block  = "10.84.0.0/16"
 
-  administrator_ips   = var.administrator_ips
+  administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
 
   bastion_ami                = "ami-096cb92bb3580c759"
@@ -435,7 +435,7 @@ module "govwifi_grafana" {
 
   bastion_ip = var.bastion_server_ip
 
-  administrator_ips = var.administrator_ips
+  administrator_cidrs = var.administrator_cidrs
 
   prometheus_ips = [
     var.prometheus_ip_london,

--- a/govwifi/wifi/firewall-variables.tf
+++ b/govwifi/wifi/firewall-variables.tf
@@ -1,4 +1,4 @@
-variable "administrator_ips" {
+variable "administrator_cidrs" {
 }
 
 variable "bastion_server_ip" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -89,7 +89,7 @@ module "backend" {
   route53_zone_id = data.aws_route53_zone.main.zone_id
   vpc_cidr_block  = "10.42.0.0/16"
 
-  administrator_ips   = var.administrator_ips
+  administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
 
   # Instance-specific setup -------------------------------


### PR DESCRIPTION
### What
We need to accept IP values formatted as the CIDR standard to accommodate a new range of IP used by VPN DR.

### Why
Current code was enforcing use of single IPs.

Link to Trello card (if applicable): 
