### PR TITLE
Mark the docker_image_path values as nonsensitive

### DIFF
--- a/govwifi/staging-dublin/locals.tf
+++ b/govwifi/staging-dublin/locals.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 locals {
-  docker_image_path = jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"]
+  docker_image_path = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"])
 }
 
 locals {

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 locals {
-  docker_image_path = jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"]
+  docker_image_path = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"])
 }
 
 locals {

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 locals {
-  docker_image_path = jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"]
+  docker_image_path = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"])
 }
 
 locals {

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 locals {
-  docker_image_path = jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"]
+  docker_image_path = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"])
 }
 
 locals {


### PR DESCRIPTION
### What
Mark the docker_image_path values as nonsensitive

### Why
This secret actually contains the URL for a AWS ECR
repository. Ideally, this wouldn't be a secret at all, and the
Terraform would just describe where the attribute from the repository
resource should be used.

Unfortunately, this is difficult to address until the Terraform for
different regions is consolidated, so for now, just mark the values as
non sensitive to improve the plan output.
