### PR TITLE
Add variables with ALLOWLIST when WHITELIST is used in user signup api

### DIFF
--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -125,7 +125,13 @@ resource "aws_ecs_task_definition" "user_signup_api_task" {
           "name": "S3_SIGNUP_WHITELIST_BUCKET",
           "value": "${data.aws_s3_bucket.admin_bucket[0].bucket}"
         },{
+          "name": "S3_SIGNUP_ALLOWLIST_BUCKET",
+          "value": "${data.aws_s3_bucket.admin_bucket[0].bucket}"
+        },{
           "name": "S3_SIGNUP_WHITELIST_OBJECT_KEY",
+          "value": "signup-whitelist.conf"
+        },{
+          "name": "S3_SIGNUP_ALLOWLIST_OBJECT_KEY",
           "value": "signup-whitelist.conf"
         },{
           "name": "FIRETEXT_TOKEN",


### PR DESCRIPTION
### What
Add variables with ALLOWLIST when WHITELIST is used in user signup api

### Why
In the user signup api all affected variables are renamed to 'allowlist'
To accommodate this change, the first step is to add ALLOWLIST
variables so the switchover can be smooth.

In a further commit the WHITELIST references will be removed
