### PR TITLE
Add codebuild job for safe-restarter

### DIFF
--- a/govwifi-deploy/codebuild-saferestarter.tf
+++ b/govwifi-deploy/codebuild-saferestarter.tf
@@ -1,0 +1,86 @@
+resource "aws_codebuild_project" "govwifi_codebuild_saferestarter" {
+  name           = "govwifi-build-safe-restarter"
+  description    = "This project builds the safe-restarter image and pushes it to ECR"
+  build_timeout  = "5"
+  service_role   = aws_iam_role.govwifi_codebuild.arn
+  encryption_key = aws_kms_key.codepipeline_key.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    environment_variable {
+      name  = "DOCKER_HUB_AUTHTOKEN_ENV"
+      value = data.aws_secretsmanager_secret_version.docker_hub_authtoken.secret_string
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_USERNAME_ENV"
+      value = data.aws_secretsmanager_secret_version.docker_hub_username.secret_string
+    }
+
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID"
+      value = local.aws_account_id
+    }
+
+    environment_variable {
+      name  = "STAGE"
+      value = "staging"
+    }
+
+    environment_variable {
+      name  = "REPOSITORY_URI"
+      value = aws_ecr_repository.safe_restarter_ecr.name
+    }
+
+
+  }
+
+  source_version = "codebuild-test"
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/alphagov/govwifi-safe-restarter.git"
+    git_clone_depth = 1
+    buildspec       = "buildspec-build.yml"
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "govwifi-safe-restarter-group"
+      stream_name = "govwifi-safe-restarter-stream"
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${aws_s3_bucket.codepipeline_bucket.id}/safe-restarter-log"
+    }
+  }
+
+}
+
+resource "aws_codebuild_webhook" "govwifi_saferestarter_webhook" {
+  project_name = aws_codebuild_project.govwifi_codebuild_saferestarter.name
+
+  build_type = "BUILD"
+
+  filter_group {
+    filter {
+      type    = "EVENT"
+      pattern = "PUSH"
+    }
+
+    filter {
+      type    = "HEAD_REF"
+      pattern = "^refs/heads/codebuild-test$"
+    }
+  }
+}

--- a/govwifi-deploy/codepipeline.tf
+++ b/govwifi-deploy/codepipeline.tf
@@ -1,5 +1,5 @@
 resource "aws_codepipeline" "codepipeline" {
-  for_each = toset(var.app_names)
+  for_each = toset(var.deployed_app_names)
   name     = "govwifi-deploy-${each.key}-staging-pipeline"
   role_arn = aws_iam_role.govwifi_codepipeline_staging_role.arn
 

--- a/govwifi-deploy/ecr.tf
+++ b/govwifi-deploy/ecr.tf
@@ -1,10 +1,10 @@
 resource "aws_ecr_repository" "govwifi_ecr_repo" {
-  for_each = toset(var.app_names)
+  for_each = toset(var.deployed_app_names)
   name     = "govwifi/staging/${each.key}"
 }
 
 resource "aws_ecr_repository_policy" "govwifi_ecr_repo_policy" {
-  for_each   = toset(var.app_names)
+  for_each   = toset(var.deployed_app_names)
   repository = aws_ecr_repository.govwifi_ecr_repo[each.key].name
   policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy.json
 }
@@ -25,7 +25,6 @@ resource "aws_ecr_repository" "safe_restarter_ecr" {
 }
 
 resource "aws_ecr_repository_policy" "govwifi_ecr_saferestater_policy" {
-  for_each   = toset(var.app_names)
   repository = aws_ecr_repository.safe_restarter_ecr.name
   policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy.json
 }

--- a/govwifi-deploy/ecr.tf
+++ b/govwifi-deploy/ecr.tf
@@ -6,30 +6,7 @@ resource "aws_ecr_repository" "govwifi_ecr_repo" {
 resource "aws_ecr_repository_policy" "govwifi_ecr_repo_policy" {
   for_each   = toset(var.app_names)
   repository = aws_ecr_repository.govwifi_ecr_repo[each.key].name
-
-  policy = <<EOF
-{
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "AllowPushPull",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "arn:aws:iam::${local.aws_staging_account_id}:root"
-      },
-      "Action": [
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:BatchGetImage",
-        "ecr:CompleteLayerUpload",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:InitiateLayerUpload",
-        "ecr:PutImage",
-        "ecr:UploadLayerPart"
-      ]
-    }
-  ]
-}
-EOF
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy.json
 }
 
 resource "aws_ecr_repository" "govwifi_frontend" {
@@ -40,28 +17,41 @@ resource "aws_ecr_repository" "govwifi_frontend" {
 resource "aws_ecr_repository_policy" "govwifi_frontend_policy" {
   for_each   = toset(var.frontend_docker_images)
   repository = aws_ecr_repository.govwifi_frontend[each.key].name
-
-  policy = <<EOF
-{
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "AllowPushPull",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "arn:aws:iam::${local.aws_staging_account_id}:root"
-      },
-      "Action": [
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:BatchGetImage",
-        "ecr:CompleteLayerUpload",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:InitiateLayerUpload",
-        "ecr:PutImage",
-        "ecr:UploadLayerPart"
-      ]
-    }
-  ]
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy.json
 }
-EOF
+
+resource "aws_ecr_repository" "safe_restarter_ecr" {
+  name = "govwifi/staging/safe-restarter"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_saferestater_policy" {
+  for_each   = toset(var.app_names)
+  repository = aws_ecr_repository.safe_restarter_ecr.name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy.json
+}
+
+
+data "aws_iam_policy_document" "govwifi_ecr_repo_policy" {
+  statement {
+    sid = "AllowPushPull"
+
+    effect = "Allow"
+
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.aws_staging_account_id}:root"]
+    }
+
+  }
+
 }

--- a/govwifi-deploy/variables.tf
+++ b/govwifi-deploy/variables.tf
@@ -1,6 +1,8 @@
-variable "app_names" {
+variable "deployed_app_names" {
 }
 
 variable "frontend_docker_images" {
+}
 
+variable "built_app_names" {
 }

--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -47,6 +47,7 @@ module "govwifi_deploy" {
 
   source = "../../govwifi-deploy"
 
-  app_names              = ["user-signup-api", "logging-api", "admin"]
+  deployed_app_names     = ["user-signup-api", "logging-api", "admin"]
+  built_app_names        = ["frontend", "safe-restarter"]
   frontend_docker_images = ["raddb", "frontend"]
 }


### PR DESCRIPTION
### What
Add codebuild job for safe-restarter
Also change the ECR policy in tools into a data resource to make it easier to reuse.

### Why
We are migrating our pipelines from Concourse to AWS.

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-238

