### PR TITLE
Enable ECS Exec for all clusters in addition to frontend-fargate

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -179,6 +179,8 @@ resource "aws_ecs_service" "admin_service" {
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
 
+  enable_execute_command = true
+
   load_balancer {
     target_group_arn = aws_alb_target_group.admin_tg.arn
     container_name   = "admin"

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -97,6 +97,27 @@ resource "aws_iam_role" "ecs_admin_instance_role" {
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 
+resource "aws_iam_role_policy" "allow_ssm" {
+  name   = "${var.aws_region_name}-allow-ssm-${var.env_name}"
+  role   = aws_iam_role.ecs_admin_instance_role.id
+  policy = data.aws_iam_policy_document.allow_ssm.json
+}
+
+data "aws_iam_policy_document" "allow_ssm" {
+  statement {
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+}
+
 resource "aws_iam_role" "ecs_task_execution_role" {
   name               = "admin-ecsTaskExecutionRole-${var.rails_env}-${var.aws_region_name}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -260,3 +260,18 @@ resource "aws_iam_role_policy_attachment" "crossaccount_tools_ecs_access" {
   role       = aws_iam_role.crossaccount_tools[0].name
   policy_arn = "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
 }
+
+data "aws_iam_policy_document" "allow_ssm" {
+  statement {
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+}

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -126,6 +126,8 @@ resource "aws_ecs_service" "logging_api_service" {
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
 
+  enable_execute_command = true
+
   health_check_grace_period_seconds = 20
 
   network_configuration {
@@ -217,6 +219,14 @@ resource "aws_iam_role" "logging_api_task_role" {
 }
 EOF
 
+}
+
+resource "aws_iam_role_policy" "logging_allow_ssm" {
+  count = var.logging_enabled
+
+  name   = "${var.aws_region_name}-allow-ssm-${var.env_name}"
+  role   = aws_iam_role.logging_api_task_role[0].id
+  policy = data.aws_iam_policy_document.allow_ssm.json
 }
 
 resource "aws_iam_role_policy" "logging_api_task_policy" {

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -68,6 +68,14 @@ EOF
 
 }
 
+resource "aws_iam_role_policy" "user_signup_api_allow_ssm" {
+  count = var.user_signup_enabled
+
+  name   = "${var.aws_region_name}-allow-ssm-${var.env_name}"
+  role   = aws_iam_role.user_signup_api_task_role[0].id
+  policy = data.aws_iam_policy_document.allow_ssm.json
+}
+
 data "aws_s3_bucket" "admin_bucket" {
   count  = var.user_signup_enabled
   bucket = var.admin_app_data_s3_bucket_name
@@ -182,6 +190,8 @@ resource "aws_ecs_service" "user_signup_api_service" {
   desired_count    = var.backend_instance_count
   launch_type      = "FARGATE"
   platform_version = "1.3.0"
+
+  enable_execute_command = true
 
   health_check_grace_period_seconds = 20
 


### PR DESCRIPTION
### What
Enable ECS Exec for all clusters in addition to frontend-fargate

### Why
This is mainly to make it easier to document the ECS Exec
functionality, as I can say it'll work for any task.
