### PR TITLE
Add logging-api codepipeline project.

### DIFF
--- a/govwifi-deploy/buildspec_acceptance_tests.yml
+++ b/govwifi-deploy/buildspec_acceptance_tests.yml
@@ -1,0 +1,11 @@
+version: 0.2
+phases:
+    pre_build:
+        commands:
+              - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+    build:
+        commands:
+            - echo "Acceptance tests running"
+            - git clone https://github.com/alphagov/govwifi-acceptance-tests.git
+            - cd govwifi-acceptance-tests
+            - make test

--- a/govwifi-deploy/iam-codebuild-image-push.tf
+++ b/govwifi-deploy/iam-codebuild-image-push.tf
@@ -106,3 +106,9 @@ resource "aws_iam_policy_attachment" "codepipeline_ssm_readonly" {
   roles      = [aws_iam_role.govwifi_codebuild.name]
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
 }
+
+resource "aws_iam_policy_attachment" "codebuild_start_build_perm" {
+  name       = "codebuild-startbuild-perm"
+  roles      = [aws_iam_role.govwifi_codebuild.name]
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeBuildDeveloperAccess"
+}

--- a/govwifi-deploy/secrets-manager.tf
+++ b/govwifi-deploy/secrets-manager.tf
@@ -13,3 +13,19 @@ data "aws_secretsmanager_secret_version" "staging_aws_account_no" {
 data "aws_secretsmanager_secret" "staging_aws_account_no" {
   name = "staging/AccountID"
 }
+
+data "aws_secretsmanager_secret_version" "docker_hub_authtoken" {
+  secret_id = data.aws_secretsmanager_secret.docker_hub_authtoken.id
+}
+
+data "aws_secretsmanager_secret" "docker_hub_authtoken" {
+  name = "deploy/docker_hub_authtoken"
+}
+
+data "aws_secretsmanager_secret_version" "docker_hub_username" {
+  secret_id = data.aws_secretsmanager_secret.docker_hub_username.id
+}
+
+data "aws_secretsmanager_secret" "docker_hub_username" {
+  name = "deploy/docker_hub_username"
+}

--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -46,6 +46,6 @@ module "govwifi_deploy" {
   }
 
   source    = "../../govwifi-deploy"
-  app_names = ["user-signup-api"]
+  app_names = ["user-signup-api", "logging-api"]
 
 }


### PR DESCRIPTION
### What
Add logging-api codepipeline project.
Add acceptance tests codebuild project.

### Why
We are migrating our pipelines from Concourse to AWS. 

Link to Trello card (if applicable): 
https://trello.com/c/8LvfdcSL/2400-migrate-the-remaining-applications-and-deploy-tasks-from-concourse-logging-api
