### PR TITLE
Ignore tags for a couple of services

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -197,6 +197,12 @@ resource "aws_ecs_service" "admin_service" {
 
     assign_public_ip = true
   }
+
+  # TODO: Terraform has problems tagging this service due to ARN
+  # issues in production, so avoid this by ignoring tag changes
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
 }
 
 resource "aws_alb_target_group" "admin_tg" {

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -366,6 +366,12 @@ resource "aws_ecs_service" "frontend_service" {
     type  = "spread"
     field = "instanceId"
   }
+
+  # TODO: Terraform has problems tagging this service due to ARN
+  # issues in production, so avoid this by ignoring tag changes
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
 }
 
 resource "aws_ecs_service" "load_balanced_frontend_service" {


### PR DESCRIPTION
### What
Ignore tags for a couple of services

### Why
These seem to have short ARNs in production, which Terraform has a
problem tagging. The error looks like:

  Error: failed updating tags for ECS Service (...): error tagging
  resource (...): InvalidParameterException: Long arn format must be
  used for tagging operations

Work around this by just ignoring tag changes.
