### PR TITLE
Populate the new auth and logging api load balancers

### DIFF
--- a/govwifi-api/authorisation-api-cluster.tf
+++ b/govwifi-api/authorisation-api-cluster.tf
@@ -120,6 +120,12 @@ resource "aws_ecs_service" "authorisation_api_service" {
     container_port   = "8080"
   }
 
+  load_balancer {
+    target_group_arn = aws_alb_target_group.authentication_api.arn
+    container_name   = "authentication-api"
+    container_port   = "8080"
+  }
+
   lifecycle {
     ignore_changes = [desired_count]
   }

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -146,6 +146,12 @@ resource "aws_ecs_service" "logging_api_service" {
     container_port   = "8080"
   }
 
+  load_balancer {
+    target_group_arn = aws_alb_target_group.logging_api[0].arn
+    container_name   = "logging-api"
+    container_port   = "8080"
+  }
+
   lifecycle {
     ignore_changes = [desired_count]
   }


### PR DESCRIPTION
### What
Populate the new auth and logging api load balancers

### Why
This will enable the new internal authentication and logging API load balancers, which serve the new Fargate frontend cluster.
