### PR TITLE
Add govwifi-deploy module for creating AWS pipelines.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 check-env:
 	$(if ${DEPLOY_ENV},,$(error Must pass DEPLOY_ENV=<name>))
+
+govwifi-tools: #The name "tools" would be the obvious choice here, but this is a reserved word in Makefiles and will cause an error
+	$(eval export DEPLOY_ENV=tools)
+	$(eval export REPO=tools)
+	$(eval export AWS_REGION=eu-west-2)
 staging:
 	$(eval export DEPLOY_ENV=staging)
 	$(eval export REPO=staging)

--- a/govwifi-deploy/build_spec_convert.yml
+++ b/govwifi-deploy/build_spec_convert.yml
@@ -1,0 +1,14 @@
+version: 0.2
+phases:
+    build:
+        commands:
+            - ContainerName=$CONTAINER_APP_NAME
+            - ImageURI=$(cat imageDetail.json | jq -r '.ImageURI')
+            - printf '[{"name":"CONTAINER_NAME","imageUri":"IMAGE_URI"}]' > imagedefinitions.json
+            - sed -i -e "s|CONTAINER_NAME|$ContainerName|g" imagedefinitions.json
+            - sed -i -e "s|IMAGE_URI|$ImageURI|g" imagedefinitions.json
+            - cat imagedefinitions.json
+
+artifacts:
+    files:
+        - imagedefinitions.json

--- a/govwifi-deploy/codebuild.tf
+++ b/govwifi-deploy/codebuild.tf
@@ -1,0 +1,149 @@
+resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr" {
+  for_each      = toset(var.app_names)
+  name          = "govwifi-codebuild-${each.key}-push-image-to-ecr"
+  description   = "Test codebuild project for the ${each.key}"
+  build_timeout = "5"
+  service_role  = aws_iam_role.govwifi_codebuild.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  cache {
+    type     = "S3"
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID"
+      value = local.aws_account_id
+    }
+
+    environment_variable {
+      name  = "AWS_REGION"
+      value = "eu-west-2"
+    }
+
+    environment_variable {
+      name  = "STAGE"
+      value = "staging"
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_AUTHTOKEN_ENV"
+      value = "/govwifi-cd/pipelines/main/docker_hub_authtoken"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_USERNAME_ENV"
+      value = "/govwifi-cd/pipelines/main/docker_hub_username"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "WORDLIST_BUCKET_NAME"
+      value = "/govwifi-cd/pipelines/main/wordlist_bucket_name"
+      type  = "PARAMETER_STORE"
+    }
+
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "govwifi-codebuild-push-image-to-ecr-log-group"
+      stream_name = "govwifi-codebuild-push-image-to-ecr-log-stream"
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${aws_s3_bucket.codepipeline_bucket.id}/build-log"
+    }
+  }
+
+  source_version = "codebuild-test"
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/alphagov/govwifi-${each.key}.git"
+    git_clone_depth = 1
+    buildspec       = "buildspec-build.yml"
+  }
+
+}
+
+resource "aws_codebuild_webhook" "govwifi_app_webhook" {
+  for_each     = toset(var.app_names)
+  project_name = aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr[each.key].name
+
+  build_type = "BUILD"
+
+  filter_group {
+    filter {
+      type    = "EVENT"
+      pattern = "PUSH"
+    }
+
+    filter {
+      type    = "HEAD_REF"
+      pattern = "^refs/heads/codebuild-test$"
+    }
+  }
+}
+
+
+### This job converts the ECR image into a format usable by the ECS deploy stage
+### more info here: https://stackoverflow.com/questions/61919191/how-to-deploy-to-ecs-when-an-image-is-pushed-to-ecr
+
+resource "aws_codebuild_project" "govwifi_codebuild_project_convert_image_format" {
+  for_each       = toset(var.app_names)
+  name           = "govwifi-codebuild-convert-image-format-${each.key}"
+  description    = "This job converts the ECR image into a format usable by the ECS deploy stage"
+  build_timeout  = "5"
+  service_role   = aws_iam_role.govwifi_codebuild_convert.arn
+  encryption_key = aws_kms_key.codepipeline_key.arn
+
+  artifacts {
+    type      = "CODEPIPELINE"
+    packaging = "ZIP"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    environment_variable {
+      name  = "CONTAINER_APP_NAME"
+      value = each.key
+    }
+  }
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = file("${path.module}/build_spec_convert.yml")
+
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "govwifi-codebuild-convert-image-group"
+      stream_name = "govwifi-codebuild-convert-image-group-log-stream"
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${aws_s3_bucket.codepipeline_bucket.id}/image-convert-log"
+    }
+  }
+
+}

