### PR TITLE
Add missing provider to aws_s3_bucket_versioning resource

### DIFF
--- a/new-terraform-state/replication_bucket.tf
+++ b/new-terraform-state/replication_bucket.tf
@@ -43,6 +43,8 @@ EOF
 }
 
 resource "aws_s3_bucket_versioning" "replication_state_bucket" {
+  provider = aws.replication
+
   bucket = aws_s3_bucket.replication_state_bucket.id
 
   versioning_configuration {


### PR DESCRIPTION
### What
Add missing provider to aws_s3_bucket_versioning resource

### Why
This was missed in a5f32cf21fcb1d865f660e3cc0778010ad98a961.
