### PR TITLE
Disable the Fargate frontend cluster

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -363,7 +363,7 @@ resource "aws_ecs_service" "load_balanced_frontend_service" {
   cluster         = aws_ecs_cluster.frontend_fargate.id
   launch_type     = "FARGATE"
   task_definition = aws_ecs_task_definition.frontend_fargate.arn
-  desired_count   = var.radius_instance_count
+  desired_count   = 0
 
   load_balancer {
     target_group_arn = aws_lb_target_group.main.arn


### PR DESCRIPTION
### What
Disable the Fargate frontend cluster

### Why
As it's not working yet, and this avoids alarms about it not
working. This can be enabled again once the internal load balancers
for the authentication and logging APIs are setup.