### PR TITLE
Switch from RACK_ENV to RAILS_ENV for the admin app

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -37,13 +37,13 @@ resource "aws_ecs_task_definition" "admin_task" {
       "environment": [
         {
           "name": "DB_NAME",
-          "value": "govwifi_admin_${var.rack_env}"
+          "value": "govwifi_admin_${var.rails_env}"
         },{
           "name": "DB_HOST",
           "value": "${aws_db_instance.admin_db.address}"
         },{
-          "name": "RACK_ENV",
-          "value": "${var.rack_env}"
+          "name": "RAILS_ENV",
+          "value": "staging"
         },{
           "name": "SENTRY_CURRENT_ENV",
           "value": "${var.sentry_current_env}"

--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -54,7 +54,7 @@ resource "aws_db_instance" "admin_db" {
   apply_immediately           = true
   instance_class              = var.db_instance_type
   identifier                  = "wifi-admin-${var.env_name}-db"
-  name                        = "govwifi_admin_${var.rack_env}"
+  name                        = "govwifi_admin_${var.rails_env}"
   username                    = local.admin_db_username
   password                    = local.admin_db_password
   backup_retention_period     = var.db_backup_retention_days

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -98,7 +98,7 @@ resource "aws_iam_role" "ecs_admin_instance_role" {
 }
 
 resource "aws_iam_role" "ecs_task_execution_role" {
-  name               = "admin-ecsTaskExecutionRole-${var.rack_env}-${var.aws_region_name}"
+  name               = "admin-ecsTaskExecutionRole-${var.rails_env}-${var.aws_region_name}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 

--- a/govwifi-admin/s3.tf
+++ b/govwifi-admin/s3.tf
@@ -1,13 +1,13 @@
 resource "aws_s3_bucket" "admin_bucket" {
   count         = 1
-  bucket        = "govwifi-${var.rack_env}-admin"
+  bucket        = "govwifi-${var.rails_env}-admin"
   force_destroy = true
   acl           = "private"
 
   tags = {
     Name        = "${title(var.env_name)} Admin data"
     Region      = title(var.aws_region_name)
-    Environment = title(var.rack_env)
+    Environment = title(var.rails_env)
   }
 
   versioning {
@@ -17,14 +17,14 @@ resource "aws_s3_bucket" "admin_bucket" {
 
 resource "aws_s3_bucket" "product_page_data_bucket" {
   count         = 1
-  bucket        = "govwifi-${var.rack_env}-product-page-data"
+  bucket        = "govwifi-${var.rails_env}-product-page-data"
   force_destroy = true
   acl           = "public-read"
 
   tags = {
-    Name        = "${title(var.rack_env)} Product page data"
+    Name        = "${title(var.rails_env)} Product page data"
     Region      = title(var.aws_region_name)
-    Environment = title(var.rack_env)
+    Environment = title(var.rails_env)
   }
 
   versioning {
@@ -34,14 +34,14 @@ resource "aws_s3_bucket" "product_page_data_bucket" {
 
 resource "aws_s3_bucket" "admin_mou_bucket" {
   count         = 1
-  bucket        = "govwifi-${var.rack_env}-admin-mou"
+  bucket        = "govwifi-${var.rails_env}-admin-mou"
   force_destroy = true
   acl           = "private"
 
   tags = {
     Name        = "${title(var.env_name)} MOU documents from Admin"
     Region      = title(var.aws_region_name)
-    Environment = title(var.rack_env)
+    Environment = title(var.rails_env)
   }
 
   versioning {

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -24,7 +24,7 @@ variable "ecr_repository_count" {
   default     = 0
 }
 
-variable "rack_env" {
+variable "rails_env" {
   description = "E.g. staging"
 }
 

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -150,7 +150,7 @@ module "london_admin" {
   route53_zone_id = data.aws_route53_zone.main.zone_id
 
   admin_docker_image   = format("%s/admin:staging", local.docker_image_path)
-  rack_env             = "staging"
+  rails_env            = "staging"
   sentry_current_env   = "secondary-staging"
   ecr_repository_count = 1
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -201,7 +201,7 @@ module "govwifi_admin" {
   route53_zone_id = data.aws_route53_zone.main.zone_id
 
   admin_docker_image   = format("%s/admin:production", local.docker_image_path)
-  rack_env             = "production"
+  rails_env            = "production"
   sentry_current_env   = "production"
   ecr_repository_count = 1
 


### PR DESCRIPTION
### What
Switch from RACK_ENV to RAILS_ENV for the admin app

### Why
RACK_ENV worked when starting the app with rails server, but doesn't
work when directly running the app with Puma. Instead, set the
RAILS_ENV environment variable which is a more usual thing to set.

Also, this isn't great because some of the app configuration seems to
be in the govwifi-admin, and depend on setting the right RAILS_ENV for
a particular deployment (e.g. staging for staging).
