### PR TITLE
Database backup codebuild

### DIFF
--- a/govwifi-deploy/ecr.tf
+++ b/govwifi-deploy/ecr.tf
@@ -29,6 +29,14 @@ resource "aws_ecr_repository_policy" "govwifi_ecr_saferestater_policy" {
   policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy.json
 }
 
+resource "aws_ecr_repository" "database_backup_ecr" {
+  name = "govwifi/staging/database-backup"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_database_backup_policy" {
+  repository = aws_ecr_repository.database_backup_ecr.name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy.json
+}
 
 data "aws_iam_policy_document" "govwifi_ecr_repo_policy" {
   statement {

--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -48,6 +48,6 @@ module "govwifi_deploy" {
   source = "../../govwifi-deploy"
 
   deployed_app_names     = ["user-signup-api", "logging-api", "admin"]
-  built_app_names        = ["frontend", "safe-restarter"]
+  built_app_names        = ["frontend", "safe-restarter", "database-backup"]
   frontend_docker_images = ["raddb", "frontend"]
 }


### PR DESCRIPTION
### What
Add the terraform to include AWS Codebuild Project for the Database Backup module.
Create the AWS Tools account ECR Repo for Database backup images.

### Why
This is part of our migration from Concourse to AWS Developer Tools.
This task is not deployed as such and so only requires a CodeBuild Project.
The reference module is in repo: govwifi-database-backup.

### Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-246