### PR TITLE
Enable the Fargate frontend cluster

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -363,7 +363,7 @@ resource "aws_ecs_service" "load_balanced_frontend_service" {
   cluster         = aws_ecs_cluster.frontend_fargate.id
   launch_type     = "FARGATE"
   task_definition = aws_ecs_task_definition.frontend_fargate.arn
-  desired_count   = 0
+  desired_count   = var.radius_instance_count
 
   load_balancer {
     target_group_arn = aws_lb_target_group.main.arn


### PR DESCRIPTION
### What
Enable the Fargate frontend cluster

This reverts commit 31484b6b235edfa24894a34c0404268fc91813f0.

### Why
This was disabled while the internal load balancers for the
authentication and logging APIs were disabled, which has now happened.
