### PR TITLE
Migrate one EIP to the frontend Network Load Balancer

### DIFF
--- a/govwifi-frontend/alarms.tf
+++ b/govwifi-frontend/alarms.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_metric_alarm" "radius_healthcheck" {
   for_each = {
     for az, subnet
     in aws_subnet.wifi_frontend_subnet :
-    index(data.aws_availability_zones.zones.names, az) => subnet.id
+    index(data.aws_availability_zones.zones.names, az) => subnet.id if index(data.aws_availability_zones.zones.names, az) != 1
   }
 
   provider            = aws.us_east_1
@@ -28,21 +28,13 @@ resource "aws_cloudwatch_metric_alarm" "radius_healthcheck" {
   alarm_description = "Route53 healthcheck request failed to authenticate via FreeRADIUS and Authentication API. Investigate CloudWatch logs for root cause."
 }
 
-resource "aws_cloudwatch_composite_alarm" "all_radius_servers_down" {
-  provider   = aws.us_east_1
-  alarm_name = "${var.env_name} ${var.aws_region} All Radius servers down"
-
-  alarm_actions = [var.us_east_1_pagerduty_notifications_arn]
-
-  alarm_rule = join(" AND ", formatlist("ALARM(\"%s\")", [for alarm in aws_cloudwatch_metric_alarm.radius_healthcheck : alarm.alarm_name]))
-}
 
 # TODO This resource can be removed after the switch to the NLBs
 resource "aws_cloudwatch_metric_alarm" "radius_latency" {
   for_each = {
     for az, subnet
     in aws_subnet.wifi_frontend_subnet :
-    index(data.aws_availability_zones.zones.names, az) => subnet.id
+    index(data.aws_availability_zones.zones.names, az) => subnet.id if index(data.aws_availability_zones.zones.names, az) != 1
   }
 
   provider            = aws.us_east_1

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -178,7 +178,7 @@ resource "aws_eip_association" "eip_assoc" {
   for_each = {
     for az, subnet
     in aws_subnet.wifi_frontend_subnet :
-    index(data.aws_availability_zones.zones.names, az) => subnet.id
+    index(data.aws_availability_zones.zones.names, az) => subnet.id if index(data.aws_availability_zones.zones.names, az) != 1
   }
 
   instance_id = element(aws_instance.radius.*.id, each.key)

--- a/govwifi-frontend/load-balancer.tf
+++ b/govwifi-frontend/load-balancer.tf
@@ -5,12 +5,12 @@ resource "aws_lb" "main" {
   enable_cross_zone_load_balancing = true
 
   dynamic "subnet_mapping" {
-    for_each = { for az, subnet in aws_subnet.wifi_frontend_subnet : index(data.aws_availability_zones.zones.names, az) => subnet.id }
+    for_each = { for az, subnet in aws_subnet.wifi_frontend_subnet : index(data.aws_availability_zones.zones.names, az) => subnet.id if index(data.aws_availability_zones.zones.names, az) == 1 }
     iterator = subnet_id
 
     content {
       subnet_id     = subnet_id.value
-      allocation_id = aws_eip.test_radius_eips[subnet_id.key].id
+      allocation_id = aws_eip.radius_eips[subnet_id.key].id
     }
   }
 }

--- a/govwifi-frontend/route53.tf
+++ b/govwifi-frontend/route53.tf
@@ -21,7 +21,7 @@ resource "aws_route53_health_check" "radius" {
   for_each = {
     for az, subnet
     in aws_subnet.wifi_frontend_subnet :
-    index(data.aws_availability_zones.zones.names, az) => subnet.id
+    index(data.aws_availability_zones.zones.names, az) => subnet.id if index(data.aws_availability_zones.zones.names, az) != 1
   }
 
   reference_name = format(

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -81,10 +81,6 @@ variable "us_east_1_critical_notifications_arn" {
   type = string
 }
 
-variable "us_east_1_pagerduty_notifications_arn" {
-  type = string
-}
-
 variable "admin_app_data_s3_bucket_name" {
   type = string
 }

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -222,9 +222,8 @@ module "dublin_frontend" {
   authentication_api_internal_dns_name = module.dublin_api.authentication_api_internal_dns_name
   logging_api_internal_dns_name        = one(module.london_api.logging_api_internal_dns_name)
 
-  critical_notifications_arn            = module.dublin_notifications.topic_arn
-  us_east_1_critical_notifications_arn  = module.dublin_route53_notifications.topic_arn
-  us_east_1_pagerduty_notifications_arn = module.london_route53_notifications.topic_arn
+  critical_notifications_arn           = module.dublin_notifications.topic_arn
+  us_east_1_critical_notifications_arn = module.dublin_route53_notifications.topic_arn
 
   bastion_server_ip = module.london_backend.bastion_public_ip
 

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -126,9 +126,8 @@ module "london_frontend" {
   authentication_api_internal_dns_name = module.london_api.authentication_api_internal_dns_name
   logging_api_internal_dns_name        = one(module.london_api.logging_api_internal_dns_name)
 
-  critical_notifications_arn            = module.london_notifications.topic_arn
-  us_east_1_critical_notifications_arn  = module.london_route53_notifications.topic_arn
-  us_east_1_pagerduty_notifications_arn = module.london_route53_notifications.topic_arn
+  critical_notifications_arn           = module.london_notifications.topic_arn
+  us_east_1_critical_notifications_arn = module.london_route53_notifications.topic_arn
 
   bastion_server_ip = module.london_backend.bastion_public_ip
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -182,9 +182,8 @@ module "frontend" {
   authentication_api_internal_dns_name = module.api.authentication_api_internal_dns_name
   logging_api_internal_dns_name        = one(module.api.logging_api_internal_dns_name)
 
-  critical_notifications_arn            = module.critical_notifications.topic_arn
-  us_east_1_critical_notifications_arn  = module.route53_critical_notifications.topic_arn
-  us_east_1_pagerduty_notifications_arn = module.us_east_1_pagerduty.topic_arn
+  critical_notifications_arn           = module.critical_notifications.topic_arn
+  us_east_1_critical_notifications_arn = module.route53_critical_notifications.topic_arn
 
   bastion_server_ip = var.bastion_server_ip
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -221,9 +221,8 @@ module "frontend" {
   authentication_api_internal_dns_name = module.api.authentication_api_internal_dns_name
   logging_api_internal_dns_name        = one(data.terraform_remote_state.london.outputs.logging_api_internal_dns_name)
 
-  critical_notifications_arn            = module.critical_notifications.topic_arn
-  us_east_1_critical_notifications_arn  = module.route53_critical_notifications.topic_arn
-  us_east_1_pagerduty_notifications_arn = data.terraform_remote_state.london.outputs.us_east_1_pagerduty_topic_arn
+  critical_notifications_arn           = module.critical_notifications.topic_arn
+  us_east_1_critical_notifications_arn = module.route53_critical_notifications.topic_arn
 
   bastion_server_ip = var.bastion_server_ip
 


### PR DESCRIPTION
### What
This commit sets Terraform up to migrate the 2nd EIP (eu-west-1b,
eu-west-2b) from the EC2 instances to the Network Load Balancer.

### Why
To start the switch to the Network Load Balancer.
