### PR TITLE
Rename buildspec file

### DIFF
--- a/govwifi-deploy/codebuild-built-apps.tf
+++ b/govwifi-deploy/codebuild-built-apps.tf
@@ -45,7 +45,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_built_app" {
     type            = "GITHUB"
     location        = "https://github.com/alphagov/govwifi-${each.key}.git"
     git_clone_depth = 1
-    buildspec       = "buildspec-build.yml"
+    buildspec       = "buildspec.yml"
   }
 
   logs_config {

--- a/govwifi-deploy/codebuild-deployed-apps.tf
+++ b/govwifi-deploy/codebuild-deployed-apps.tf
@@ -79,7 +79,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr" {
     type            = "GITHUB"
     location        = "https://github.com/alphagov/govwifi-${each.key}.git"
     git_clone_depth = 1
-    buildspec       = "buildspec-build.yml"
+    buildspec       = "buildspec.yml"
   }
 
 }


### PR DESCRIPTION
### What
Rename buildspec-build.yml file to buildspec.yml

### Why
This is to make the naming more consistent.

Link to Trello card (if applicable): 
Jira card: https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-260

