### PR TITLE
Add Admin deploy codepipeline project

### DIFF
--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -46,6 +46,6 @@ module "govwifi_deploy" {
   }
 
   source    = "../../govwifi-deploy"
-  app_names = ["user-signup-api", "logging-api"]
+  app_names = ["user-signup-api", "logging-api", "admin"]
 
 }


### PR DESCRIPTION
What
Add Admin deploy codepipeline project

Why
We are migrating our pipelines from Concourse to AWS.

Link to Trello card (if applicable):
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-238