### PR TITLE
Replicate the admin bucket

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -61,16 +61,16 @@ resource "aws_ecs_task_definition" "admin_task" {
           "value": "${join(",", var.dublin_radius_ip_addresses)}"
         },{
           "name": "S3_MOU_BUCKET",
-          "value": "${aws_s3_bucket.admin_mou_bucket[0].id}"
+          "value": "${aws_s3_bucket.admin_mou_bucket.id}"
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_BUCKET",
-          "value": "${aws_s3_bucket.admin_bucket[0].id}"
+          "value": "${aws_s3_bucket.admin_bucket.id}"
         },{
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
         },{
           "name": "S3_SIGNUP_ALLOWLIST_BUCKET",
-          "value": "${aws_s3_bucket.admin_bucket[0].id}"
+          "value": "${aws_s3_bucket.admin_bucket.id}"
         },{
           "name": "S3_SIGNUP_ALLOWLIST_OBJECT_KEY",
           "value": "signup-allowlist.conf"
@@ -79,7 +79,7 @@ resource "aws_ecs_task_definition" "admin_task" {
           "value": "clients.conf"
         },{
           "name": "S3_PRODUCT_PAGE_DATA_BUCKET",
-          "value": "${aws_s3_bucket.product_page_data_bucket[0].id}"
+          "value": "${aws_s3_bucket.product_page_data_bucket.id}"
         },{
           "name": "S3_ORGANISATION_NAMES_OBJECT_KEY",
           "value": "organisations.yml"

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -58,7 +58,7 @@ resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
         "s3:PutObject",
         "s3:GetObject"
       ],
-      "Resource": ["${aws_s3_bucket.admin_bucket[0].arn}/*"]
+      "Resource": ["${aws_s3_bucket.admin_bucket.arn}/*"]
     },{
       "Effect": "Allow",
       "Action": [
@@ -68,13 +68,13 @@ resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
         "s3:GetObjectAcl",
         "s3:DeleteObject"
       ],
-      "Resource": ["${aws_s3_bucket.admin_mou_bucket[0].arn}/*"]
+      "Resource": ["${aws_s3_bucket.admin_mou_bucket.arn}/*"]
     },{
       "Effect": "Allow",
       "Action": [
         "s3:ListBucket"
       ],
-      "Resource": ["${aws_s3_bucket.admin_mou_bucket[0].arn}"]
+      "Resource": ["${aws_s3_bucket.admin_mou_bucket.arn}"]
     },
     {
       "Effect": "Allow",
@@ -83,7 +83,7 @@ resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
         "s3:PutObjectAcl",
         "s3:PutObjectVersionAcl"
       ],
-      "Resource": ["${aws_s3_bucket.product_page_data_bucket[0].arn}/*"]
+      "Resource": ["${aws_s3_bucket.product_page_data_bucket.arn}/*"]
     }
   ]
 }

--- a/govwifi-admin/main.tf
+++ b/govwifi-admin/main.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.replication]
     }
   }
 }

--- a/govwifi-admin/outputs.tf
+++ b/govwifi-admin/outputs.tf
@@ -7,3 +7,7 @@ output "app_data_s3_bucket_name" {
   value       = aws_s3_bucket.admin_bucket.id
 }
 
+output "replica_app_data_s3_bucket_name" {
+  description = "Name (id) for the replica admin bucket"
+  value       = aws_s3_bucket.replication_admin_bucket.id
+}

