### PR TITLE
Tag all resources by environment

### DIFF
--- a/govwifi-admin/loadbalancer.tf
+++ b/govwifi-admin/loadbalancer.tf
@@ -24,9 +24,8 @@ resource "aws_s3_bucket" "access_logs" {
   bucket_prefix = "govwifi-admin-access-logs-"
 
   tags = {
-    Name        = "${title(var.env_name)} admin access logs"
-    Region      = title(var.aws_region_name)
-    Environment = title(var.rails_env)
+    Name   = "${title(var.env_name)} admin access logs"
+    Region = title(var.aws_region_name)
   }
 }
 

--- a/govwifi-admin/s3.tf
+++ b/govwifi-admin/s3.tf
@@ -3,9 +3,8 @@ resource "aws_s3_bucket" "admin_bucket" {
   force_destroy = true
 
   tags = {
-    Name        = "${title(var.env_name)} Admin data"
-    Region      = title(var.aws_region_name)
-    Environment = title(var.rails_env)
+    Name   = "${title(var.env_name)} Admin data"
+    Region = title(var.aws_region_name)
   }
 }
 
@@ -22,9 +21,8 @@ resource "aws_s3_bucket" "product_page_data_bucket" {
   force_destroy = true
 
   tags = {
-    Name        = "${title(var.rails_env)} Product page data"
-    Region      = title(var.aws_region_name)
-    Environment = title(var.rails_env)
+    Name   = "${title(var.rails_env)} Product page data"
+    Region = title(var.aws_region_name)
   }
 }
 
@@ -46,9 +44,8 @@ resource "aws_s3_bucket" "admin_mou_bucket" {
   force_destroy = true
 
   tags = {
-    Name        = "${title(var.env_name)} MOU documents from Admin"
-    Region      = title(var.aws_region_name)
-    Environment = title(var.rails_env)
+    Name   = "${title(var.env_name)} MOU documents from Admin"
+    Region = title(var.aws_region_name)
   }
 }
 

--- a/govwifi-api/wordlist.tf
+++ b/govwifi-api/wordlist.tf
@@ -5,7 +5,6 @@ resource "aws_s3_bucket" "wordlist" {
 
   tags = {
     Name = "wordlist"
-    Env  = title(var.env_name)
   }
 }
 

--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -156,7 +156,6 @@ DATA
 
   tags = {
     Name = "${title(var.env_name)} Bastion - backend (${aws_vpc.wifi_backend.id})"
-    Env  = title(var.env_name)
   }
 }
 
@@ -253,7 +252,6 @@ resource "aws_eip" "bastion_eip" {
 
   tags = {
     Name = "bastion"
-    Env  = title(var.env_name)
   }
 }
 

--- a/govwifi-dashboard/s3.tf
+++ b/govwifi-dashboard/s3.tf
@@ -2,8 +2,7 @@ resource "aws_s3_bucket" "metrics_bucket" {
   bucket = "govwifi-${var.env_name}-metrics-bucket"
 
   tags = {
-    Name        = "${title(var.env_name)} Metrics data"
-    Environment = title(var.env_name)
+    Name = "${title(var.env_name)} Metrics data"
   }
 }
 
@@ -19,8 +18,7 @@ resource "aws_s3_bucket" "export_data_bucket" {
   bucket = "govwifi-${var.env_name}-export-data-bucket"
 
   tags = {
-    Name        = "${title(var.env_name)} Exported metrics data"
-    Environment = title(var.env_name)
+    Name = "${title(var.env_name)} Exported metrics data"
   }
 }
 

--- a/govwifi-datasync/main.tf
+++ b/govwifi-datasync/main.tf
@@ -11,9 +11,8 @@ resource "aws_s3_bucket" "govwifi_datasync" {
   bucket = "govwifi-datasync"
 
   tags = {
-    Name        = "Govwifi Datasync"
-    Region      = title(var.aws_region)
-    Environment = title(var.rack_env)
+    Name   = "Govwifi Datasync"
+    Region = title(var.aws_region)
   }
 }
 

--- a/govwifi-datasync/variables.tf
+++ b/govwifi-datasync/variables.tf
@@ -1,7 +1,3 @@
-variable "rack_env" {
-  description = "E.g. staging"
-}
-
 variable "aws_region" {
   description = "E.g. eu-west-2"
 }

