### PR TITLE
Upgrade tflint aws plugin

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -4,7 +4,7 @@ config {
 
 plugin "aws" {
   enabled = true
-  version = "0.8.0"
+  version = "0.13.2"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/govwifi-admin/acm.tf
+++ b/govwifi-admin/acm.tf
@@ -1,6 +1,10 @@
 resource "aws_acm_certificate" "admin_cert" {
   domain_name       = aws_route53_record.admin.name
   validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "admin_cert_validation" {

--- a/govwifi-grafana/acm.tf
+++ b/govwifi-grafana/acm.tf
@@ -2,7 +2,6 @@ resource "aws_acm_certificate" "grafana_cert" {
   domain_name       = aws_route53_record.grafana_route53_record.name
   validation_method = "DNS"
 
-  depends_on = [aws_route53_record.grafana_route53_record]
 }
 
 resource "aws_route53_record" "grafana_cert_validation" {

--- a/govwifi-grafana/acm.tf
+++ b/govwifi-grafana/acm.tf
@@ -2,6 +2,9 @@ resource "aws_acm_certificate" "grafana_cert" {
   domain_name       = aws_route53_record.grafana_route53_record.name
   validation_method = "DNS"
 
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "grafana_cert_validation" {


### PR DESCRIPTION
### What
Upgrade tflint aws plugin, plus a few other changes.

### Why
The new version of tflint which Homebrew provides doesn't like the current tflint aws plugin version being used.