--- a/govwifi-admin/outputs.tf
+++ b/govwifi-admin/outputs.tf
@@ -4,6 +4,6 @@ output "db_hostname" {
 
 output "app_data_s3_bucket_name" {
   description = "Name (id) for the admin bucket"
-  value       = aws_s3_bucket.admin_bucket[0].id
+  value       = aws_s3_bucket.admin_bucket.id
 }
 

--- a/govwifi-admin/s3.tf
+++ b/govwifi-admin/s3.tf
@@ -1,5 +1,4 @@
 resource "aws_s3_bucket" "admin_bucket" {
-  count         = 1
   bucket        = "govwifi-${var.rails_env}-admin"
   force_destroy = true
   acl           = "private"
@@ -12,7 +11,7 @@ resource "aws_s3_bucket" "admin_bucket" {
 }
 
 resource "aws_s3_bucket_versioning" "admin_bucket" {
-  bucket = aws_s3_bucket.admin_bucket[0].id
+  bucket = aws_s3_bucket.admin_bucket.id
 
   versioning_configuration {
     status = "Enabled"
@@ -20,7 +19,6 @@ resource "aws_s3_bucket_versioning" "admin_bucket" {
 }
 
 resource "aws_s3_bucket" "product_page_data_bucket" {
-  count         = 1
   bucket        = "govwifi-${var.rails_env}-product-page-data"
   force_destroy = true
   acl           = "public-read"
@@ -33,7 +31,7 @@ resource "aws_s3_bucket" "product_page_data_bucket" {
 }
 
 resource "aws_s3_bucket_versioning" "product_page_data_bucket" {
-  bucket = aws_s3_bucket.product_page_data_bucket[0].id
+  bucket = aws_s3_bucket.product_page_data_bucket.id
 
   versioning_configuration {
     status = "Enabled"
@@ -41,7 +39,6 @@ resource "aws_s3_bucket_versioning" "product_page_data_bucket" {
 }
 
 resource "aws_s3_bucket" "admin_mou_bucket" {
-  count         = 1
   bucket        = "govwifi-${var.rails_env}-admin-mou"
   force_destroy = true
   acl           = "private"
@@ -54,7 +51,7 @@ resource "aws_s3_bucket" "admin_mou_bucket" {
 }
 
 resource "aws_s3_bucket_versioning" "admin_mou_bucket" {
-  bucket = aws_s3_bucket.admin_mou_bucket[0].id
+  bucket = aws_s3_bucket.admin_mou_bucket.id
 
   versioning_configuration {
     status = "Enabled"
@@ -62,7 +59,7 @@ resource "aws_s3_bucket_versioning" "admin_mou_bucket" {
 }
 
 resource "aws_s3_bucket_policy" "admin_bucket_policy" {
-  bucket = aws_s3_bucket.admin_bucket[0].id
+  bucket = aws_s3_bucket.admin_bucket.id
 
   policy = <<POLICY
 {
@@ -74,7 +71,7 @@ resource "aws_s3_bucket_policy" "admin_bucket_policy" {
       "Effect": "Allow",
       "Principal": "*",
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::${aws_s3_bucket.admin_bucket[0].id}/clients.conf",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.admin_bucket.id}/clients.conf",
       "Condition": {
         "IpAddress": {
           "aws:SourceIp": [
@@ -99,7 +96,7 @@ POLICY
 }
 
 resource "aws_s3_bucket_policy" "product_page_data_bucket_policy" {
-  bucket = aws_s3_bucket.product_page_data_bucket[0].id
+  bucket = aws_s3_bucket.product_page_data_bucket.id
 
   policy = <<POLICY
 {
@@ -114,7 +111,7 @@ resource "aws_s3_bucket_policy" "product_page_data_bucket_policy" {
                 "s3:GetObject",
                 "s3:GetObjectVersion"
             ],
-            "Resource": "arn:aws:s3:::${aws_s3_bucket.product_page_data_bucket[0].id}/*"
+            "Resource": "arn:aws:s3:::${aws_s3_bucket.product_page_data_bucket.id}/*"
         },
         {
             "Sid": "Get Product Page Data For Bucket",
@@ -125,7 +122,7 @@ resource "aws_s3_bucket_policy" "product_page_data_bucket_policy" {
                 "s3:ListBucket",
                 "s3:ListBucketVersions"
             ],
-            "Resource": "arn:aws:s3:::${aws_s3_bucket.product_page_data_bucket[0].id}"
+            "Resource": "arn:aws:s3:::${aws_s3_bucket.product_page_data_bucket.id}"
         }
     ]
 }

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -140,7 +140,8 @@ module "london_frontend" {
 
 module "london_admin" {
   providers = {
-    aws = aws.london
+    aws             = aws.london
+    aws.replication = aws.dublin
   }
 
   source        = "../../govwifi-admin"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -41,6 +41,11 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "dublin"
+  region = "eu-west-1"
+}
+
+provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
 }
@@ -191,7 +196,8 @@ module "frontend" {
 
 module "govwifi_admin" {
   providers = {
-    aws = aws.main
+    aws             = aws.main
+    aws.replication = aws.dublin
   }
 
   source        = "../../govwifi-admin"


### PR DESCRIPTION
### What
Replicate the admin bucket

### Why
This will enable frontend in eu-west-1 to not have to access the
eu-west-2 admin-bucket, which is particularly helpful when deploying
frontend using Fargate, as it doesn't have to have access to the
internet.