--- a/govwifi-deploy/codepipeline.tf
+++ b/govwifi-deploy/codepipeline.tf
@@ -1,0 +1,67 @@
+resource "aws_codepipeline" "codepipeline" {
+  for_each = toset(var.app_names)
+  name     = "govwifi-deploy-${each.key}-staging-pipeline"
+  role_arn = aws_iam_role.govwifi_codepipeline_staging_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "NewECRImagDetectedFor-${each.key}"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        RepositoryName = "govwifi/staging/${each.key}"
+      }
+    }
+  }
+
+  stage {
+    name = "govwifi-build-${each.key}-convert-imagedetail"
+
+    action {
+      name             = "govwifi-build-${each.key}-convert-imagedetail"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["SourceArtifact"]
+      output_artifacts = ["govwifi-build-${each.key}-convert-imagedetail-amended"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format[each.key].name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy"
+
+    action {
+      name            = "Deploy"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-${each.key}-convert-imagedetail-amended"]
+      version         = "1"
+      region          = "eu-west-2"
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "staging-api-cluster"
+        ServiceName : "${each.key}-service-staging"
+      }
+    }
+  }
+}

--- a/govwifi-deploy/ecr.tf
+++ b/govwifi-deploy/ecr.tf
@@ -1,0 +1,33 @@
+resource "aws_ecr_repository" "govwifi_ecr_repo" {
+  for_each = toset(var.app_names)
+  name     = "govwifi/staging/${each.key}"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_repo_policy" {
+  for_each   = toset(var.app_names)
+  repository = aws_ecr_repository.govwifi_ecr_repo[each.key].name
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPushPull",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${local.aws_staging_account_id}:root"
+      },
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:CompleteLayerUpload",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:InitiateLayerUpload",
+        "ecr:PutImage",
+        "ecr:UploadLayerPart"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/govwifi-deploy/github-connections.tf
+++ b/govwifi-deploy/github-connections.tf
@@ -1,0 +1,10 @@
+resource "aws_codebuild_source_credential" "govwifi_github_token" {
+  auth_type   = "PERSONAL_ACCESS_TOKEN"
+  server_type = "GITHUB"
+  token       = jsondecode(data.aws_secretsmanager_secret_version.github_token.secret_string)["token"]
+}
+
+# # resource "aws_codestarconnections_connection" "github_connection" {
+# #   name          = "govwifi-connection"
+# #   provider_type = "GitHub"
+# # }

