### PR TITLE
Cicd staging permissions

### DIFF
--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -69,3 +69,11 @@ data "aws_secretsmanager_secret_version" "tools_account" {
 data "aws_secretsmanager_secret" "tools_account" {
   name = "tools/AccountID"
 }
+
+data "aws_secretsmanager_secret_version" "tools_kms_key" {
+  secret_id = data.aws_secretsmanager_secret.tools_kms_key.id
+}
+
+data "aws_secretsmanager_secret" "tools_kms_key" {
+  name = "tools/codepipeline-kms-key-arn"
+}

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -61,3 +61,11 @@ data "aws_secretsmanager_secret" "user_signup_api_sentry_dsn" {
 data "aws_secretsmanager_secret" "logging_api_sentry_dsn" {
   name = "sentry/logging_api_dsn"
 }
+
+data "aws_secretsmanager_secret_version" "tools_account" {
+  secret_id = data.aws_secretsmanager_secret.tools_account.id
+}
+
+data "aws_secretsmanager_secret" "tools_account" {
+  name = "tools/AccountID"
+}

--- a/govwifi-api/wordlist.tf
+++ b/govwifi-api/wordlist.tf
@@ -21,3 +21,26 @@ resource "aws_s3_bucket_object" "wordlist" {
   source = var.wordlist_file_path
   etag   = filemd5(var.wordlist_file_path)
 }
+
+resource "aws_s3_bucket_policy" "wordlist_bucket_policy" {
+  count  = var.create_wordlist_bucket ? 1 : 0
+  bucket = aws_s3_bucket.wordlist[0].id
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ToolsAccess",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${data.aws_secretsmanager_secret_version.tools_account.secret_string}:role/govwifi-codebuild-role"
+            },
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::${aws_s3_bucket.wordlist[0].id}/*"
+        }
+    ]
+}
+POLICY
+
+}


### PR DESCRIPTION
### What
Add crossaccount role for use by Codepipeline.
Update permissions on wordlist S3 bucket so our AWSTools account can access it.

### Why
These updates are part of the migration from Concourse to AWS Codepipeline.

Link to Trello card (if applicable): 
https://trello.com/c/BleRw2qn/2353-tidy-up-terraform-code-ensure-the-module-will-work-across-all-deploy-pipelines-across-all-environments