### PR TITLE
Add authentication-api to built apps list

### DIFF
--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -31,6 +31,6 @@ module "govwifi_deploy" {
   source = "../../govwifi-deploy"
 
   deployed_app_names     = ["user-signup-api", "logging-api", "admin"]
-  built_app_names        = ["frontend", "safe-restarter", "database-backup"]
+  built_app_names        = ["frontend", "safe-restarter", "database-backup", "authentication-api"]
   frontend_docker_images = ["raddb", "frontend"]
 }


### PR DESCRIPTION
### What
Add authentication-api to built apps module list because we're ready to test it

### Why
We were waiting until we had solved the naming conflict authentication Vs authorisation. This has now been completed, settling on authentication.

Link to Trello card (if applicable): 
