### PR TITLE
Start the transition to frontend using fargate and a load balancer

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -9,6 +9,17 @@ resource "aws_ecs_cluster" "frontend_cluster" {
   }
 }
 
+resource "aws_ecs_cluster" "frontend_fargate" {
+  name = "frontend-fargate"
+
+  capacity_providers = ["FARGATE"]
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
 resource "aws_cloudwatch_log_group" "frontend_log_group" {
   name = "${var.env_name}-frontend-docker-log-group"
 
@@ -174,6 +185,145 @@ EOF
 
 }
 
+resource "aws_ecs_task_definition" "frontend_fargate" {
+  family             = "frontend-fargate"
+  task_role_arn      = aws_iam_role.ecs_task_role.arn
+  execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
+
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 1024
+  memory                   = 2048
+
+  volume {
+    name = "raddb-certs"
+  }
+
+  container_definitions = <<EOF
+[
+  {
+    "portMappings": [
+      {
+        "hostPort": 3000,
+        "containerPort": 3000,
+        "protocol": "tcp"
+      },
+      {
+        "hostPort": 1812,
+        "containerPort": 1812,
+        "protocol": "udp"
+      },
+      {
+        "hostPort": 1813,
+        "containerPort": 1813,
+        "protocol": "udp"
+      },
+      {
+        "hostPort": 9812,
+        "containerPort": 9812,
+        "protocol": "tcp"
+      }
+    ],
+    "essential": true,
+    "mountPoints": [
+      {
+        "sourceVolume": "raddb-certs",
+        "containerPath": "/etc/raddb/certs"
+      }
+    ],
+    "name": "frontend-radius",
+    "environment": [
+      {
+        "name": "AUTHORISATION_API_BASE_URL",
+        "value": "${var.auth_api_base_url}"
+      },{
+        "name": "LOGGING_API_BASE_URL",
+        "value": "${var.logging_api_base_url}"
+      },{
+        "name": "RADIUSD_PARAMS",
+        "value": "${var.radiusd_params}"
+      },{
+        "name": "RACK_ENV",
+        "value": "${var.rack_env}"
+      },{
+        "name": "SERVICE_DOMAIN",
+        "value": "${var.env_subdomain}"
+      },{
+        "name": "SENTRY_CURRENT_ENV",
+        "value": "${var.sentry_current_env}"
+      }
+    ],
+    "secrets": [
+      {
+        "name": "BACKEND_API_KEY",
+        "valueFrom": "${data.aws_secretsmanager_secret_version.shared_key.arn}:shared-key::"
+      },{
+        "name": "HEALTH_CHECK_IDENTITY",
+        "valueFrom": "${data.aws_secretsmanager_secret_version.healthcheck.arn}:identity::"
+      },{
+        "name": "HEALTH_CHECK_PASSWORD",
+        "valueFrom": "${data.aws_secretsmanager_secret_version.healthcheck.arn}:pass::"
+      },{
+        "name": "HEALTH_CHECK_RADIUS_KEY",
+        "valueFrom": "${data.aws_secretsmanager_secret_version.healthcheck.arn}:key::"
+      },{
+        "name": "HEALTH_CHECK_SSID",
+        "valueFrom": "${data.aws_secretsmanager_secret_version.healthcheck.arn}:ssid::"
+      }
+    ],
+    "image": "${var.frontend_docker_image}",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_cloudwatch_log_group.frontend_log_group.name}",
+        "awslogs-region": "${var.aws_region}",
+        "awslogs-stream-prefix": "${var.env_name}-docker-logs"
+      }
+    },
+    "expanded": true,
+    "dependsOn": [
+      {
+        "containerName": "populate-radius-certs",
+        "condition": "SUCCESS"
+      }
+    ]
+  },
+  {
+    "essential": false,
+    "mountPoints": [
+      {
+        "sourceVolume": "raddb-certs",
+        "containerPath": "/etc/raddb/certs"
+      }
+    ],
+    "name": "populate-radius-certs",
+    "environment": [
+      {
+        "name": "WHITELIST_BUCKET",
+        "value": "s3://${var.admin_app_data_s3_bucket_name}"
+      },{
+        "name": "ALLOWLIST_BUCKET",
+        "value": "s3://${var.admin_app_data_s3_bucket_name}"
+      },{
+        "name": "CERT_STORE_BUCKET",
+        "value": "s3://${aws_s3_bucket.frontend_cert_bucket.bucket}"
+      }
+    ],
+    "image": "${var.raddb_docker_image}",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_cloudwatch_log_group.frontend_log_group.name}",
+        "awslogs-region": "${var.aws_region}",
+        "awslogs-stream-prefix": "${var.env_name}-docker-logs"
+      }
+    },
+    "expanded": true
+  }
+]
+EOF
+}
+
 resource "aws_ecs_service" "frontend_service" {
   name            = "frontend-service-${var.env_name}"
   cluster         = aws_ecs_cluster.frontend_cluster.id
@@ -184,4 +334,90 @@ resource "aws_ecs_service" "frontend_service" {
     type  = "spread"
     field = "instanceId"
   }
+}
+
+resource "aws_ecs_service" "load_balanced_frontend_service" {
+  name            = "load-balanced-frontend"
+  cluster         = aws_ecs_cluster.frontend_fargate.id
+  launch_type     = "FARGATE"
+  task_definition = aws_ecs_task_definition.frontend_fargate.arn
+  desired_count   = var.radius_instance_count
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.main.arn
+    container_name   = "frontend-radius"
+    container_port   = 1812
+  }
+
+  network_configuration {
+    subnets = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+
+    security_groups = [
+      aws_security_group.load_balanced_frontend_service.id,
+    ]
+  }
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id            = aws_vpc.wifi_frontend.id
+  service_name      = "com.amazonaws.${var.aws_region}.ecr.dkr"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoints.id,
+  ]
+
+  subnet_ids = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id            = aws_vpc.wifi_frontend.id
+  service_name      = "com.amazonaws.${var.aws_region}.ecr.api"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoints.id,
+  ]
+
+  subnet_ids = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.wifi_frontend.id
+  service_name      = "com.amazonaws.${var.aws_region}.s3"
+  vpc_endpoint_type = "Gateway"
+
+  route_table_ids = [aws_vpc.wifi_frontend.main_route_table_id]
+}
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id            = aws_vpc.wifi_frontend.id
+  service_name      = "com.amazonaws.${var.aws_region}.secretsmanager"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoints.id,
+  ]
+
+  subnet_ids = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "logs" {
+  vpc_id            = aws_vpc.wifi_frontend.id
+  service_name      = "com.amazonaws.${var.aws_region}.logs"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.vpc_endpoints.id,
+  ]
+
+  subnet_ids = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+
+  private_dns_enabled = true
 }

