### PR TITLE
Make any references to the authentication-api infrastructure consistent.

### DIFF
--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -17,7 +17,7 @@ resource "aws_cloudwatch_metric_alarm" "auth_ecs_cpu_alarm_high" {
   alarm_description = "ECS cluster CPU is high, scaling up number of tasks. Investigate api cluster and CloudWatch logs for root cause."
 
   alarm_actions = [
-    aws_appautoscaling_policy.ecs_policy_up.arn,
+    aws_appautoscaling_policy.ecs_policy_up_authentication_api.arn,
     var.devops_notifications_arn,
   ]
 
@@ -44,7 +44,7 @@ resource "aws_cloudwatch_metric_alarm" "auth_ecs_cpu_alarm_low" {
   alarm_description = "ECS cluster CPU is low, scaling down number of ECS tasks to save on cost."
 
   alarm_actions = [
-    aws_appautoscaling_policy.ecs_policy_down.arn,
+    aws_appautoscaling_policy.ecs_policy_down_authentication_api.arn,
   ]
 
   treat_missing_data = "breaching"

--- a/govwifi-api/alarms.tf
+++ b/govwifi-api/alarms.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "auth_ecs_cpu_alarm_high" {
 
   dimensions = {
     ClusterName = aws_ecs_cluster.api_cluster.name
-    ServiceName = aws_ecs_service.authorisation_api_service.name
+    ServiceName = aws_ecs_service.authentication_api_service.name
   }
 
   alarm_description = "ECS cluster CPU is high, scaling up number of tasks. Investigate api cluster and CloudWatch logs for root cause."
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "auth_ecs_cpu_alarm_low" {
 
   dimensions = {
     ClusterName = aws_ecs_cluster.api_cluster.name
-    ServiceName = aws_ecs_service.authorisation_api_service.name
+    ServiceName = aws_ecs_service.authentication_api_service.name
   }
 
   alarm_description = "ECS cluster CPU is low, scaling down number of ECS tasks to save on cost."

--- a/govwifi-api/authentication-api-cluster.tf
+++ b/govwifi-api/authentication-api-cluster.tf
@@ -9,6 +9,11 @@ resource "aws_ecr_repository" "authentication_api_ecr" {
   name  = "govwifi/authentication-api"
 }
 
+resource "aws_ecr_repository" "authorisation_api_ecr" {
+  count = var.ecr_repository_count
+  name  = "govwifi/authorisation-api"
+}
+
 resource "aws_ecs_task_definition" "authentication_api_task" {
   family                   = "authentication-api-task-${var.env_name}"
   requires_compatibilities = ["FARGATE"]

--- a/govwifi-api/authentication-api-cluster.tf
+++ b/govwifi-api/authentication-api-cluster.tf
@@ -1,16 +1,16 @@
-resource "aws_cloudwatch_log_group" "authorisation_api_log_group" {
-  name = "${var.env_name}-authorisation-api-docker-log-group"
+resource "aws_cloudwatch_log_group" "authentication_api_log_group" {
+  name = "${var.env_name}-authentication-api-docker-log-group"
 
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "authorisation_api_ecr" {
+resource "aws_ecr_repository" "authentication_api_ecr" {
   count = var.ecr_repository_count
-  name  = "govwifi/authorisation-api"
+  name  = "govwifi/authentication-api"
 }
 
-resource "aws_ecs_task_definition" "authorisation_api_task" {
-  family                   = "authorisation-api-task-${var.env_name}"
+resource "aws_ecs_task_definition" "authentication_api_task" {
+  family                   = "authentication-api-task-${var.env_name}"
   requires_compatibilities = ["FARGATE"]
   task_role_arn            = aws_iam_role.authentication_api_ecs_task.arn
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
@@ -72,16 +72,17 @@ resource "aws_ecs_task_definition" "authorisation_api_task" {
       "links": null,
       "workingDirectory": null,
       "readonlyRootFilesystem": null,
-      "image": "${var.auth_docker_image}",
+      "image": "${var.aws_account_id}.dkr.ecr.eu-west-2.amazonaws.com/govwifi/authentication-api:${var.rack_env}",
+
       "command": null,
       "user": null,
       "dockerLabels": null,
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "${aws_cloudwatch_log_group.authorisation_api_log_group.name}",
+          "awslogs-group": "${aws_cloudwatch_log_group.authentication_api_log_group.name}",
           "awslogs-region": "${var.aws_region}",
-          "awslogs-stream-prefix": "${var.env_name}-authorisation-api-docker-logs"
+          "awslogs-stream-prefix": "${var.env_name}-authentication-api-docker-logs"
         }
       },
       "cpu": 0,
@@ -93,11 +94,11 @@ EOF
 
 }
 
-resource "aws_ecs_service" "authorisation_api_service" {
-  name             = "authorisation-api-service-${var.env_name}"
+resource "aws_ecs_service" "authentication_api_service" {
+  name             = "authentication-api-service-${var.env_name}"
   cluster          = aws_ecs_cluster.api_cluster.id
-  task_definition  = aws_ecs_task_definition.authorisation_api_task.arn
-  desired_count    = var.authorisation_api_count
+  task_definition  = aws_ecs_task_definition.authentication_api_task.arn
+  desired_count    = var.authentication_api_count
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
 

--- a/govwifi-api/authentication-metrics.tf
+++ b/govwifi-api/authentication-metrics.tf
@@ -3,13 +3,12 @@ resource "aws_cloudwatch_log_metric_filter" "response_status_ok" {
   name  = "${var.env_name}-response-status-ok"
 
   pattern        = "\"status=200\" -\"user/HEALTH\""
-  log_group_name = aws_cloudwatch_log_group.authorisation_api_log_group.name
+  log_group_name = aws_cloudwatch_log_group.authentication_api_log_group.name
 
   metric_transformation {
     name          = "${var.env_name}-response-status-ok-count"
-    namespace     = local.authorisation_api_namespace
+    namespace     = local.authentication_api_namespace
     value         = "1"
     default_value = "0"
   }
 }
-

--- a/govwifi-api/locals.tf
+++ b/govwifi-api/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  logging_api_namespace       = "${var.env_name}-logging-api"
-  authorisation_api_namespace = "${var.env_name}-authorisation-api"
-  signup_api_namespace        = "${var.env_name}-user-signup-api"
+  logging_api_namespace = "${var.env_name}-logging-api"
+  # authorisation_api_namespace = "${var.env_name}-authorisation-api"
+  authentication_api_namespace = "${var.env_name}-authentication-api"
+  signup_api_namespace         = "${var.env_name}-user-signup-api"
 }
-

--- a/govwifi-api/scaling-policy.tf
+++ b/govwifi-api/scaling-policy.tf
@@ -1,16 +1,16 @@
-resource "aws_appautoscaling_target" "auth_ecs_target" {
+resource "aws_appautoscaling_target" "auth_ecs_target_authentication_api" {
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.authorisation_api_service.name}"
+  resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.authentication_api_service.name}"
   max_capacity       = 20
   min_capacity       = 2
   scalable_dimension = "ecs:service:DesiredCount"
 }
 
-resource "aws_appautoscaling_policy" "ecs_policy_up" {
+resource "aws_appautoscaling_policy" "ecs_policy_up_authentication_api" {
   name               = "ECS Scale Up"
   service_namespace  = "ecs"
   policy_type        = "StepScaling"
-  resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.authorisation_api_service.name}"
+  resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.authentication_api_service.name}"
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
@@ -23,13 +23,13 @@ resource "aws_appautoscaling_policy" "ecs_policy_up" {
     }
   }
 
-  depends_on = [aws_appautoscaling_target.auth_ecs_target]
+  depends_on = [aws_appautoscaling_target.auth_ecs_target_authentication_api]
 }
 
-resource "aws_appautoscaling_policy" "ecs_policy_down" {
+resource "aws_appautoscaling_policy" "ecs_policy_down_authentication_api" {
   name               = "ECS Scale Down"
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.authorisation_api_service.name}"
+  resource_id        = "service/${aws_ecs_cluster.api_cluster.name}/${aws_ecs_service.authentication_api_service.name}"
   policy_type        = "StepScaling"
   scalable_dimension = "ecs:service:DesiredCount"
 
@@ -43,6 +43,5 @@ resource "aws_appautoscaling_policy" "ecs_policy_down" {
     }
   }
 
-  depends_on = [aws_appautoscaling_target.auth_ecs_target]
+  depends_on = [aws_appautoscaling_target.auth_ecs_target_authentication_api]
 }
-

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -27,7 +27,7 @@ variable "event_rule_count" {
 variable "backend_instance_count" {
 }
 
-variable "authorisation_api_count" {
+variable "authentication_api_count" {
   default = 3
 }
 
@@ -89,9 +89,6 @@ variable "subnet_ids" {
 
 variable "private_subnet_ids" {
   type = list(string)
-}
-
-variable "auth_docker_image" {
 }
 
 variable "user_signup_docker_image" {

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -272,7 +272,6 @@ module "dublin_api" {
   devops_notifications_arn   = module.dublin_notifications.topic_arn
   notification_arn           = module.dublin_notifications.topic_arn
 
-  auth_docker_image             = format("%s/authorisation-api:staging", local.docker_image_path)
   user_signup_docker_image      = ""
   logging_docker_image          = ""
   safe_restart_docker_image     = ""

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -228,7 +228,6 @@ module "london_api" {
   devops_notifications_arn   = module.london_notifications.topic_arn
   notification_arn           = module.london_notifications.topic_arn
 
-  auth_docker_image             = format("%s/authorisation-api:staging", local.docker_image_path)
   user_signup_docker_image      = format("%s/user-signup-api:staging", local.docker_image_path)
   logging_docker_image          = format("%s/logging-api:staging", local.docker_image_path)
   safe_restart_docker_image     = format("%s/safe-restarter:staging", local.docker_image_path)

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -295,7 +295,6 @@ module "api" {
   devops_notifications_arn   = module.devops_notifications.topic_arn
   notification_arn           = module.region_pagerduty.topic_arn
 
-  auth_docker_image             = format("%s/authorisation-api:production", local.docker_image_path)
   user_signup_docker_image      = format("%s/user-signup-api:production", local.docker_image_path)
   logging_docker_image          = format("%s/logging-api:production", local.docker_image_path)
   safe_restart_docker_image     = format("%s/safe-restarter:production", local.docker_image_path)

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -262,14 +262,14 @@ module "api" {
   env_name      = local.env_name
   env_subdomain = local.env_subdomain
 
-  backend_elb_count       = 1
-  backend_instance_count  = 2
-  authorisation_api_count = 3
-  aws_account_id          = local.aws_account_id
-  aws_region_name         = lower(var.aws_region_name)
-  aws_region              = var.aws_region
-  route53_zone_id         = data.aws_route53_zone.main.zone_id
-  vpc_id                  = module.backend.backend_vpc_id
+  backend_elb_count        = 1
+  backend_instance_count   = 2
+  authentication_api_count = 3
+  aws_account_id           = local.aws_account_id
+  aws_region_name          = lower(var.aws_region_name)
+  aws_region               = var.aws_region
+  route53_zone_id          = data.aws_route53_zone.main.zone_id
+  vpc_id                   = module.backend.backend_vpc_id
 
   vpc_endpoints_security_group_id = module.backend.vpc_endpoints_security_group_id
 
@@ -283,7 +283,6 @@ module "api" {
   devops_notifications_arn   = module.devops_notifications.topic_arn
   notification_arn           = module.region_pagerduty.topic_arn
 
-  auth_docker_image             = format("%s/authorisation-api:production", local.docker_image_path)
   logging_docker_image          = format("%s/logging-api:production", local.docker_image_path)
   safe_restart_docker_image     = format("%s/safe-restarter:production", local.docker_image_path)
   backup_rds_to_s3_docker_image = ""


### PR DESCRIPTION
### What
Make any references to the authentication-api infrastructure
consistent. 

### Why
At present we are using the name "authentication-api" and
"authorization-api" to refer to the same things, which is confusing. This
change is part of rectifying that. It updates the name of the cluster, service
and related resources.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-204
