### PR TITLE
Switch govwifi-admin to connect to the primary users DB

### DIFF
--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -218,7 +218,7 @@ module "govwifi_admin" {
   rr_db_host = "rr.london.wifi.service.gov.uk"
   rr_db_name = "govwifi_wifi"
 
-  user_db_host = var.user_rr_hostname
+  user_db_host = var.user_db_hostname
   user_db_name = "govwifi_production_users"
 
   critical_notifications_arn = module.critical_notifications.topic_arn


### PR DESCRIPTION
### What
Switch govwifi-admin to connect to the primary users DB

### Why
As this will allow deleting users from the admin app, something which
currently happens but has to be done by hand.

In staging, I believe the admin app is currently connected to the
primary database.


Link to Trello card: https://trello.com/c/yw5VYGdD/2265-a-super-admin-can-delete-user-credentials