### PR TITLE
Permit the Fargate RADIUS to talk to APIs it needs

### DIFF
--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -107,6 +107,7 @@ resource "aws_ecs_service" "authorisation_api_service" {
       var.backend_sg_list,
       [aws_security_group.api_in.id],
       [aws_security_group.api_out.id],
+      [aws_security_group.authentication_api_service.id]
     )
 
     subnets          = var.subnet_ids
@@ -115,6 +116,12 @@ resource "aws_ecs_service" "authorisation_api_service" {
 
   load_balancer {
     target_group_arn = aws_alb_target_group.alb_target_group.arn
+    container_name   = "authentication-api"
+    container_port   = "8080"
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.authentication_api.arn
     container_name   = "authentication-api"
     container_port   = "8080"
   }
@@ -159,5 +166,45 @@ resource "aws_alb_target_group" "alb_target_group" {
     timeout             = 4
     interval            = 10
     path                = "/authorize/user/HEALTH"
+  }
+}
+
+resource "aws_lb" "authentication_api" {
+  name     = "authentication-api"
+  internal = true
+
+  subnets = var.subnet_ids
+
+  security_groups = [
+    aws_security_group.authentication_api_alb.id,
+  ]
+
+  load_balancer_type = "application"
+}
+
+resource "aws_alb_target_group" "authentication_api" {
+  name        = "authentication-api"
+  port        = "8080"
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 4
+    interval            = 10
+    path                = "/authorize/user/HEALTH"
+  }
+}
+
+resource "aws_alb_listener" "authentication" {
+  load_balancer_arn = aws_lb.authentication_api.arn
+  protocol          = "HTTP"
+  port              = 80
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.authentication_api.id
   }
 }

--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -120,12 +120,6 @@ resource "aws_ecs_service" "authorisation_api_service" {
     container_port   = "8080"
   }
 
-  load_balancer {
-    target_group_arn = aws_alb_target_group.authentication_api.arn
-    container_name   = "authentication-api"
-    container_port   = "8080"
-  }
-
   lifecycle {
     ignore_changes = [desired_count]
   }

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -146,12 +146,6 @@ resource "aws_ecs_service" "logging_api_service" {
     container_port   = "8080"
   }
 
-  load_balancer {
-    target_group_arn = aws_alb_target_group.logging_api[0].arn
-    container_name   = "logging-api"
-    container_port   = "8080"
-  }
-
   lifecycle {
     ignore_changes = [desired_count]
   }

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -132,7 +132,8 @@ resource "aws_ecs_service" "logging_api_service" {
     security_groups = concat(
       var.backend_sg_list,
       [aws_security_group.api_in.id],
-      [aws_security_group.api_out.id]
+      [aws_security_group.api_out.id],
+      [aws_security_group.logging_api_service.id]
     )
 
     subnets          = var.subnet_ids
@@ -141,6 +142,12 @@ resource "aws_ecs_service" "logging_api_service" {
 
   load_balancer {
     target_group_arn = aws_alb_target_group.logging_api_tg[0].arn
+    container_name   = "logging-api"
+    container_port   = "8080"
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.logging_api[0].arn
     container_name   = "logging-api"
     container_port   = "8080"
   }
@@ -247,4 +254,50 @@ resource "aws_iam_role_policy" "logging_api_task_policy" {
 }
 EOF
 
+}
+
+resource "aws_lb" "logging_api" {
+  count = var.logging_enabled
+
+  name     = "logging-api"
+  internal = true
+
+  subnets = var.subnet_ids
+
+  security_groups = [
+    aws_security_group.logging_api_alb.id,
+  ]
+
+  load_balancer_type = "application"
+}
+
+resource "aws_alb_target_group" "logging_api" {
+  count = var.logging_enabled
+
+  name        = "logging-api"
+  port        = "8080"
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 4
+    interval            = 10
+    path                = "/healthcheck"
+  }
+}
+
+resource "aws_alb_listener" "logging_api" {
+  count = var.logging_enabled
+
+  load_balancer_arn = aws_lb.logging_api[0].arn
+  protocol          = "HTTP"
+  port              = 80
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.logging_api[0].id
+  }
 }

