### PR TITLE
Install grep for running the linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
       - name: lint
         run: |
-          brew install tfenv tflint findutils
+          brew install tfenv tflint grep findutils
           tfenv install $(cat .terraform-version)
           tfenv use $(cat .terraform-version)
           GITHUB_TOKEN=${{ secrets.GH_TOKEN }} tflint --init


### PR DESCRIPTION
### What
Install grep for running the linting

### Why
As there's a weird error in the output:

  A metaphysical dichotomy has caused this unit to overload and shut
  down. GNU Grep is a requirement and your Mac does not have
  it. Consider "brew install grep"
