### PR TITLE
Remove references to WHITELIST variables. 

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -69,20 +69,11 @@ resource "aws_ecs_task_definition" "admin_task" {
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
         },{
-          "name": "S3_SIGNUP_WHITELIST_BUCKET",
-          "value": "${aws_s3_bucket.admin_bucket[0].id}"
-        },{
           "name": "S3_SIGNUP_ALLOWLIST_BUCKET",
           "value": "${aws_s3_bucket.admin_bucket[0].id}"
         },{
-          "name": "S3_SIGNUP_WHITELIST_OBJECT_KEY",
-          "value": "signup-whitelist.conf"
-        },{
           "name": "S3_SIGNUP_ALLOWLIST_OBJECT_KEY",
           "value": "signup-whitelist.conf"
-        },{
-          "name": "S3_WHITELIST_OBJECT_KEY",
-          "value": "clients.conf"
         },{
           "name": "S3_ALLOWLIST_OBJECT_KEY",
           "value": "clients.conf"

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -122,14 +122,8 @@ resource "aws_ecs_task_definition" "user_signup_api_task" {
           "name": "ENVIRONMENT_NAME",
           "value": "${var.env_name}"
         },{
-          "name": "S3_SIGNUP_WHITELIST_BUCKET",
-          "value": "${data.aws_s3_bucket.admin_bucket[0].bucket}"
-        },{
           "name": "S3_SIGNUP_ALLOWLIST_BUCKET",
           "value": "${data.aws_s3_bucket.admin_bucket[0].bucket}"
-        },{
-          "name": "S3_SIGNUP_WHITELIST_OBJECT_KEY",
-          "value": "signup-whitelist.conf"
         },{
           "name": "S3_SIGNUP_ALLOWLIST_OBJECT_KEY",
           "value": "signup-whitelist.conf"

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -146,9 +146,6 @@ resource "aws_ecs_task_definition" "radius_task" {
     "name": "populate-radius-certs",
     "environment": [
       {
-        "name": "WHITELIST_BUCKET",
-        "value": "s3://${var.admin_app_data_s3_bucket_name}"
-      },{
         "name": "ALLOWLIST_BUCKET",
         "value": "s3://${var.admin_app_data_s3_bucket_name}"
       },{


### PR DESCRIPTION
References to WHITELIST have recently been renamed to ALLOWLIST.
previously we added ALLOWLIST variables and now, as the relevant
apps have been deployed, we can remove variables called 'WHITELIST'
in accordance to guidelines