### PR TITLE
Handle Sentry DSNs properly in container definitions

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -60,9 +60,6 @@ resource "aws_ecs_task_definition" "admin_task" {
           "name": "DUBLIN_RADIUS_IPS",
           "value": "${join(",", var.dublin_radius_ip_addresses)}"
         },{
-          "name": "SENTRY_DSN",
-          "value": "${var.sentry_dsn}"
-        },{
           "name": "S3_MOU_BUCKET",
           "value": "${aws_s3_bucket.admin_mou_bucket[0].id}"
         },{
@@ -152,6 +149,9 @@ resource "aws_ecs_task_definition" "admin_task" {
         },{
           "name": "ZENDESK_API_TOKEN",
           "valueFrom": "${data.aws_secretsmanager_secret_version.zendesk_api_token.arn}:zendesk-api-token::"
+        },{
+          "name": "SENTRY_DSN",
+          "valueFrom": "${data.aws_secretsmanager_secret.sentry_dsn.arn}"
         }
       ],
       "image": "${var.admin_docker_image}",

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -139,6 +139,7 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret_version.users_db.arn,
       data.aws_secretsmanager_secret_version.admin_db.arn,
       data.aws_secretsmanager_secret_version.google_service_account_backup_credentials.arn,
+      data.aws_secretsmanager_secret.sentry_dsn.arn,
     ]
   }
 }

--- a/govwifi-admin/secrets-manager.tf
+++ b/govwifi-admin/secrets-manager.tf
@@ -61,3 +61,7 @@ data "aws_secretsmanager_secret_version" "google_service_account_backup_credenti
 data "aws_secretsmanager_secret" "google_service_account_backup_credentials" {
   name = "admin/google-service-account-backup-credentials"
 }
+
+data "aws_secretsmanager_secret" "sentry_dsn" {
+  name = "sentry/admin_dsn"
+}

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -91,9 +91,6 @@ variable "dublin_radius_ip_addresses" {
   type = list(string)
 }
 
-variable "sentry_dsn" {
-}
-
 variable "logging_api_search_url" {
 }
 

--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -53,9 +53,6 @@ resource "aws_ecs_task_definition" "authorisation_api_task" {
           "name": "SENTRY_CURRENT_ENV",
           "value": "${var.sentry_current_env}"
         },{
-          "name": "SENTRY_DSN",
-          "value": "${var.authentication_sentry_dsn}"
-        },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.env_name}"
         }
@@ -66,6 +63,9 @@ resource "aws_ecs_task_definition" "authorisation_api_task" {
         },{
           "name": "DB_USER",
           "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
+        },{
+          "name": "SENTRY_DSN",
+          "valueFrom": "${data.aws_secretsmanager_secret.authentication_api_sentry_dsn.arn}"
         }
       ],
       "links": null,

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -37,7 +37,8 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.admin_db.arn,
       data.aws_secretsmanager_secret.notify_api_key.arn,
       data.aws_secretsmanager_secret.notify_bearer_token.arn,
-      data.aws_secretsmanager_secret.database_s3_encryption.arn
+      data.aws_secretsmanager_secret.database_s3_encryption.arn,
+      data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.arn
     ]
   }
 }

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -38,7 +38,8 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.notify_api_key.arn,
       data.aws_secretsmanager_secret.notify_bearer_token.arn,
       data.aws_secretsmanager_secret.database_s3_encryption.arn,
-      data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.arn
+      data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.arn,
+      data.aws_secretsmanager_secret.authentication_api_sentry_dsn.arn
     ]
   }
 }

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -40,7 +40,8 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.database_s3_encryption.arn,
       data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.arn,
       data.aws_secretsmanager_secret.authentication_api_sentry_dsn.arn,
-      data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.arn
+      data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.arn,
+      data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn
     ]
   }
 }

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -39,7 +39,8 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.notify_bearer_token.arn,
       data.aws_secretsmanager_secret.database_s3_encryption.arn,
       data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.arn,
