### PR TITLE
Only create a bastion status alarm when the bastion is enabled

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -275,6 +275,7 @@ resource "aws_cloudwatch_metric_alarm" "bastion_statusalarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "wifi_bastion_status_alarm" {
+  count               = var.enable_bastion
   alarm_name          = "wifi-bastion-status-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"


### PR DESCRIPTION
### What
Only create a bastion status alarm when the bastion is enabled

### Why
To avoid Terraform erroring.

This should have been added in
2321016fcce9bd53e98b88a1add76988aaa4a51a, but was missed.


Link to Trello card: https://trello.com/c/ngF625Eo/2054-terraform-missing-cloudwatch-alarms