--- a/govwifi-emails/s3sns.tf
+++ b/govwifi-emails/s3sns.tf
@@ -4,10 +4,9 @@ resource "aws_s3_bucket" "emailbucket" {
   force_destroy = true
 
   tags = {
-    Name        = "${title(var.env_name)} Email Bucket"
-    Region      = title(var.aws_region_name)
-    Environment = title(var.env_name)
-    Category    = "User emails"
+    Name     = "${title(var.env_name)} Email Bucket"
+    Region   = title(var.aws_region_name)
+    Category = "User emails"
   }
 }
 
@@ -94,10 +93,9 @@ resource "aws_s3_bucket" "admin_emailbucket" {
   force_destroy = true
 
   tags = {
-    Name        = "${title(var.env_name)} Admin Email Bucket"
-    Region      = title(var.aws_region_name)
-    Environment = title(var.env_name)
-    Category    = "Admin emails"
+    Name     = "${title(var.env_name)} Admin Email Bucket"
+    Region   = title(var.aws_region_name)
+    Category = "Admin emails"
   }
 }
 

--- a/govwifi-frontend/certs.tf
+++ b/govwifi-frontend/certs.tf
@@ -2,9 +2,8 @@ resource "aws_s3_bucket" "frontend_cert_bucket" {
   bucket_prefix = "frontend-cert-${lower(var.aws_region_name)}-"
 
   tags = {
-    Name        = "${title(var.env_name)} Frontend certs"
-    Region      = title(var.aws_region_name)
-    Environment = title(var.rack_env)
+    Name   = "${title(var.env_name)} Frontend certs"
+    Region = title(var.aws_region_name)
   }
 }
 

--- a/govwifi-frontend/eips.tf
+++ b/govwifi-frontend/eips.tf
@@ -9,7 +9,6 @@ resource "aws_eip" "radius_eips" {
   tags = {
     Name   = "${title(var.env_name)} Frontend Radius-${var.dns_numbering_base + count.index + 1}"
     Region = title(var.aws_region_name)
-    Env    = title(var.env_name)
   }
 }
 

