### PR TITLE
change container name for authentication-api

### DIFF
--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -36,7 +36,7 @@ resource "aws_ecs_task_definition" "authorisation_api_task" {
       "essential": true,
       "entryPoint": null,
       "mountPoints": [],
-      "name": "authorisation",
+      "name": "authentication-api",
       "ulimits": null,
       "dockerSecurityOptions": null,
       "environment": [
@@ -115,7 +115,7 @@ resource "aws_ecs_service" "authorisation_api_service" {
 
   load_balancer {
     target_group_arn = aws_alb_target_group.alb_target_group.arn
-    container_name   = "authorisation"
+    container_name   = "authentication-api"
     container_port   = "8080"
   }
 


### PR DESCRIPTION

### What
Change the container name to something consistent with our approach (should ideally match ECS service name)

### Why
Container names were misleading

Link to Trello card (if applicable): https://trello.com/c/qYDjGMcV/2437-make-authorisation-api-container-name-references-in-terraform-deploy-process-consistent