--- a/govwifi-deploy/iam-codebuild-image-covert.tf
+++ b/govwifi-deploy/iam-codebuild-image-covert.tf
@@ -1,0 +1,103 @@
+resource "aws_iam_role" "govwifi_codebuild_convert" {
+  name = "govwifi-codebuild-convert-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "govwifi_codebuild_convert_staging_role_access_cloudwatch_policy" {
+  name = "cloudwatch-logs-for-codepipeline-staging"
+  path = "/"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:logs:eu-west-2:${local.aws_account_id}:log-group:govwifi-codebuild-convert-image-group",
+                "arn:aws:logs:eu-west-2:${local.aws_account_id}:log-group:govwifi-codebuild-convert-image-group:*"
+            ],
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "govwifi_codebuild_convert_cloudwatch_policy" {
+  name       = "codebuild-convert-cloudwatch-policy"
+  roles      = [aws_iam_role.govwifi_codebuild_convert.name]
+  policy_arn = aws_iam_policy.govwifi_codebuild_convert_staging_role_access_cloudwatch_policy.arn
+}
+
+resource "aws_iam_policy" "govwifi_codebuild_convert_service_policy" {
+  name = "codebuild-convert-service-role"
+  path = "/"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:logs:eu-west-2:${local.aws_account_id}:log-group:/aws/codebuild/govwifi-codebuild-convert-image-format",
+                "arn:aws:logs:eu-west-2:${local.aws_account_id}:log-group:/aws/codebuild/govwifi-codebuild-convert-image-format:*"
+            ],
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ]
+        },
+        {
+            "Effect": "Allow",
+						"Action": [
+							"s3:*"
+						],
+            "Resource": [
+                "${aws_s3_bucket.codepipeline_bucket.arn}",
+                "${aws_s3_bucket.codepipeline_bucket.arn}/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages"
+            ],
+            "Resource": [
+                "arn:aws:codebuild:eu-west-2:${local.aws_account_id}:report-group/govwifi-codebuild-convert-image-format-*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "govwifi_codebuild_convert_service_role" {
+  name       = "codebuild-convert-service-role"
+  roles      = [aws_iam_role.govwifi_codebuild_convert.name]
+  policy_arn = aws_iam_policy.govwifi_codebuild_convert_service_policy.arn
+}

--- a/govwifi-deploy/iam-codebuild-image-push.tf
+++ b/govwifi-deploy/iam-codebuild-image-push.tf
@@ -1,0 +1,108 @@
+resource "aws_iam_role" "govwifi_codebuild" {
+  name = "govwifi-codebuild-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_iam_policy" "govwifi_codebuild_role_policy" {
+  name = "GovwifiCodeBuildServiceRolePolicy"
+  path = "/"
+
+  policy = <<EOF
+{
+    "Statement": [
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "CloudWatchLogsPolicy"
+        },
+        {
+            "Action": [
+                "codecommit:GitPull"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "CodeCommitPolicy"
+        },
+        {
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectVersion"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "S3GetObjectPolicy"
+        },
+        {
+            "Action": [
+                "s3:PutObject"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "S3PutObjectPolicy"
+        },
+        {
+            "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "ECRPullPolicy"
+        },
+        {
+            "Action": [
+                "ecr:GetAuthorizationToken"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "ECRAuthPolicy"
+        },
+        {
+            "Action": [
+                "s3:GetBucketAcl",
+                "s3:GetBucketLocation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "S3BucketIdentity"
+        }
+    ],
+    "Version": "2012-10-17"
+}
+EOF
+
+}
+
+resource "aws_iam_policy_attachment" "govwifi_codebuild_role_policy" {
+  name       = "govwifi-codebuild-role-policy"
+  roles      = [aws_iam_role.govwifi_codebuild.name]
+  policy_arn = aws_iam_policy.govwifi_codebuild_role_policy.arn
+}
+
+
+resource "aws_iam_policy_attachment" "codepipeline_ssm_readonly" {
+  name       = "codepipeline-ssm-readonly"
+  roles      = [aws_iam_role.govwifi_codebuild.name]
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+}

--- a/govwifi-deploy/iam-codepipeline.tf
+++ b/govwifi-deploy/iam-codepipeline.tf
@@ -1,0 +1,117 @@
+resource "aws_iam_role" "govwifi_codepipeline_staging_role" {
+  name               = "govwifi-codepipeline-staging-role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codepipeline.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+# I think that this should just be delete and we have one role eventually
+resource "aws_iam_role" "govwifi_codepipeline_production_role" {
+  name               = "govwifi-codepipeline-production-role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codepipeline.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codepipeline_staging_policy" {
+  name = "govwifi-codepipeline-staging-policy"
+  role = aws_iam_role.govwifi_codepipeline_staging_role.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:*"
+            ],
+            "Resource": [
+								"${aws_s3_bucket.codepipeline_bucket.arn}",
+								"${aws_s3_bucket.codepipeline_bucket.arn}/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "sts:AssumeRole"
+            ],
+            "Resource": "arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-crossaccount-tools-deploy",
+            "Effect": "Allow"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "govwifi_pipeline_staging_role_additional_policy" {
+  name = "govwifi-additional-policy-for-codepipeline-staging"
+  path = "/"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "kms:GenerateDataKey",
+            "Resource": "*"
+        },
+				{
+						"Sid": "",
+						"Effect": "Allow",
+						"Action": "ecr:DescribeImages",
+						"Resource": "*"
+				}
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "govwifi_pipeline_staging_role_additional_policy" {
+  name       = "govwifi-additional-policy-for-codepipeline-staging"
+  roles      = [aws_iam_role.govwifi_codepipeline_staging_role.name]
+  policy_arn = aws_iam_policy.govwifi_pipeline_staging_role_additional_policy.arn
+}
+
+resource "aws_iam_policy_attachment" "codepipeline_kms_power_user" {
+  name       = "codepipeline-kms-power-user"
+  roles      = [aws_iam_role.govwifi_codepipeline_staging_role.name]
+  policy_arn = "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+}
+
+resource "aws_iam_policy_attachment" "codepipeline_ecr_power_user" {
+  name       = "codepipeline-ecr-power-user"
+  roles      = [aws_iam_role.govwifi_codepipeline_staging_role.name, aws_iam_role.govwifi_codebuild.name]
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}

--- a/govwifi-deploy/kms.tf
+++ b/govwifi-deploy/kms.tf
@@ -1,0 +1,75 @@
+# Creates/manages KMS CMK
+resource "aws_kms_key" "codepipeline_key" {
+  description = "Key used across accounts Tools, Staging & Production to encrypt and decrypt S3 artifacts used in codebuild and codepipeline initially."
+  policy      = <<EOF
+{
+    "Version": "2012-10-17",
+    "Id": "CodepipelineKeyPolicy",
+    "Statement": [
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${local.aws_account_id}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${local.aws_account_id}:role/${aws_iam_role.govwifi_codebuild_convert.name}"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow use of the key",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${local.aws_staging_account_id}:root"
+            },
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey",
+                "kms:List*",
+                "kms:Put*",
+                "kms:Update*",
+                "kms:Revoke*",
+                "kms:Disable*",
+                "kms:Get*"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow attachment of persistent resources",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${local.aws_staging_account_id}:root"
+            },
+            "Action": [
+                "kms:CreateGrant",
+                "kms:ListGrants",
+                "kms:RevokeGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": "true"
+                }
+            }
+        }
+    ]
+}
+EOF
+}
+
+# Add an alias to the key
+resource "aws_kms_alias" "codepipeline_key_alias" {
+  name          = "alias/govwifi-aws-developer-tools-kms-key-terraformed"
+  target_key_id = aws_kms_key.codepipeline_key.key_id
+}

--- a/govwifi-deploy/locals.tf
+++ b/govwifi-deploy/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  aws_staging_account_id = jsondecode(data.aws_secretsmanager_secret_version.staging_aws_account_no.secret_string)["account-id"]
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  aws_account_id = data.aws_caller_identity.current.account_id
+}

--- a/govwifi-deploy/main.tf
+++ b/govwifi-deploy/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/govwifi-deploy/s3.tf
+++ b/govwifi-deploy/s3.tf
@@ -1,0 +1,67 @@
+resource "aws_s3_bucket" "codepipeline_bucket" {
+  bucket = "govwifi-codepipeline-bucket"
+}
+
+resource "aws_s3_bucket_policy" "codepipeline_bucket_policy" {
+  bucket = aws_s3_bucket.codepipeline_bucket.id
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Id": "SSEAndSSLPolicy",
+    "Statement": [
+        {
+            "Sid": "DenyUnEncryptedObjectUploads",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:PutObject",
+            "Resource": "${aws_s3_bucket.codepipeline_bucket.arn}/*",
+            "Condition": {
+                "StringNotEquals": {
+                    "s3:x-amz-server-side-encryption": "aws:kms"
+                }
+            }
+        },
+        {
+            "Sid": "DenyInsecureConnections",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:*",
+            "Resource": "${aws_s3_bucket.codepipeline_bucket.arn}/*",
+            "Condition": {
+                "Bool": {
+                    "aws:SecureTransport": "false"
+                }
+            }
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-crossaccount-tools-deploy"
+            },
+            "Action": [
+                "s3:Get*",
+                "s3:Put*"
+            ],
+            "Resource": "${aws_s3_bucket.codepipeline_bucket.arn}/*"
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-crossaccount-tools-deploy"
+            },
+            "Action": "s3:ListBucket",
+            "Resource": "${aws_s3_bucket.codepipeline_bucket.arn}"
+        }
+    ]
+}
+POLICY
+
+}
+
+resource "aws_s3_bucket_acl" "codepipeline_bucket_acl" {
+  bucket = aws_s3_bucket.codepipeline_bucket.id
+  acl    = "private"
+}