--- a/govwifi-frontend/load-balancer.tf
+++ b/govwifi-frontend/load-balancer.tf
@@ -1,0 +1,51 @@
+resource "aws_lb" "main" {
+  name               = "frontend"
+  load_balancer_type = "network"
+
+  dynamic "subnet_mapping" {
+    for_each = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+    iterator = subnet_id
+
+    content {
+      subnet_id     = subnet_id.value
+      allocation_id = aws_eip.test_radius_eips[subnet_id.key].id
+    }
+  }
+}
+
+resource "aws_lb_listener" "main" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = "1812"
+  protocol          = "UDP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.main.arn
+  }
+}
+
+resource "aws_lb_target_group" "main" {
+  name        = "frontend"
+  port        = 1812
+  protocol    = "UDP"
+  vpc_id      = aws_vpc.wifi_frontend.id
+  target_type = "ip"
+}
+
+# TODO These EIPs are being used to test the network load balancer,
+# and can be replaced by the radius_eips once the network load
+# balancer is used behind these eips
+resource "aws_eip" "test_radius_eips" {
+  count = var.radius_instance_count
+  vpc   = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    Name   = "${title(var.env_name)} Frontend Radius-${var.dns_numbering_base + count.index + 1}"
+    Region = title(var.aws_region_name)
+    Env    = title(var.env_name)
+  }
+}


### PR DESCRIPTION
### What
The commit adda a whole new set of resources to run frontend (RADIUS)
as a load balanced service using ECS Fargate.


### Why
The intent here is to run this in addition to the current EC2 setup,
then migrate EIPs over to the load balancer. For testing prior to
this, a new set of EIPs is used, and these will be deregistered once
the migration is complete.


Link to Trello card: https://trello.com/c/5zf9ZXj5/2399-add-udp-network-loadbalancers-in-front-of-the-radius-servers-to-increase-resiliency