-      data.aws_secretsmanager_secret.authentication_api_sentry_dsn.arn
+      data.aws_secretsmanager_secret.authentication_api_sentry_dsn.arn,
+      data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.arn
     ]
   }
 }

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -63,9 +63,6 @@ resource "aws_ecs_task_definition" "logging_api_task" {
           "name": "SENTRY_CURRENT_ENV",
           "value": "${var.sentry_current_env}"
         },{
-          "name": "SENTRY_DSN",
-          "value": "${var.logging_sentry_dsn}"
-        },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.env_name}"
         },{
@@ -92,6 +89,9 @@ resource "aws_ecs_task_definition" "logging_api_task" {
         },{
           "name": "USER_DB_USER",
           "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
+        },{
+          "name": "SENTRY_DSN",
+          "valueFrom": "${data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn}"
         }
       ],
       "links": null,

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -500,9 +500,6 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
           "name": "SENTRY_CURRENT_ENV",
           "value": "${var.sentry_current_env}"
         },{
-          "name": "SENTRY_DSN",
-          "value": "${var.logging_sentry_dsn}"
-        },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.env_name}"
         },{
@@ -532,6 +529,9 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
         },{
           "name": "USER_DB_USER",
           "valueFrom": "${data.aws_secretsmanager_secret_version.users_db.arn}:username::"
+        },{
+          "name": "SENTRY_DSN",
+          "valueFrom": "${data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn}"
         }
       ],
       "links": null,

--- a/govwifi-api/safe-restart-scheduled-task.tf
+++ b/govwifi-api/safe-restart-scheduled-task.tf
@@ -58,9 +58,12 @@ resource "aws_ecs_task_definition" "safe_restart_task_definition" {
         },{
           "name": "SENTRY_CURRENT_ENV",
           "value": "${var.sentry_current_env}"
-        },{
+        }
+      ],
+      "secrets": [
+        {
           "name": "SENTRY_DSN",
-          "value": "${var.safe_restart_sentry_dsn}"
+          "valueFrom": "${data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.arn}"
         }
       ],
       "links": null,

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -53,3 +53,7 @@ data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
 data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
   name = "sentry/authentication_api_dsn"
 }
+
+data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
+  name = "sentry/user_signup_api_dsn"
+}

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -45,3 +45,7 @@ data "aws_secretsmanager_secret_version" "database_s3_encryption" {
 data "aws_secretsmanager_secret" "database_s3_encryption" {
   name = "rds/database-s3-encryption"
 }
+
+data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
+  name = "sentry/safe_restarter_dsn"
+}

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -49,3 +49,7 @@ data "aws_secretsmanager_secret" "database_s3_encryption" {
 data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
   name = "sentry/safe_restarter_dsn"
 }
+
+data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
+  name = "sentry/authentication_api_dsn"
+}

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -57,3 +57,7 @@ data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
 data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
   name = "sentry/user_signup_api_dsn"
 }
+
+data "aws_secretsmanager_secret" "logging_api_sentry_dsn" {
+  name = "sentry/logging_api_dsn"
+}

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -119,9 +119,6 @@ resource "aws_ecs_task_definition" "user_signup_api_task" {
           "name": "SENTRY_CURRENT_ENV",
           "value": "${var.sentry_current_env}"
         },{
-          "name": "SENTRY_DSN",
-          "value": "${var.user_signup_sentry_dsn}"
-        },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.env_name}"
         },{
@@ -148,6 +145,9 @@ resource "aws_ecs_task_definition" "user_signup_api_task" {
         },{
           "name": "GOVNOTIFY_BEARER_TOKEN",
           "valueFrom": "${data.aws_secretsmanager_secret_version.notify_bearer_token.arn}:token::"
+        },{
+          "name": "SENTRY_DSN",
+          "valueFrom": "${data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.arn}"
         }
       ],
       "links": null,

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -258,9 +258,6 @@ resource "aws_ecs_task_definition" "user_signup_api_scheduled_task" {
           "name": "SENTRY_CURRENT_ENV",
           "value": "${var.sentry_current_env}"
         },{
-          "name": "SENTRY_DSN",
-          "value": "${var.user_signup_sentry_dsn}"
-        },{
           "name": "ENVIRONMENT_NAME",
           "value": "${var.env_name}"
         },{
@@ -284,6 +281,9 @@ resource "aws_ecs_task_definition" "user_signup_api_scheduled_task" {
         },{
           "name": "GOVNOTIFY_BEARER_TOKEN",
           "valueFrom": "${data.aws_secretsmanager_secret_version.notify_bearer_token.arn}:token::"
+        },{
+          "name": "SENTRY_DSN",
+          "valueFrom": "${data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.arn}"
         }
       ],
       "links": null,

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -49,10 +49,6 @@ variable "safe_restart_enabled" {
   default = 1
 }
 