--- a/govwifi-deploy/secrets-manager.tf
+++ b/govwifi-deploy/secrets-manager.tf
@@ -1,0 +1,15 @@
+data "aws_secretsmanager_secret_version" "github_token" {
+  secret_id = data.aws_secretsmanager_secret.github_token.id
+}
+
+data "aws_secretsmanager_secret" "github_token" {
+  name = "github/deployment-user"
+}
+
+data "aws_secretsmanager_secret_version" "staging_aws_account_no" {
+  secret_id = data.aws_secretsmanager_secret.staging_aws_account_no.id
+}
+
+data "aws_secretsmanager_secret" "staging_aws_account_no" {
+  name = "staging/AccountID"
+}

--- a/govwifi-deploy/variables.tf
+++ b/govwifi-deploy/variables.tf
@@ -1,0 +1,2 @@
+variable "app_names" {
+}

--- a/govwifi/tools/.terraform.lock.hcl
+++ b/govwifi/tools/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.9.0"
+  hashes = [
+    "h1:OWIIlbMZl/iQ8qR1U7Co3sGjNHL1HJtgNRnnV1kXNuI=",
+    "zh:084b83aef3335ad4f5e4b8323c6fe43c1ff55e17a7647c6a5cad6af519f72b42",
+    "zh:132e47ce69f14de4523b84b213cedf7173398acda14245b1ffe7747aac50f050",
+    "zh:2068baef7dfce3613f3b4f27314175e971f8db68d9cde9ec30b5659f80c68c6c",
+    "zh:63c6f489683d5f1ac55e82a0df387143ed22701d5f22c109a4d5c9924dd4e437",
+    "zh:8115fd21965954fa4568c09331e05bb29da967fab8d077419aed09954378e216",
+    "zh:8efdc95fde108f777ed9c79ae25dc17aea9771903250f5c5c8a4c726b90a345f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d42a7bc34d84b70c1d1bcc215cabd63abbcbd0352b70bd84da6c3916634932f",
+    "zh:aacbcceb241aa475888c0869e87593182edeced3170c76a0c960dd9c905df449",
+    "zh:c7fe7904511052e4102870256819a1917177572cf684f0611ebf767f9c1fbaa8",
+    "zh:c8e07c3424663d1d0e7e32f4ade8099c19f6326d37c6da98104d90c986ff66fc",
+    "zh:e47cafbd38b56ef14fd8d727b4ffea847c166b1c684f585ee5fb78983b537248",
+  ]
+}

