### PR TITLE
Send staging London logs to Cyber for ITHC

### DIFF
--- a/govwifi-admin/log-subscription-filters.tf
+++ b/govwifi-admin/log-subscription-filters.tf
@@ -1,0 +1,20 @@
+# Cyber has requested we add these
+
+variable "staging_log_group_names" {
+  type = list(string)
+  default = [
+    "staging-admin-log-group",
+    "/aws/rds/instance/wifi-admin-staging-db/audit",
+    "/aws/rds/instance/wifi-admin-staging-db/error",
+    "/aws/rds/instance/wifi-admin-staging-db/slowquery"
+  ]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
+  count = var.env_name == "staging" ? length(var.staging_log_group_names) : 0
+
+  name            = "log_subscription_${count.index}"
+  log_group_name  = element(var.staging_log_group_names, count.index)
+  filter_pattern  = ""
+  destination_arn = "arn:aws:logs:eu-west-2:${var.cyber_account_id}:destination:csls_cw_logs_destination_prod"
+}

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -120,3 +120,6 @@ variable "public_google_api_key" {
 
 variable "bastion_server_ip" {
 }
+
+variable "cyber_account_id" {
+}

--- a/govwifi-api/log-subscription-filters.tf
+++ b/govwifi-api/log-subscription-filters.tf
@@ -1,0 +1,24 @@
+# Cyber has requested we add these
+
+variable "staging_log_group_names" {
+  type = list(string)
+  default = [
+    "staging-authorisation-api-docker-log-group",
+    "staging-logging-api-docker-log-group",
+    "staging-user-signup-api-docker-log-group",
+    "/aws/rds/instance/wifi-staging-user-db/error",
+    "/aws/rds/instance/wifi-staging-user-db/slowquery",
+    "/aws/rds/instance/wifi-staging-db/audit",
+    "/aws/rds/instance/wifi-staging-db/error",
+    "/aws/rds/instance/wifi-staging-db/slowquery"
+  ]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
+  count = var.env_name == "staging" ? length(var.staging_log_group_names) : 0
+
+  name            = "log_subscription_${count.index}"
+  log_group_name  = element(var.staging_log_group_names, count.index)
+  filter_pattern  = ""
+  destination_arn = "arn:aws:logs:eu-west-2:${var.cyber_account_id}:destination:csls_cw_logs_destination_prod"
+}

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -177,3 +177,6 @@ variable "elasticsearch_endpoint" {
   type    = string
   default = ""
 }
+
+variable "cyber_account_id" {
+}

--- a/govwifi-backend/log-subscription-filters.tf
+++ b/govwifi-backend/log-subscription-filters.tf
@@ -1,0 +1,23 @@
+# Cyber has requested we add these
+
+variable "staging_log_group_names" {
+  type = list(string)
+  default = [
+    "staging-database-backup-log-group",
+    "staging-database-backup-log-group",
+    "staging-bastion/var/log/auth.log",
+    "staging-bastion/var/log/cloud-init-output.log",
+    "staging-bastion/var/log/dmesg",
+    "staging-bastion/var/log/syslog",
+    "staging-bastion/var/log/unattended-upgrades/unattended-upgrades.log"
+  ]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
+  count = var.env_name == "staging" ? length(var.staging_log_group_names) : 0
+
+  name            = "log_subscription_${count.index}"
+  log_group_name  = element(var.staging_log_group_names, count.index)
+  filter_pattern  = ""
+  destination_arn = "arn:aws:logs:eu-west-2:${var.cyber_account_id}:destination:csls_cw_logs_destination_prod"
+}

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -130,3 +130,6 @@ variable "db_storage_alarm_threshold" {
   description = "DB storage threshold used for alarms. Value varies based on environment and storage average."
   type        = number
 }
+
+variable "cyber_account_id" {
+}

--- a/govwifi-frontend/log-subscription-filters.tf
+++ b/govwifi-frontend/log-subscription-filters.tf
@@ -1,0 +1,18 @@
+# Cyber has requested we add these
+
+variable "staging_log_group_names" {
+  type = list(string)
+  default = [
+    "staging-frontend-docker-log-group",
+    "staging-safe-restart-docker-log-group"
+  ]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
+  count = var.env_name == "staging" ? length(var.staging_log_group_names) : 0
+
+  name            = "log_subscription_${count.index}"
+  log_group_name  = element(var.staging_log_group_names, count.index)
+  filter_pattern  = ""
+  destination_arn = "arn:aws:logs:eu-west-2:${var.cyber_account_id}:destination:csls_cw_logs_destination_prod"
+}

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -90,3 +90,6 @@ variable "prometheus_ip_london" {
 
 variable "prometheus_ip_ireland" {
 }
+
+variable "cyber_account_id" {
+}

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -119,6 +119,7 @@ module "backend" {
   grafana_ip            = var.grafana_ip
 
   db_storage_alarm_threshold = 19327342936
+  cyber_account_id           = ""
 }
 
 # Emails ======================================================================
@@ -206,6 +207,7 @@ module "frontend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
+  cyber_account_id   = ""
 
 }
 
@@ -262,6 +264,7 @@ module "api" {
   ]
 
   low_cpu_threshold = 0.3
+  cyber_account_id  = ""
 }
 
 module "notifications" {

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -13,6 +13,7 @@ locals {
   user_signup_api_sentry_dsn    = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
   logging_api_sentry_dsn        = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
   admin_sentry_dsn              = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
+  cyber_account_id              = jsondecode(data.aws_secretsmanager_secret_version.cyber_account_id.secret_string)["id"]
 }
 
 locals {

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -118,6 +118,7 @@ module "backend" {
   backup_mysql_rds = local.backup_mysql_rds
 
   db_storage_alarm_threshold = 19327342936
+  cyber_account_id           = local.cyber_account_id
 }
 
 # London Frontend ==================================================================
@@ -170,6 +171,7 @@ module "frontend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
+  cyber_account_id   = local.cyber_account_id
 }
 
 module "govwifi_admin" {
@@ -226,6 +228,8 @@ module "govwifi_admin" {
   bastion_server_ip = var.bastion_server_ip
 
   notification_arn = module.notifications.topic_arn
+
+  cyber_account_id = local.cyber_account_id
 }
 
 module "api" {
@@ -291,6 +295,7 @@ module "api" {
   low_cpu_threshold = 0.3
 
   elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
+  cyber_account_id       = local.cyber_account_id
 }
 
 module "notifications" {

--- a/govwifi/staging-london/secrets-manager.tf
+++ b/govwifi/staging-london/secrets-manager.tf
@@ -47,3 +47,11 @@ data "aws_secretsmanager_secret" "admin_sentry_dsn" {
 data "aws_secretsmanager_secret_version" "admin_sentry_dsn" {
   secret_id = data.aws_secretsmanager_secret.admin_sentry_dsn.id
 }
+
+data "aws_secretsmanager_secret" "cyber_account_id" {
+  name = "cyber/account-id"
+}
+
+data "aws_secretsmanager_secret_version" "cyber_account_id" {
+  secret_id = data.aws_secretsmanager_secret.cyber_account_id.id
+}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -131,6 +131,8 @@ module "backend" {
   backup_mysql_rds = local.backup_mysql_rds
 
   db_storage_alarm_threshold = 32212254720
+  cyber_account_id           = ""
+
 }
 
 # London Frontend ======DIFFERENT AWS REGION===================================
@@ -183,6 +185,7 @@ module "frontend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
+  cyber_account_id   = ""
 }
 
 module "govwifi_admin" {
@@ -239,6 +242,7 @@ module "govwifi_admin" {
   zendesk_api_user     = var.zendesk_api_user
 
   bastion_server_ip = var.bastion_server_ip
+  cyber_account_id  = ""
 }
 
 module "api" {
@@ -300,6 +304,7 @@ module "api" {
   low_cpu_threshold = 10
 
   elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
+  cyber_account_id       = ""
 }
 
 module "critical_notifications" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -133,6 +133,7 @@ module "backend" {
   grafana_ip            = var.grafana_ip
 
   db_storage_alarm_threshold = 32212254720
+  cyber_account_id           = ""
 }
 
 # Emails ======================================================================
@@ -216,6 +217,7 @@ module "frontend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
+  cyber_account_id   = ""
 }
 
 module "api" {
@@ -268,6 +270,7 @@ module "api" {
   ]
 
   low_cpu_threshold = 10
+  cyber_account_id  = ""
 }
 
 module "critical_notifications" {


### PR DESCRIPTION
### What
Send staging London logs to Cyber for ITHC

### Why
Cyber are performing some tests on our systems and would like our logs to be temporarily forwarded to them. This change is implemented following the guidance here:
https://github.com/alphagov/centralised-security-logging-service

Unfortunately the log names need to be hardcoded in the variable array as terraform cannot perform interpolation here.

Link to Trello card (if applicable): https://trello.com/c/MwGpCYMb/1964-send-data-from-govwifi-log-group-to-cybers-kinesis-stream
