### PR TITLE
Rename all container references 'logging' to 'logging-api'

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -40,7 +40,7 @@ resource "aws_ecs_task_definition" "logging_api_task" {
       "essential": true,
       "entryPoint": null,
       "mountPoints": [],
-      "name": "logging",
+      "name": "logging-api",
       "ulimits": null,
       "dockerSecurityOptions": null,
       "environment": [
@@ -141,7 +141,7 @@ resource "aws_ecs_service" "logging_api_service" {
 
   load_balancer {
     target_group_arn = aws_alb_target_group.logging_api_tg[0].arn
-    container_name   = "logging"
+    container_name   = "logging-api"
     container_port   = "8080"
   }
 

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -86,7 +86,7 @@ resource "aws_cloudwatch_event_target" "logging_daily_session_deletion" {
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "daily_session_deletion"]
     }
   ]
@@ -125,7 +125,7 @@ resource "aws_cloudwatch_event_target" "gdpr_set_user_last_login" {
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "update_yesterdays_last_login"]
     }
   ]
@@ -164,7 +164,7 @@ resource "aws_cloudwatch_event_target" "hourly_request_statistics" {
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "send_request_statistics"]
     }
   ]
@@ -204,7 +204,7 @@ resource "aws_cloudwatch_event_target" "publish_monthly_metrics_logging" {
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "publish_monthly_metrics"]
     }
   ]
@@ -243,7 +243,7 @@ resource "aws_cloudwatch_event_target" "publish_weekly_metrics_logging" {
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "publish_weekly_metrics"]
     }
   ]
@@ -282,7 +282,7 @@ resource "aws_cloudwatch_event_target" "publish_daily_metrics_logging" {
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "publish_daily_metrics"]
     }
   ]
@@ -321,7 +321,7 @@ resource "aws_cloudwatch_event_target" "publish_monthly_metrics_to_elasticsearch
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "publish_monthly_metrics_to_elasticsearch"]
     }
   ]
@@ -360,7 +360,7 @@ resource "aws_cloudwatch_event_target" "publish_weekly_metrics_to_elasticsearch"
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "publish_weekly_metrics_to_elasticsearch"]
     }
   ]
@@ -399,7 +399,7 @@ resource "aws_cloudwatch_event_target" "publish_daily_metrics_to_elasticsearch" 
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "publish_daily_metrics_to_elasticsearch"]
     }
   ]
@@ -438,7 +438,7 @@ resource "aws_cloudwatch_event_target" "publish_metrics_to_data_bucket" {
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "sync_s3_to_data_bucket[${var.metrics_bucket_name}, ${var.export_data_bucket_name}]"]
     }
   ]
@@ -477,7 +477,7 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
       "essential": true,
       "entryPoint": null,
       "mountPoints": [],
-      "name": "logging",
+      "name": "logging-api",
       "ulimits": null,
       "dockerSecurityOptions": null,
       "environment": [
@@ -588,7 +588,7 @@ resource "aws_cloudwatch_event_target" "sync_s3_to_elasticsearch" {
 {
   "containerOverrides": [
     {
-      "name": "logging",
+      "name": "logging-api",
       "command": ["bundle", "exec", "rake", "sync_s3_volumetrics"]
     }
   ]


### PR DESCRIPTION
### What
Make container name consistent with the name we use for the ECS service,
cluster and task definition. In our ECS task definitions we currently declare a
container name that is different from the app, task and cluster name:
https://github.com/alphagov/govwifi-terraform/blob/13c45e4791ba82dfaba89cf68847eb2d720c4825/govwifi-api/logging-api-cluster.tf#L144

This name is also referenced in our application code, see here for an example:
https://github.com/alphagov/govwifi-logging-api/search?q=container_name

The name used is "logging" but elsewhere we use "logging-api" to refer
to related resources like the ECS service. This should be consistent -
"logging-api" should be used everywhere, and references to "logging"
should be deleted.

### Why
Using different values for the container name, service name and cluster
name is confusing and makes writing AWS pipeline code more complicated.


Link to Trello card (if applicable): https://trello.com/c/RdBIxo8X/2428-make-logging-api-container-name-references-in-terraform-deploy-process-consistent