--- a/govwifi-frontend/instances.tf
+++ b/govwifi-frontend/instances.tf
@@ -166,7 +166,6 @@ DATA
 
   tags = {
     Name = "${title(var.env_name)} Frontend Radius-${var.dns_numbering_base + count.index + 1}"
-    Env  = title(var.env_name)
   }
 
   lifecycle {

--- a/govwifi-frontend/load-balancer.tf
+++ b/govwifi-frontend/load-balancer.tf
@@ -61,6 +61,5 @@ resource "aws_eip" "test_radius_eips" {
   tags = {
     Name   = "${title(var.env_name)} Frontend Radius-${var.dns_numbering_base + count.index + 1}"
     Region = title(var.aws_region_name)
-    Env    = title(var.env_name)
   }
 }

--- a/govwifi-grafana/eip.tf
+++ b/govwifi-grafana/eip.tf
@@ -3,7 +3,6 @@ resource "aws_eip" "grafana_eip" {
 
   tags = {
     Name = "grafana-${var.env_name}"
-    Env  = title(var.env_name)
   }
 }
 

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -46,7 +46,6 @@ resource "aws_instance" "grafana_instance" {
 
   tags = {
     Name = "${title(var.env_name)} Grafana-Server"
-    Env  = title(var.env_name)
   }
 
   lifecycle {

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -51,7 +51,6 @@ resource "aws_instance" "prometheus_instance" {
 
   tags = {
     Name = "${title(var.env_name)} Prometheus-Server"
-    Env  = title(var.env_name)
   }
 
   lifecycle {
@@ -87,7 +86,6 @@ resource "aws_eip" "eip" {
 
   tags = {
     Name = "prometheus"
-    Env  = title(var.env_name)
   }
 }
 

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -8,6 +8,12 @@ locals {
 provider "aws" {
   alias  = "dublin"
   region = local.dublin_aws_region
+
+  default_tags {
+    tags = {
+      Environment = title(local.env_name)
+    }
+  }
 }
 
 # Cross region peering

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -6,6 +6,12 @@ locals {
 provider "aws" {
   alias  = "london"
   region = local.london_aws_region
+
+  default_tags {
+    tags = {
+      Environment = title(local.env_name)
+    }
+  }
 }
 
 module "london_keys" {

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -379,5 +379,4 @@ module "datasync" {
   source = "../../govwifi-datasync"
 
   aws_region = local.london_aws_region
-  rack_env   = "staging"
 }

--- a/govwifi/staging/main.tf
+++ b/govwifi/staging/main.tf
@@ -18,6 +18,12 @@ terraform {
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Environment = title(local.env_name)
+    }
+  }
 }
 
 module "tfstate" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -38,16 +38,34 @@ terraform {
 provider "aws" {
   alias  = "main"
   region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = "Production"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "dublin"
   region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      Environment = "Production"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Environment = title(local.env_name)
+    }
+  }
 }
 
 module "govwifi_keys" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -38,16 +38,34 @@ terraform {
 provider "aws" {
   alias  = "main"
   region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = "Production"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "london"
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      Environment = "Production"
+    }
+  }
 }
 
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Environment = title(local.env_name)
+    }
+  }
 }
 
 data "terraform_remote_state" "london" {

--- a/new-terraform-state/accesslogs_bucket.tf
+++ b/new-terraform-state/accesslogs_bucket.tf
@@ -74,9 +74,8 @@ resource "aws_s3_bucket" "accesslogs_bucket" {
   bucket = local.accesslogs_bucket_name
 
   tags = {
-    Region      = data.aws_region.main.name
-    Environment = title(var.env_name)
-    Category    = "Accesslogs"
+    Region   = data.aws_region.main.name
+    Category = "Accesslogs"
   }
 }
 

--- a/new-terraform-state/bucket.tf
+++ b/new-terraform-state/bucket.tf
@@ -74,9 +74,8 @@ resource "aws_s3_bucket" "state_bucket" {
   bucket = local.bucket_name
 
   tags = {
-    Region      = data.aws_region.main.name
-    Environment = title(var.env_name)
-    Category    = "TFstate"
+    Region   = data.aws_region.main.name
+    Category = "TFstate"
   }
 }
 

--- a/new-terraform-state/replication_accesslogs_bucket.tf
+++ b/new-terraform-state/replication_accesslogs_bucket.tf
@@ -2,9 +2,8 @@ resource "aws_s3_bucket" "replication_accesslogs_bucket" {
   bucket = "govwifi-${var.env_name}-accesslogs-${data.aws_region.replication.name}"
 
   tags = {
-    Region      = data.aws_region.replication.name
-    Environment = title(var.env_name)
-    Category    = "Accesslogs"
+    Region   = data.aws_region.replication.name
+    Category = "Accesslogs"
   }
 }
 

--- a/new-terraform-state/replication_bucket.tf
+++ b/new-terraform-state/replication_bucket.tf
@@ -8,9 +8,8 @@ resource "aws_s3_bucket" "replication_state_bucket" {
   bucket = local.replication_bucket_name
 
   tags = {
-    Region      = data.aws_region.replication.name
-    Environment = title(var.env_name)
-    Category    = "TFstate"
+    Region   = data.aws_region.replication.name
+    Category = "TFstate"
   }
 }
 

--- a/terraform-state/accesslogs.tf
+++ b/terraform-state/accesslogs.tf
@@ -74,10 +74,9 @@ resource "aws_s3_bucket" "accesslogs_bucket" {
   bucket = "${lower(var.product_name)}-${var.env_name}-${lower(var.aws_region_name)}-accesslogs"
 
   tags = {
-    Region      = title(var.aws_region_name)
-    Product     = var.product_name
-    Environment = title(var.env_name)
-    Category    = "Accesslogs"
+    Region   = title(var.aws_region_name)
+    Product  = var.product_name
+    Category = "Accesslogs"
   }
 }
 

--- a/terraform-state/tfstate.tf
+++ b/terraform-state/tfstate.tf
@@ -73,10 +73,9 @@ resource "aws_kms_key" "tfstate_key" {
   is_enabled              = true
 
   tags = {
-    Region      = title(var.aws_region_name)
-    Product     = var.product_name
-    Environment = title(var.env_name)
-    Category    = "TFstate"
+    Region   = title(var.aws_region_name)
+    Product  = var.product_name
+    Category = "TFstate"
   }
 }
 
@@ -89,10 +88,9 @@ resource "aws_s3_bucket" "state_bucket" {
   bucket = "${lower(var.product_name)}-${lower(var.env_name)}-${lower(var.aws_region_name)}-tfstate"
 
   tags = {
-    Region      = title(var.aws_region_name)
-    Product     = var.product_name
-    Environment = title(var.env_name)
-    Category    = "TFstate"
+    Region   = title(var.aws_region_name)
+    Product  = var.product_name
+    Category = "TFstate"
   }
 }
 


### PR DESCRIPTION
### What
Tag all resources by environment

### Why
This can help to check what environment a resources corresponds to, as
it's not always obvious on the AWS website.

This is more important now that there are more resources where the
environment name (wifi, staging, ...) hasn't leaked in to the resource
name.