--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -1,0 +1,51 @@
+# module "tfstate" {
+#   providers = {
+#     aws = aws.main
+#   }
+#
+#   source             = "../../terraform-state"
+#   product_name       = local.product_name
+#   env_name           = local.env_name
+#   aws_account_id     = local.aws_account_id
+#   aws_region_name    = var.aws_region_name
+#   backup_region_name = var.backup_region_name
+#
+#   # TODO: separate module for accesslogs
+#   accesslogs_glacier_transition_days = 7
+#   accesslogs_expiration_days         = 30
+# }
+
+terraform {
+  required_version = "~> 1.1.8"
+
+  backend "s3" {
+    # Interpolation is not allowed here.
+    #bucket = "${lower(local.product_name)}-${lower(local.env_name)}-${lower(var.aws_region_name)}-tfstate"
+    #key    = "${lower(var.aws_region_name)}-tfstate"
+    #region = "${var.aws_region}"
+    bucket = "govwifi-tools-tfstate"
+
+    key    = "govwifi-terraform-tfstate"
+    region = "eu-west-2"
+  }
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "main"
+  region = var.aws_region
+}
+
+module "govwifi_deploy" {
+  providers = {
+    aws = aws.main
+  }
+
+  source    = "../../govwifi-deploy"
+  app_names = ["user-signup-api"]
+
+}

--- a/govwifi/tools/variables.tf
+++ b/govwifi/tools/variables.tf
@@ -1,0 +1,6 @@
+# Entries below should probably stay as is for different environments
+#####################################################################
+variable "aws_region" {
+  type    = string
+  default = "eu-west-2"
+}


### PR DESCRIPTION
### What
Add govwifi-deploy module for creating AWS pipelines. This module is used for
creating deployment pipelines in our AWS Tools account.

Also set up main file for our Tools account.

### Why
This is part of our migration from Concourse to AWS’s managed code deployment
service.

