### PR TITLE
Point the radius* domain names directly at the EIPs

### DIFF
--- a/govwifi-frontend/route53.tf
+++ b/govwifi-frontend/route53.tf
@@ -7,13 +7,9 @@ resource "aws_route53_record" "radius" {
     var.dns_numbering_base + count.index + 1,
     var.env_subdomain
   )
-  type    = "CNAME"
+  type    = "A"
   ttl     = "300"
-  records = [element(aws_instance.radius.*.public_dns, count.index)]
-  depends_on = [
-    aws_instance.radius,
-    aws_eip_association.eip_assoc
-  ]
+  records = [element(aws_eip.radius_eips.*.public_ip, count.index)]
 }
 
 # TODO This resource can be removed after the switch to the NLBs


### PR DESCRIPTION
### What
Rather than using a CNAME to the EC2 instances.

### Why
This means that these domains will point at the EIPs, even when
they're migrated over to the Network Load Balancer.

Currently there seems to still be traffic coming to the EC2 instances
that don't have EIPs attached, and these DNS entries could be how
they're being found.
