### PR TITLE
Prepare for switching to the network load balancer for frontend

### DIFF
--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -175,7 +175,12 @@ DATA
 }
 
 resource "aws_eip_association" "eip_assoc" {
-  count       = var.radius_instance_count
-  instance_id = element(aws_instance.radius.*.id, count.index)
-  public_ip   = aws_eip.radius_eips[count.index].public_ip
+  for_each = {
+    for az, subnet
+    in aws_subnet.wifi_frontend_subnet :
+    index(data.aws_availability_zones.zones.names, az) => subnet.id
+  }
+
+  instance_id = element(aws_instance.radius.*.id, each.key)
+  public_ip   = aws_eip.radius_eips[each.key].public_ip
 }

--- a/govwifi-frontend/load-balancer.tf
+++ b/govwifi-frontend/load-balancer.tf
@@ -5,7 +5,7 @@ resource "aws_lb" "main" {
   enable_cross_zone_load_balancing = true
 
   dynamic "subnet_mapping" {
-    for_each = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+    for_each = { for az, subnet in aws_subnet.wifi_frontend_subnet : index(data.aws_availability_zones.zones.names, az) => subnet.id }
     iterator = subnet_id
 
     content {


### PR DESCRIPTION
### What
Prepare for switching to the network load balancer for frontend

### Why
The plan is to switch just two IPs out of the 6 at first. To allow
doing this in part with Terraform, and to allow Terraform to run while
only 2 out of the 6 IPs have been moved, this commit changes some
resources to use for_each rather than count. 