-variable "safe_restart_sentry_dsn" {
-  default = ""
-}
-
 variable "user_db_hostname" {
 }
 

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -68,10 +68,6 @@ variable "radius_server_ips" {
   type = list(string)
 }
 
-variable "user_signup_sentry_dsn" {
-  default = ""
-}
-
 variable "logging_sentry_dsn" {
   default = ""
 }

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -68,9 +68,6 @@ variable "radius_server_ips" {
   type = list(string)
 }
 
-variable "authentication_sentry_dsn" {
-}
-
 variable "user_signup_sentry_dsn" {
   default = ""
 }

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -68,10 +68,6 @@ variable "radius_server_ips" {
   type = list(string)
 }
 
-variable "logging_sentry_dsn" {
-  default = ""
-}
-
 variable "backend_sg_list" {
   type = list(string)
 }

--- a/govwifi/staging-dublin/locals.tf
+++ b/govwifi/staging-dublin/locals.tf
@@ -7,7 +7,6 @@ locals {
 
 locals {
   authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
-  safe_restarter_sentry_dsn     = data.aws_secretsmanager_secret_version.safe_restarter_sentry_dsn.secret_string
 }
 
 locals {

--- a/govwifi/staging-dublin/locals.tf
+++ b/govwifi/staging-dublin/locals.tf
@@ -6,10 +6,6 @@ locals {
 }
 
 locals {
-  authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
-}
-
-locals {
   aws_account_id = data.aws_caller_identity.current.account_id
 }
 

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -250,7 +250,6 @@ module "api" {
   sentry_current_env        = "secondary-staging"
   radius_server_ips         = local.frontend_radius_ips
   authentication_sentry_dsn = local.authentication_api_sentry_dsn
-  safe_restart_sentry_dsn   = local.safe_restarter_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids
   private_subnet_ids        = module.backend.backend_private_subnet_ids
   nat_gateway_elastic_ips   = module.backend.nat_gateway_elastic_ips

--- a/govwifi/staging-dublin/main.tf
+++ b/govwifi/staging-dublin/main.tf
@@ -246,14 +246,13 @@ module "api" {
   user_db_hostname = ""
   user_rr_hostname = var.user_rr_hostname
 
-  rack_env                  = "staging"
-  sentry_current_env        = "secondary-staging"
-  radius_server_ips         = local.frontend_radius_ips
-  authentication_sentry_dsn = local.authentication_api_sentry_dsn
-  subnet_ids                = module.backend.backend_subnet_ids
-  private_subnet_ids        = module.backend.backend_private_subnet_ids
-  nat_gateway_elastic_ips   = module.backend.nat_gateway_elastic_ips
-  rds_mysql_backup_bucket   = module.backend.rds_mysql_backup_bucket
+  rack_env                = "staging"
+  sentry_current_env      = "secondary-staging"
+  radius_server_ips       = local.frontend_radius_ips
+  subnet_ids              = module.backend.backend_subnet_ids
+  private_subnet_ids      = module.backend.backend_private_subnet_ids
+  nat_gateway_elastic_ips = module.backend.nat_gateway_elastic_ips
+  rds_mysql_backup_bucket = module.backend.rds_mysql_backup_bucket
 
   admin_app_data_s3_bucket_name = data.terraform_remote_state.london.outputs.admin_app_data_s3_bucket_name
 

--- a/govwifi/staging-dublin/secrets-manager.tf
+++ b/govwifi/staging-dublin/secrets-manager.tf
@@ -5,13 +5,3 @@ data "aws_secretsmanager_secret_version" "docker_image_path" {
 data "aws_secretsmanager_secret" "docker_image_path" {
   name = "aws/ecr/docker-image-path/govwifi"
 }
-
-# Sentry
-
-data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
-  name = "sentry/authentication_api_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
-}

--- a/govwifi/staging-dublin/secrets-manager.tf
+++ b/govwifi/staging-dublin/secrets-manager.tf
@@ -15,11 +15,3 @@ data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
 data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
   secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
 }
-
-data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
-  name = "sentry/safe_restarter_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "safe_restarter_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.id
-}

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -8,9 +8,8 @@ locals {
 }
 
 locals {
-  user_signup_api_sentry_dsn = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
-  logging_api_sentry_dsn     = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
-  admin_sentry_dsn           = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
+  logging_api_sentry_dsn = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
+  admin_sentry_dsn       = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
 }
 
 locals {

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -9,7 +9,6 @@ locals {
 
 locals {
   authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
-  safe_restarter_sentry_dsn     = data.aws_secretsmanager_secret_version.safe_restarter_sentry_dsn.secret_string
   user_signup_api_sentry_dsn    = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
   logging_api_sentry_dsn        = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
   admin_sentry_dsn              = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -8,10 +8,9 @@ locals {
 }
 
 locals {
-  authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
-  user_signup_api_sentry_dsn    = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
-  logging_api_sentry_dsn        = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
-  admin_sentry_dsn              = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
+  user_signup_api_sentry_dsn = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
+  logging_api_sentry_dsn     = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
+  admin_sentry_dsn           = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
 }
 
 locals {

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -8,10 +8,6 @@ locals {
 }
 
 locals {
-  admin_sentry_dsn = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
-}
-
-locals {
   aws_account_id = data.aws_caller_identity.current.account_id
 }
 

--- a/govwifi/staging-london/locals.tf
+++ b/govwifi/staging-london/locals.tf
@@ -8,8 +8,7 @@ locals {
 }
 
 locals {
-  logging_api_sentry_dsn = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
-  admin_sentry_dsn       = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
+  admin_sentry_dsn = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
 }
 
 locals {

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -270,7 +270,6 @@ module "api" {
   sentry_current_env        = "secondary-staging"
   radius_server_ips         = local.frontend_radius_ips
   authentication_sentry_dsn = local.authentication_api_sentry_dsn
-  safe_restart_sentry_dsn   = local.safe_restarter_sentry_dsn
   user_signup_sentry_dsn    = local.user_signup_api_sentry_dsn
   logging_sentry_dsn        = local.logging_api_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -215,7 +215,6 @@ module "govwifi_admin" {
 
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
-  sentry_dsn                 = local.admin_sentry_dsn
   logging_api_search_url     = "https://api-elb.london.${local.env_subdomain}.service.gov.uk:8443/logging/authentication/events/search/"
   public_google_api_key      = var.public_google_api_key
 

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -269,7 +269,6 @@ module "api" {
   rack_env                  = "staging"
   sentry_current_env        = "secondary-staging"
   radius_server_ips         = local.frontend_radius_ips
-  user_signup_sentry_dsn    = local.user_signup_api_sentry_dsn
   logging_sentry_dsn        = local.logging_api_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids
   private_subnet_ids        = module.backend.backend_private_subnet_ids

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -269,7 +269,6 @@ module "api" {
   rack_env                  = "staging"
   sentry_current_env        = "secondary-staging"
   radius_server_ips         = local.frontend_radius_ips
-  authentication_sentry_dsn = local.authentication_api_sentry_dsn
   user_signup_sentry_dsn    = local.user_signup_api_sentry_dsn
   logging_sentry_dsn        = local.logging_api_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids

--- a/govwifi/staging-london/main.tf
+++ b/govwifi/staging-london/main.tf
@@ -269,7 +269,6 @@ module "api" {
   rack_env                  = "staging"
   sentry_current_env        = "secondary-staging"
   radius_server_ips         = local.frontend_radius_ips
-  logging_sentry_dsn        = local.logging_api_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids
   private_subnet_ids        = module.backend.backend_private_subnet_ids
   nat_gateway_elastic_ips   = module.backend.nat_gateway_elastic_ips

--- a/govwifi/staging-london/secrets-manager.tf
+++ b/govwifi/staging-london/secrets-manager.tf
@@ -8,14 +8,6 @@ data "aws_secretsmanager_secret" "docker_image_path" {
 
 # Sentry
 
-data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
-  name = "sentry/authentication_api_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
-}
-
 data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
   name = "sentry/user_signup_api_dsn"
 }

--- a/govwifi/staging-london/secrets-manager.tf
+++ b/govwifi/staging-london/secrets-manager.tf
@@ -8,14 +8,6 @@ data "aws_secretsmanager_secret" "docker_image_path" {
 
 # Sentry
 
-data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
-  name = "sentry/user_signup_api_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "user_signup_api_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.id
-}
-
 data "aws_secretsmanager_secret" "logging_api_sentry_dsn" {
   name = "sentry/logging_api_dsn"
 }

--- a/govwifi/staging-london/secrets-manager.tf
+++ b/govwifi/staging-london/secrets-manager.tf
@@ -16,14 +16,6 @@ data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
   secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
 }
 
-data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
-  name = "sentry/safe_restarter_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "safe_restarter_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.id
-}
-
 data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
   name = "sentry/user_signup_api_dsn"
 }

--- a/govwifi/staging-london/secrets-manager.tf
+++ b/govwifi/staging-london/secrets-manager.tf
@@ -5,13 +5,3 @@ data "aws_secretsmanager_secret_version" "docker_image_path" {
 data "aws_secretsmanager_secret" "docker_image_path" {
   name = "aws/ecr/docker-image-path/govwifi"
 }
-
-# Sentry
-
-data "aws_secretsmanager_secret" "admin_sentry_dsn" {
-  name = "sentry/admin_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "admin_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.admin_sentry_dsn.id
-}

--- a/govwifi/staging-london/secrets-manager.tf
+++ b/govwifi/staging-london/secrets-manager.tf
@@ -8,14 +8,6 @@ data "aws_secretsmanager_secret" "docker_image_path" {
 
 # Sentry
 
-data "aws_secretsmanager_secret" "logging_api_sentry_dsn" {
-  name = "sentry/logging_api_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "logging_api_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.logging_api_sentry_dsn.id
-}
-
 data "aws_secretsmanager_secret" "admin_sentry_dsn" {
   name = "sentry/admin_dsn"
 }

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -8,9 +8,8 @@ locals {
 }
 
 locals {
-  user_signup_api_sentry_dsn = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
-  logging_api_sentry_dsn     = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
-  admin_sentry_dsn           = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
+  logging_api_sentry_dsn = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
+  admin_sentry_dsn       = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
 }
 
 locals {

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -9,7 +9,6 @@ locals {
 
 locals {
   authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
-  safe_restarter_sentry_dsn     = data.aws_secretsmanager_secret_version.safe_restarter_sentry_dsn.secret_string
   user_signup_api_sentry_dsn    = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
   logging_api_sentry_dsn        = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
   admin_sentry_dsn              = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -8,10 +8,9 @@ locals {
 }
 
 locals {
-  authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
-  user_signup_api_sentry_dsn    = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
-  logging_api_sentry_dsn        = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
-  admin_sentry_dsn              = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
+  user_signup_api_sentry_dsn = data.aws_secretsmanager_secret_version.user_signup_api_sentry_dsn.secret_string
+  logging_api_sentry_dsn     = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
+  admin_sentry_dsn           = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
 }
 
 locals {

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -8,10 +8,6 @@ locals {
 }
 
 locals {
-  admin_sentry_dsn = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
-}
-
-locals {
   aws_account_id = data.aws_caller_identity.current.account_id
 }
 

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -8,8 +8,7 @@ locals {
 }
 
 locals {
-  logging_api_sentry_dsn = data.aws_secretsmanager_secret_version.logging_api_sentry_dsn.secret_string
-  admin_sentry_dsn       = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
+  admin_sentry_dsn = data.aws_secretsmanager_secret_version.admin_sentry_dsn.secret_string
 }
 
 locals {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -276,7 +276,6 @@ module "api" {
   rack_env                  = "production"
   sentry_current_env        = "production"
   radius_server_ips         = local.frontend_radius_ips
-  logging_sentry_dsn        = local.logging_api_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids
   private_subnet_ids        = module.backend.backend_private_subnet_ids
   nat_gateway_elastic_ips   = module.backend.nat_gateway_elastic_ips

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -276,7 +276,6 @@ module "api" {
   rack_env                  = "production"
   sentry_current_env        = "production"
   radius_server_ips         = local.frontend_radius_ips
-  user_signup_sentry_dsn    = local.user_signup_api_sentry_dsn
   logging_sentry_dsn        = local.logging_api_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids
   private_subnet_ids        = module.backend.backend_private_subnet_ids

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -277,7 +277,6 @@ module "api" {
   sentry_current_env        = "production"
   radius_server_ips         = local.frontend_radius_ips
   authentication_sentry_dsn = local.authentication_api_sentry_dsn
-  safe_restart_sentry_dsn   = local.safe_restarter_sentry_dsn
   user_signup_sentry_dsn    = local.user_signup_api_sentry_dsn
   logging_sentry_dsn        = local.logging_api_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -229,7 +229,6 @@ module "govwifi_admin" {
 
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
-  sentry_dsn                 = local.admin_sentry_dsn
   public_google_api_key      = var.public_google_api_key
 
   logging_api_search_url = "https://api-elb.london.${local.env_subdomain}.service.gov.uk:8443/logging/authentication/events/search/"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -276,7 +276,6 @@ module "api" {
   rack_env                  = "production"
   sentry_current_env        = "production"
   radius_server_ips         = local.frontend_radius_ips
-  authentication_sentry_dsn = local.authentication_api_sentry_dsn
   user_signup_sentry_dsn    = local.user_signup_api_sentry_dsn
   logging_sentry_dsn        = local.logging_api_sentry_dsn
   subnet_ids                = module.backend.backend_subnet_ids

--- a/govwifi/wifi-london/secrets-manager.tf
+++ b/govwifi/wifi-london/secrets-manager.tf
@@ -13,13 +13,3 @@ data "aws_secretsmanager_secret" "pagerduty_config" {
 data "aws_secretsmanager_secret_version" "pagerduty_config" {
   secret_id = data.aws_secretsmanager_secret.pagerduty_config.id
 }
-
-# Sentry
-
-data "aws_secretsmanager_secret" "admin_sentry_dsn" {
-  name = "sentry/admin_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "admin_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.admin_sentry_dsn.id
-}

--- a/govwifi/wifi-london/secrets-manager.tf
+++ b/govwifi/wifi-london/secrets-manager.tf
@@ -16,14 +16,6 @@ data "aws_secretsmanager_secret_version" "pagerduty_config" {
 
 # Sentry
 
-data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
-  name = "sentry/authentication_api_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
-}
-
 data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
   name = "sentry/user_signup_api_dsn"
 }

--- a/govwifi/wifi-london/secrets-manager.tf
+++ b/govwifi/wifi-london/secrets-manager.tf
@@ -16,14 +16,6 @@ data "aws_secretsmanager_secret_version" "pagerduty_config" {
 
 # Sentry
 
-data "aws_secretsmanager_secret" "logging_api_sentry_dsn" {
-  name = "sentry/logging_api_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "logging_api_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.logging_api_sentry_dsn.id
-}
-
 data "aws_secretsmanager_secret" "admin_sentry_dsn" {
   name = "sentry/admin_dsn"
 }

--- a/govwifi/wifi-london/secrets-manager.tf
+++ b/govwifi/wifi-london/secrets-manager.tf
@@ -16,14 +16,6 @@ data "aws_secretsmanager_secret_version" "pagerduty_config" {
 
 # Sentry
 
-data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
-  name = "sentry/user_signup_api_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "user_signup_api_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.id
-}
-
 data "aws_secretsmanager_secret" "logging_api_sentry_dsn" {
   name = "sentry/logging_api_dsn"
 }

--- a/govwifi/wifi-london/secrets-manager.tf
+++ b/govwifi/wifi-london/secrets-manager.tf
@@ -24,14 +24,6 @@ data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
   secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
 }
 
-data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
-  name = "sentry/safe_restarter_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "safe_restarter_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.id
-}
-
 data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
   name = "sentry/user_signup_api_dsn"
 }

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -7,7 +7,6 @@ locals {
 
 locals {
   authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
-  safe_restarter_sentry_dsn     = data.aws_secretsmanager_secret_version.safe_restarter_sentry_dsn.secret_string
 }
 
 locals {

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -6,10 +6,6 @@ locals {
 }
 
 locals {
-  authentication_api_sentry_dsn = data.aws_secretsmanager_secret_version.authentication_api_sentry_dsn.secret_string
-}
-
-locals {
   aws_account_id = data.aws_caller_identity.current.account_id
 }
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -254,7 +254,6 @@ module "api" {
   sentry_current_env        = "production"
   radius_server_ips         = local.frontend_radius_ips
   authentication_sentry_dsn = local.authentication_api_sentry_dsn
-  safe_restart_sentry_dsn   = local.safe_restarter_sentry_dsn
   user_signup_docker_image  = ""
   subnet_ids                = module.backend.backend_subnet_ids
   private_subnet_ids        = module.backend.backend_private_subnet_ids

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -249,18 +249,17 @@ module "api" {
   safe_restart_docker_image     = format("%s/safe-restarter:production", local.docker_image_path)
   backup_rds_to_s3_docker_image = ""
 
-  db_hostname               = "db.${lower(var.aws_region_name)}.${local.env_subdomain}.service.gov.uk"
-  rack_env                  = "production"
-  sentry_current_env        = "production"
-  radius_server_ips         = local.frontend_radius_ips
-  authentication_sentry_dsn = local.authentication_api_sentry_dsn
-  user_signup_docker_image  = ""
-  subnet_ids                = module.backend.backend_subnet_ids
-  private_subnet_ids        = module.backend.backend_private_subnet_ids
-  nat_gateway_elastic_ips   = module.backend.nat_gateway_elastic_ips
-  user_db_hostname          = var.user_db_hostname
-  user_rr_hostname          = var.user_rr_hostname
-  rds_mysql_backup_bucket   = module.backend.rds_mysql_backup_bucket
+  db_hostname              = "db.${lower(var.aws_region_name)}.${local.env_subdomain}.service.gov.uk"
+  rack_env                 = "production"
+  sentry_current_env       = "production"
+  radius_server_ips        = local.frontend_radius_ips
+  user_signup_docker_image = ""
+  subnet_ids               = module.backend.backend_subnet_ids
+  private_subnet_ids       = module.backend.backend_private_subnet_ids
+  nat_gateway_elastic_ips  = module.backend.nat_gateway_elastic_ips
+  user_db_hostname         = var.user_db_hostname
+  user_rr_hostname         = var.user_rr_hostname
+  rds_mysql_backup_bucket  = module.backend.rds_mysql_backup_bucket
 
   backend_sg_list = [
     module.backend.be_admin_in,

--- a/govwifi/wifi/secrets-manager.tf
+++ b/govwifi/wifi/secrets-manager.tf
@@ -23,11 +23,3 @@ data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
 data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
   secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
 }
-
-data "aws_secretsmanager_secret" "safe_restarter_sentry_dsn" {
-  name = "sentry/safe_restarter_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "safe_restarter_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.id
-}

--- a/govwifi/wifi/secrets-manager.tf
+++ b/govwifi/wifi/secrets-manager.tf
@@ -13,13 +13,3 @@ data "aws_secretsmanager_secret" "pagerduty_config" {
 data "aws_secretsmanager_secret_version" "pagerduty_config" {
   secret_id = data.aws_secretsmanager_secret.pagerduty_config.id
 }
-
-# Sentry
-
-data "aws_secretsmanager_secret" "authentication_api_sentry_dsn" {
-  name = "sentry/authentication_api_dsn"
-}
-
-data "aws_secretsmanager_secret_version" "authentication_api_sentry_dsn" {
-  secret_id = data.aws_secretsmanager_secret.authentication_api_sentry_dsn.id
-}


### PR DESCRIPTION
### What
Handle Sentry DSNs properly in container definitions, as secrets rather than environment variables in the clear.

### Why
This is much less hassle, avoids the secret sitting in the container
definition itself and means that the container definition can be
treated as non sensitive within the Terraform.
