### PR TITLE
Prepare for terraform region consolidation

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -247,10 +247,20 @@ resource "aws_iam_instance_profile" "bastion_instance_profile" {
   depends_on = [aws_iam_role.bastion_instance_role]
 }
 
+resource "aws_eip" "bastion_eip" {
+  count = var.enable_bastion
+  vpc   = true
+
+  tags = {
+    Name = "bastion"
+    Env  = title(var.env_name)
+  }
+}
+
 resource "aws_eip_association" "eip_assoc" {
-  count       = var.enable_bastion
-  instance_id = aws_instance.management[0].id
-  public_ip   = var.bastion_server_ip
+  count         = var.enable_bastion
+  instance_id   = aws_instance.management[0].id
+  allocation_id = aws_eip.bastion_eip[0].id
 }
 
 resource "aws_cloudwatch_metric_alarm" "bastion_statusalarm" {

--- a/govwifi-backend/outputs.tf
+++ b/govwifi-backend/outputs.tf
@@ -37,3 +37,7 @@ output "rds_mysql_backup_bucket" {
 output "nat_gateway_elastic_ips" {
   value = [for eip in aws_eip.for_nat_gateway_for_private_subnets : eip.public_ip]
 }
+
+output "bastion_public_ip" {
+  value = var.enable_bastion == 1 ? aws_eip.bastion_eip[0].public_ip : null
+}

--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -75,7 +75,7 @@ resource "aws_security_group" "be_admin_in" {
     protocol  = "tcp"
 
     cidr_blocks = concat(
-      ["${var.bastion_server_ip}/32"],
+      ["${var.bastion_server_ip == null ? aws_eip.bastion_eip[0].public_ip : var.bastion_server_ip}/32"],
       [for subnet in aws_subnet.wifi_backend_subnet : subnet.cidr_block]
     )
   }

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -39,6 +39,7 @@ variable "bastion_instance_type" {
 }
 
 variable "bastion_server_ip" {
+  default = null
 }
 
 variable "bastion_ssh_key_name" {

--- a/govwifi-frontend/outputs.tf
+++ b/govwifi-frontend/outputs.tf
@@ -25,3 +25,7 @@ output "fe_radius_out" {
 output "ecs_instance_profile" {
   value = aws_iam_instance_profile.ecs_instance_profile.id
 }
+
+output "eip_public_ips" {
+  value = [for eip in aws_eip.radius_eips : eip.public_ip]
+}

--- a/govwifi-grafana/eip.tf
+++ b/govwifi-grafana/eip.tf
@@ -1,6 +1,5 @@
 resource "aws_eip" "grafana_eip" {
-  instance = aws_instance.grafana_instance.id
-  vpc      = true
+  vpc = true
 
   tags = {
     Name = "grafana-${var.env_name}"
@@ -9,7 +8,6 @@ resource "aws_eip" "grafana_eip" {
 }
 
 resource "aws_eip_association" "grafana_eip_assoc" {
-  depends_on    = [aws_instance.grafana_instance]
   instance_id   = aws_instance.grafana_instance.id
   allocation_id = aws_eip.grafana_eip.id
 }

--- a/govwifi-grafana/outputs.tf
+++ b/govwifi-grafana/outputs.tf
@@ -1,0 +1,3 @@
+output "eip_public_ip" {
+  value = aws_eip.grafana_eip.public_ip
+}

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -93,9 +93,17 @@ resource "aws_volume_attachment" "prometheus_ebs_attach" {
   instance_id = aws_instance.prometheus_instance.id
 }
 
+resource "aws_eip" "eip" {
+  vpc = true
+
+  tags = {
+    Name = "prometheus"
+    Env  = title(var.env_name)
+  }
+}
+
 resource "aws_eip_association" "prometheus_eip_assoc" {
-  depends_on  = [aws_instance.prometheus_instance]
-  instance_id = aws_instance.prometheus_instance.id
-  public_ip   = var.prometheus_ip
+  instance_id   = aws_instance.prometheus_instance.id
+  allocation_id = aws_eip.eip.id
 }
 

--- a/govwifi-prometheus/outputs.tf
+++ b/govwifi-prometheus/outputs.tf
@@ -1,0 +1,3 @@
+output "eip_public_ip" {
+  value = aws_eip.eip.public_ip
+}

--- a/govwifi-prometheus/variables.tf
+++ b/govwifi-prometheus/variables.tf
@@ -5,11 +5,6 @@ variable "prometheus_volume_size" {
   default = "40"
 }
 
-variable "prometheus_ip" {
-  description = "The EIP of the EC2 instance"
-  type        = string
-}
-
 variable "grafana_ip" {
   description = "The grafana IP allowed into prometheus servers to connect to the EC2 instances on 9090."
   type        = string

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -85,7 +85,6 @@ module "backend" {
 
   bastion_ami                = "ami-096cb92bb3580c759"
   bastion_instance_type      = "t2.micro"
-  bastion_server_ip          = var.bastion_server_ip
   bastion_ssh_key_name       = "staging-bastion-20200717"
   enable_bastion_monitoring  = false
   aws_account_id             = local.aws_account_id

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -357,8 +357,7 @@ module "govwifi_prometheus" {
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
-  prometheus_ip = var.prometheus_ip_london
-  grafana_ip    = var.grafana_ip
+  grafana_ip = var.grafana_ip
 }
 
 module "govwifi_grafana" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -96,7 +96,6 @@ module "backend" {
 
   bastion_ami                = "ami-096cb92bb3580c759"
   bastion_instance_type      = "t2.micro"
-  bastion_server_ip          = var.bastion_server_ip
   bastion_ssh_key_name       = "govwifi-bastion-key-20210630"
   enable_bastion_monitoring  = true
   aws_account_id             = local.aws_account_id

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -410,8 +410,7 @@ module "govwifi_prometheus" {
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
-  prometheus_ip = var.prometheus_ip_london
-  grafana_ip    = var.grafana_ip
+  grafana_ip = var.grafana_ip
 }
 
 module "govwifi_grafana" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -346,6 +346,5 @@ module "govwifi_prometheus" {
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
-  prometheus_ip = var.prometheus_ip_ireland
-  grafana_ip    = var.grafana_ip
+  grafana_ip = var.grafana_ip
 }

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -98,7 +98,6 @@ module "backend" {
   # eu-west-2 eu-west-2, CIS Ubuntu Linux 20.04 LTS
   bastion_ami               = "ami-08bac620dc84221eb"
   bastion_instance_type     = "t2.micro"
-  bastion_server_ip         = var.bastion_server_ip
   bastion_ssh_key_name      = "govwifi-bastion-key-20210630"
   enable_bastion_monitoring = true
   aws_account_id            = local.aws_account_id


### PR DESCRIPTION
### What
Make some small Terraform changes around EIPs.

### Why
This is in preparation for trying to consolidate the Terraform for a single environment, as it means that the IP addresses can be passed around as values in Terraform, rather than being provided to various modules as variables.


Link to Trello card: https://trello.com/c/HublU99C/2065-remove-necessity-to-specify-a-region-when-running-govwifi-terraform