### PR TITLE
Fix Staging Ireland Prometheus connectivity

### DIFF
--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -74,7 +74,7 @@ module "london_backend" {
   user_db_storage_gb    = 20
 
   prometheus_ip_london  = module.london_prometheus.eip_public_ip
-  prometheus_ip_ireland = module.london_prometheus.eip_public_ip
+  prometheus_ip_ireland = module.dublin_prometheus.eip_public_ip
   grafana_ip            = module.london_grafana.eip_public_ip
 
   backup_mysql_rds = local.backup_mysql_rds
@@ -345,7 +345,8 @@ module "london_grafana" {
 
   administrator_cidrs = var.administrator_cidrs
   prometheus_ips = [
-    module.london_prometheus.eip_public_ip
+    module.london_prometheus.eip_public_ip,
+    module.dublin_prometheus.eip_public_ip
   ]
 
 }


### PR DESCRIPTION
### What
Fix Staging Ireland Prometheus connectivity

### Why
Adjust the security groups so that you can SSH in to the Ireland
Prometheus in Staging, and so that Grafana can connect to it too.
