### PR TITLE
Change codepipeline cluster attributes to allow admin to deploy

### DIFF
--- a/govwifi-deploy/codepipeline.tf
+++ b/govwifi-deploy/codepipeline.tf
@@ -59,8 +59,8 @@ resource "aws_codepipeline" "codepipeline" {
       role_arn = "arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-crossaccount-tools-deploy"
 
       configuration = {
-        ClusterName : "staging-api-cluster"
-        ServiceName : "${each.key}-service-staging"
+        ClusterName : each.key == "admin" ? "staging-admin-cluster" : "staging-api-cluster"
+        ServiceName : each.key == "admin" ? "admin-staging" : "${each.key}-service-staging"
       }
     }
   }


### PR DESCRIPTION
### What
Change codepipeline cluster attributes to allow admin to deploy.
Add conditional to allow for different cluster names at deploy stage.

### Why
Then admin ECS cluster and the api ECS cluster have slightly different names. This change accommodates that.

Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-243
