### PR TITLE
Replace template_file structure for Mac M1 (Apple silicone)

### DIFF
--- a/sns-notification/main.tf
+++ b/sns-notification/main.tf
@@ -10,42 +10,20 @@ resource "aws_sns_topic" "this" {
   name = var.topic_name
 }
 
-data "template_file" "email_subscription" {
-  count = length(var.emails)
-
-  vars = {
-    email     = element(var.emails, count.index)
-    index     = count.index
-    topic_arn = aws_sns_topic.this.arn
-    # Name must be alphanumeric, unique, but also consistent based on the email address.
-    # It also needs to stay under 255 characters.
-    name = sha256("${var.topic_name}-${element(var.emails, count.index)}")
-  }
-
-  template = <<-STACK
-  $${jsonencode(name)}: {
-    "Type" : "AWS::SNS::Subscription",
-    "Properties": {
-      "Endpoint": $${jsonencode(email)},
-      "Protocol": "email",
-      "TopicArn": $${jsonencode(topic_arn)}
-    }
-  }
-STACK
-
-}
-
 resource "aws_cloudformation_stack" "email" {
   count = local.enable_emails
   name  = "${var.topic_name}-subscriptions"
 
-  template_body = <<-STACK
-  {
-    "Resources": {
-      ${join(",", sort(data.template_file.email_subscription.*.rendered))}
+  template_body = jsonencode({
+    "Resources" = {
+      for email in var.emails : sha256("${var.topic_name}-${email}") => {
+        "Type" = "AWS::SNS::Subscription",
+        "Properties" = {
+          "Endpoint" = email,
+          "Protocol" = "email",
+          "TopicArn" = aws_sns_topic.this.arn
+        }
+      }
     }
-  }
-STACK
-
+  })
 }
-


### PR DESCRIPTION
### What
This change refactors our terraform to remove the template_file structure and replace it with templatefile or other refactored code.

### Why
Template_file structure is a deprecated structure and is not supported by the version of the provider on Mac M1 (Apple silicone). So a replacement structure and / or code is required in order to remove the provider from terraform and enable our code to be executed on the new hardware.

### Testing
To prepare the test, we need to execute a terraform plan and apply on old Mac hardware. This will update the state in AWS S3 removing the deprecated provider from STAGING and if successful, PRODUCTION.
To test using a Mac M1 (Apple silicone): initialise the backend from S3, execute terraform plan & apply for STAGING and PRODUCTION successfully. There should be zero new assets or changed assets in AWS because the code should generate exactly the same state but without the template provider.

Link to Trello card (if applicable):
https://trello.com/c/PpqGUlLO/2423-get-terraform-working-on-apple-silicone-architecture-macbooks
