### PR TITLE
Make API access from frontend EC2 instances with no EIP work

### DIFF
--- a/govwifi-frontend/outputs.tf
+++ b/govwifi-frontend/outputs.tf
@@ -30,6 +30,10 @@ output "eip_public_ips" {
   value = [for eip in aws_eip.radius_eips : eip.public_ip]
 }
 
+output "ec2_instance_public_ips" {
+  value = [for instance in aws_instance.radius : instance.public_ip]
+}
+
 output "load_balanced_frontend_service_security_group_id" {
   value = aws_security_group.load_balanced_frontend_service.id
 }

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -278,7 +278,7 @@ module "dublin_api" {
 
   rack_env                = "staging"
   sentry_current_env      = "secondary-staging"
-  radius_server_ips       = local.frontend_radius_ips
+  radius_server_ips       = module.dublin_frontend.ec2_instance_public_ips
   subnet_ids              = module.dublin_backend.backend_subnet_ids
   private_subnet_ids      = module.dublin_backend.backend_private_subnet_ids
   nat_gateway_elastic_ips = module.dublin_backend.nat_gateway_elastic_ips

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -235,7 +235,7 @@ module "london_api" {
 
   rack_env                  = "staging"
   sentry_current_env        = "secondary-staging"
-  radius_server_ips         = local.frontend_radius_ips
+  radius_server_ips         = module.london_frontend.ec2_instance_public_ips
   subnet_ids                = module.london_backend.backend_subnet_ids
   private_subnet_ids        = module.london_backend.backend_private_subnet_ids
   nat_gateway_elastic_ips   = module.london_backend.nat_gateway_elastic_ips

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -271,7 +271,7 @@ module "api" {
   db_hostname              = "db.${lower(var.aws_region_name)}.${local.env_subdomain}.service.gov.uk"
   rack_env                 = "production"
   sentry_current_env       = "production"
-  radius_server_ips        = local.frontend_radius_ips
+  radius_server_ips        = module.frontend.ec2_instance_public_ips
   user_signup_docker_image = ""
   subnet_ids               = module.backend.backend_subnet_ids
   private_subnet_ids       = module.backend.backend_private_subnet_ids

--- a/govwifi/wifi/outputs.tf
+++ b/govwifi/wifi/outputs.tf
@@ -1,0 +1,3 @@
+output "frontend_ec2_instance_public_ips" {
+  value = module.frontend.ec2_instance_public_ips
+}


### PR DESCRIPTION
### What
Make API access from frontend EC2 instances with no EIP work

### Why
With the loss of the EIPs, the tasks running on the EC2 instances have
lost access to the authentication and logging APIs.

Since the EIPs have switched across to the Network Load Balancer, this
shouldn't cause an issue for regular GovWifi traffic to these
IPs. However, it seems that there's still some traffic to the tasks on
these instances.

This commit should restore API access for these tasks, just in case
that's useful for some reason.