--- a/govwifi-api/outputs.tf
+++ b/govwifi-api/outputs.tf
@@ -3,3 +3,10 @@ output "api_base_url" {
   value       = "https://${aws_route53_record.elb[0].fqdn}:${aws_alb_listener.alb_listener.port}"
 }
 
+output "authentication_api_internal_dns_name" {
+  value = aws_lb.authentication_api.dns_name
+}
+
+output "logging_api_internal_dns_name" {
+  value = aws_lb.logging_api.*.dns_name
+}

--- a/govwifi-api/security-groups.tf
+++ b/govwifi-api/security-groups.tf
@@ -50,3 +50,103 @@ resource "aws_security_group" "lambda_user_api_out" {
     description = "Allow traffic out over internet so we can send messages to the user-sign-up api"
   }
 }
+
+resource "aws_security_group" "authentication_api_service" {
+  name        = "authentication-api-service"
+  description = "Authentication API service"
+  vpc_id      = var.vpc_id
+
+  # Ingress rule defined below to avoid a cycle.
+}
+
+resource "aws_security_group_rule" "authentication_api_service_ingress" {
+  type                     = "ingress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.authentication_api_alb.id
+
+  security_group_id = aws_security_group.authentication_api_service.id
+}
+
+resource "aws_security_group" "logging_api_service" {
+  name        = "logging-api-service"
+  description = "Logging API service"
+  vpc_id      = var.vpc_id
+
+  # Ingress rule defined below to avoid a cycle.
+}
+
+resource "aws_security_group_rule" "logging_api_service_ingress" {
+  type                     = "ingress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.logging_api_alb.id
+
+  security_group_id = aws_security_group.logging_api_service.id
+}
+
+resource "aws_security_group" "authentication_api_alb" {
+  name        = "authentication_api_alb"
+  description = "Security group associated with the authentication API ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+
+    security_groups = var.alb_permitted_security_groups
+  }
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+
+    cidr_blocks = var.alb_permitted_cidr_blocks
+  }
+
+  egress {
+    from_port = 8080
+    to_port   = 8080
+    protocol  = "tcp"
+
+    security_groups = [
+      aws_security_group.authentication_api_service.id
+    ]
+  }
+}
+
+resource "aws_security_group" "logging_api_alb" {
+  name        = "logging_api_alb"
+  description = "Security group associated with the logging API ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+
+    security_groups = var.alb_permitted_security_groups
+  }
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+
+    cidr_blocks = var.alb_permitted_cidr_blocks
+  }
+
+  egress {
+    from_port = 8080
+    to_port   = 8080
+    protocol  = "tcp"
+
+    security_groups = [
+      aws_security_group.logging_api_service.id
+    ]
+  }
+}

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -179,3 +179,12 @@ variable "notify_ips" {
   type    = list(string)
   default = []
 }
