### PR TITLE
Ensure the daily metrics task runs after the set_user_last_login task

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -50,8 +50,8 @@ resource "aws_cloudwatch_event_rule" "hourly_request_statistics_event" {
 resource "aws_cloudwatch_event_rule" "daily_metrics_logging_event" {
   count               = var.event_rule_count
   name                = "${var.env_name}-daily-metrics-logging"
-  description         = "Triggers daily 02:00 UTC"
-  schedule_expression = "cron(0 2 * * ? *)"
+  description         = "Triggers daily 05:00 UTC"
+  schedule_expression = "cron(0 5 * * ? *)"
   is_enabled          = true
 }
 


### PR DESCRIPTION
### What
Ensure the daily metrics task runs after the set_user_last_login task

### Why
The code that collects daily data on user signups that have also logged in
depends on the last_login field being set. It is therefore necessary
that this code should run after the daily_gdpr_set_user_last_login has run
which sets this field daily from the sessions database.


Link to Trello card (if applicable): 
https://trello.com/c/yRa3gd0W/2264-create-data-chart-on-grafana-to-show-new-users-that-have-signed-in