### PR TITLE
Add Allowlist variable to frontend configuration

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -149,6 +149,9 @@ resource "aws_ecs_task_definition" "radius_task" {
         "name": "WHITELIST_BUCKET",
         "value": "s3://${var.admin_app_data_s3_bucket_name}"
       },{
+        "name": "ALLOWLIST_BUCKET",
+        "value": "s3://${var.admin_app_data_s3_bucket_name}"
+      },{
         "name": "CERT_STORE_BUCKET",
         "value": "s3://${aws_s3_bucket.frontend_cert_bucket.bucket}"
       }


### PR DESCRIPTION
### What
Add Allowlist variable to frontend configuration

### Why
This is to allow a smooth transition to rename whitelist to
allowlist in the frontend in line with the style guide

The reference to 'whitelist' will be removed once frontend
is deployed