+
+variable "alb_permitted_security_groups" {
+  type = list(string)
+}
+
+variable "alb_permitted_cidr_blocks" {
+  type    = list(string)
+  default = []
+}

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -232,10 +232,10 @@ resource "aws_ecs_task_definition" "frontend_fargate" {
     "environment": [
       {
         "name": "AUTHORISATION_API_BASE_URL",
-        "value": "${var.auth_api_base_url}"
+        "value": "http://${var.authentication_api_internal_dns_name}"
       },{
         "name": "LOGGING_API_BASE_URL",
-        "value": "${var.logging_api_base_url}"
+        "value": "http://${var.logging_api_internal_dns_name}"
       },{
         "name": "RADIUSD_PARAMS",
         "value": "${var.radiusd_params}"

--- a/govwifi-frontend/load-balancer.tf
+++ b/govwifi-frontend/load-balancer.tf
@@ -32,7 +32,8 @@ resource "aws_lb_target_group" "main" {
   target_type = "ip"
 
   health_check {
-    protocol = "TCP"
+    protocol = "HTTP"
+    path     = "/"
     port     = 3000
   }
 }

--- a/govwifi-frontend/outputs.tf
+++ b/govwifi-frontend/outputs.tf
@@ -29,3 +29,7 @@ output "ecs_instance_profile" {
 output "eip_public_ips" {
   value = [for eip in aws_eip.radius_eips : eip.public_ip]
 }
+
+output "load_balanced_frontend_service_security_group_id" {
+  value = aws_security_group.load_balanced_frontend_service.id
+}

--- a/govwifi-frontend/security_groups.tf
+++ b/govwifi-frontend/security_groups.tf
@@ -200,6 +200,16 @@ resource "aws_security_group" "load_balanced_frontend_service" {
     cidr_blocks = ["0.0.0.0/0"] # TODO This could probably be the subnet ranges
   }
 
+  egress {
+    description = "Permit traffic to the authentication and logging APIs"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+
+    # TODO This could be replaced by the relevant security groups
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   ingress {
     description = "RADIUS traffic from load balancer"
     from_port   = 1812

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -10,6 +10,9 @@ variable "route53_zone_id" {
 variable "vpc_cidr_block" {
 }
 
+variable "backend_vpc_id" {
+}
+
 variable "aws_region" {
 }
 

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -44,6 +44,12 @@ variable "logging_api_base_url" {
 variable "auth_api_base_url" {
 }
 
+variable "authentication_api_internal_dns_name" {
+}
+
+variable "logging_api_internal_dns_name" {
+}
+
 variable "enable_detailed_monitoring" {
 }
 

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -102,6 +102,8 @@ module "london_frontend" {
   rack_env           = "staging"
   sentry_current_env = "secondary-staging"
 
+  backend_vpc_id = module.london_backend.backend_vpc_id
+
   # Instance-specific setup -------------------------------
   radius_instance_count      = 3
   enable_detailed_monitoring = false

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -123,6 +123,9 @@ module "london_frontend" {
   logging_api_base_url = module.london_api.api_base_url
   auth_api_base_url    = module.london_api.api_base_url
 
+  authentication_api_internal_dns_name = module.london_api.authentication_api_internal_dns_name
+  logging_api_internal_dns_name        = one(module.london_api.logging_api_internal_dns_name)
+
   critical_notifications_arn            = module.london_notifications.topic_arn
   us_east_1_critical_notifications_arn  = module.london_route53_notifications.topic_arn
   us_east_1_pagerduty_notifications_arn = module.london_route53_notifications.topic_arn
@@ -248,6 +251,14 @@ module "london_api" {
 
   rds_mysql_backup_bucket = module.london_backend.rds_mysql_backup_bucket
   backup_mysql_rds        = local.backup_mysql_rds
+
+  alb_permitted_security_groups = [
+    module.london_frontend.load_balanced_frontend_service_security_group_id
+  ]
+
+  alb_permitted_cidr_blocks = [
+    local.dublin_frontend_vpc_cidr_block
+  ]
 
   low_cpu_threshold = 0.3
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -153,6 +153,8 @@ module "frontend" {
   rack_env           = "production"
   sentry_current_env = "production"
 
+  backend_vpc_id = module.backend.backend_vpc_id
+
   # Instance-specific setup -------------------------------
   radius_instance_count      = 3
   enable_detailed_monitoring = true
@@ -171,6 +173,9 @@ module "frontend" {
 
   logging_api_base_url = var.london_api_base_url
   auth_api_base_url    = var.london_api_base_url
+
+  authentication_api_internal_dns_name = module.api.authentication_api_internal_dns_name
+  logging_api_internal_dns_name        = one(module.api.logging_api_internal_dns_name)
 
   critical_notifications_arn            = module.critical_notifications.topic_arn
   us_east_1_critical_notifications_arn  = module.route53_critical_notifications.topic_arn
@@ -287,6 +292,15 @@ module "api" {
 
   backend_sg_list = [
     module.backend.be_admin_in,
+  ]
+
+  alb_permitted_security_groups = [
+    module.frontend.load_balanced_frontend_service_security_group_id,
+  ]
+
+  # Dublin frontend VPC CIDR block
+  alb_permitted_cidr_blocks = [
+    "10.43.0.0/16"
   ]
 
   metrics_bucket_name     = module.govwifi_dashboard.metrics_bucket_name

--- a/govwifi/wifi-london/outputs.tf
+++ b/govwifi/wifi-london/outputs.tf
@@ -5,3 +5,7 @@ output "admin_app_data_s3_bucket_name" {
 output "us_east_1_pagerduty_topic_arn" {
   value = module.us_east_1_pagerduty.topic_arn
 }
+
+output "backend_vpc_id" {
+  value = module.backend.backend_vpc_id
+}

--- a/govwifi/wifi-london/outputs.tf
+++ b/govwifi/wifi-london/outputs.tf
@@ -9,3 +9,7 @@ output "us_east_1_pagerduty_topic_arn" {
 output "backend_vpc_id" {
   value = module.backend.backend_vpc_id
 }
+
+output "logging_api_internal_dns_name" {
+  value = module.api.logging_api_internal_dns_name
+}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -41,6 +41,11 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
 }
@@ -344,4 +349,57 @@ module "govwifi_prometheus" {
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
   grafana_ip = var.grafana_ip
+}
+
+# Cross region VPC peering
+
+resource "aws_vpc_peering_connection" "dublin_frontend_to_london_backend" {
+  vpc_id      = module.frontend.frontend_vpc_id
+  peer_vpc_id = data.terraform_remote_state.london.outputs.backend_vpc_id
+
+  # Because this is a cross region peering, accepting this happens below
+  auto_accept = false
+}
+
+resource "aws_vpc_peering_connection_options" "dublin_frontend_to_london_backend" {
+  vpc_peering_connection_id = aws_vpc_peering_connection.dublin_frontend_to_london_backend.id
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  depends_on = [
+    aws_vpc_peering_connection_accepter.dublin_frontend_to_london_backend
+  ]
+}
+
+resource "aws_vpc_peering_connection_accepter" "dublin_frontend_to_london_backend" {
+  provider = aws.london
+
+  vpc_peering_connection_id = aws_vpc_peering_connection.dublin_frontend_to_london_backend.id
+  auto_accept               = true
+}
+
+data "aws_vpc" "dublin_frontend" {
+  id = module.frontend.frontend_vpc_id
+}
+
+data "aws_vpc" "london_backend" {
+  provider = aws.london
+
+  id = data.terraform_remote_state.london.outputs.backend_vpc_id
+}
+
+resource "aws_route" "frontend_to_backend_route" {
+  route_table_id            = data.aws_vpc.dublin_frontend.main_route_table_id
+  destination_cidr_block    = one(data.aws_vpc.london_backend.cidr_block_associations).cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.dublin_frontend_to_london_backend.id
+}
+
+resource "aws_route" "backend_to_frontend_route" {
+  provider = aws.london
+
+  route_table_id            = data.aws_vpc.london_backend.main_route_table_id
+  destination_cidr_block    = one(data.aws_vpc.dublin_frontend.cidr_block_associations).cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.dublin_frontend_to_london_backend.id
 }

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -190,6 +190,8 @@ module "frontend" {
   rack_env           = "production"
   sentry_current_env = "production"
 
+  backend_vpc_id = module.backend.backend_vpc_id
+
   # Instance-specific setup -------------------------------
   radius_instance_count      = 3
   enable_detailed_monitoring = true
@@ -207,6 +209,9 @@ module "frontend" {
 
   logging_api_base_url = var.london_api_base_url
   auth_api_base_url    = var.dublin_api_base_url
+
+  authentication_api_internal_dns_name = module.api.authentication_api_internal_dns_name
+  logging_api_internal_dns_name        = one(data.terraform_remote_state.london.outputs.logging_api_internal_dns_name)
 
   critical_notifications_arn            = module.critical_notifications.topic_arn
   us_east_1_critical_notifications_arn  = module.route53_critical_notifications.topic_arn
@@ -268,6 +273,10 @@ module "api" {
 
   backend_sg_list = [
     module.backend.be_admin_in,
+  ]
+
+  alb_permitted_security_groups = [
+    module.frontend.load_balanced_frontend_service_security_group_id
   ]
 
   low_cpu_threshold = 10


### PR DESCRIPTION
### What
Permit the Fargate RADIUS to talk to APIs it needs

### Why
This was missed when setting up the security group initially.


Link to Trello card: https://trello.com/c/5zf9ZXj5/2399-add-udp-network-loadbalancers-in-front-of-the-radius-servers-to-increase-resiliency