### PR TITLE
Change task-definitions for frontend, database-backups & safe-restarter

### DIFF
--- a/govwifi-api/database-backup-task.tf
+++ b/govwifi-api/database-backup-task.tf
@@ -105,7 +105,7 @@ resource "aws_ecs_task_definition" "backup_rds_to_s3_task_definition" {
       "links": null,
       "workingDirectory": null,
       "readonlyRootFilesystem": null,
-      "image": "${var.backup_rds_to_s3_docker_image}",
+      "image": "${local.backup_rds_to_s3_docker_image_new}",
       "command": null,
       "user": null,
       "dockerLabels": null,

--- a/govwifi-api/locals.tf
+++ b/govwifi-api/locals.tf
@@ -3,4 +3,7 @@ locals {
   # authorisation_api_namespace = "${var.env_name}-authorisation-api"
   authentication_api_namespace = "${var.env_name}-authentication-api"
   signup_api_namespace         = "${var.env_name}-user-signup-api"
+
+  safe_restart_docker_image_new     = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/${var.env}/safe-restarter:latest"
+  backup_rds_to_s3_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/${var.env}/database-backup:latest"
 }

--- a/govwifi-api/safe-restart-scheduled-task.tf
+++ b/govwifi-api/safe-restart-scheduled-task.tf
@@ -69,7 +69,7 @@ resource "aws_ecs_task_definition" "safe_restart_task_definition" {
       "links": null,
       "workingDirectory": null,
       "readonlyRootFilesystem": null,
-      "image": "${var.safe_restart_docker_image}",
+      "image": "${local.safe_restart_docker_image_new}",
       "command": null,
       "user": null,
       "dockerLabels": null,

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -163,7 +163,7 @@ resource "aws_ecs_task_definition" "radius_task" {
         "valueFrom": "${data.aws_secretsmanager_secret_version.healthcheck.arn}:ssid::"
       }
     ],
-    "image": "${var.frontend_docker_image}",
+    "image": "${local.frontend_image_new}",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
@@ -199,7 +199,7 @@ resource "aws_ecs_task_definition" "radius_task" {
         "value": "s3://${aws_s3_bucket.frontend_cert_bucket.bucket}"
       }
     ],
-    "image": "${var.raddb_docker_image}",
+    "image": "${local.raddb_image_new}",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
@@ -303,7 +303,7 @@ resource "aws_ecs_task_definition" "frontend_fargate" {
         "valueFrom": "${data.aws_secretsmanager_secret_version.healthcheck.arn}:ssid::"
       }
     ],
-    "image": "${var.frontend_docker_image}",
+    "image": "${local.frontend_image_new}",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
@@ -341,7 +341,7 @@ resource "aws_ecs_task_definition" "frontend_fargate" {
         "value": "${var.aws_region}"
       }
     ],
-    "image": "${var.raddb_docker_image}",
+    "image": "${local.raddb_image_new}",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/govwifi-frontend/locals.tf
+++ b/govwifi-frontend/locals.tf
@@ -1,3 +1,6 @@
 locals {
   frontend_metrics_namespace = "${var.env_name}-frontend"
+
+  frontend_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/${var.env}/frontend:latest"
+  raddb_image_new    = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/${var.env}/raddb:latest"
 }

--- a/govwifi-frontend/secrets-manager.tf
+++ b/govwifi-frontend/secrets-manager.tf
@@ -13,3 +13,11 @@ data "aws_secretsmanager_secret_version" "shared_key" {
 data "aws_secretsmanager_secret" "shared_key" {
   name = "radius/shared-key"
 }
+
+data "aws_secretsmanager_secret_version" "tools_account" {
+  secret_id = data.aws_secretsmanager_secret.tools_account.id
+}
+
+data "aws_secretsmanager_secret" "tools_account" {
+  name = "tools/AccountID"
+}

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -4,6 +4,9 @@ variable "env_name" {
 variable "env_subdomain" {
 }
 
+variable "env" {
+}
+
 variable "route53_zone_id" {
 }
 

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -188,6 +188,7 @@ module "dublin_frontend" {
   source        = "../../govwifi-frontend"
   env_name      = local.env_name
   env_subdomain = local.env_subdomain
+  env           = local.env
 
   # AWS VPC setup -----------------------------------------
   aws_region         = local.dublin_aws_region

--- a/govwifi/staging/locals.tf
+++ b/govwifi/staging/locals.tf
@@ -1,8 +1,8 @@
 locals {
   env_name      = "staging"
   env_subdomain = "staging.wifi" # Environment specific subdomain to use under the service domain
-
-  product_name = "GovWifi"
+  env           = "staging"
+  product_name  = "GovWifi"
 
   backup_mysql_rds = true
 }

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -97,6 +97,7 @@ module "london_frontend" {
   source        = "../../govwifi-frontend"
   env_name      = local.env_name
   env_subdomain = local.env_subdomain
+  env           = local.env
 
   # AWS VPC setup -----------------------------------------
   # LONDON

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -1,6 +1,7 @@
 locals {
   env_name      = "wifi"
   env_subdomain = "wifi" # Environment specific subdomain to use under the service domain
+  env           = "production"
 
   product_name = "GovWifi"
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -165,6 +165,7 @@ module "frontend" {
   source        = "../../govwifi-frontend"
   env_name      = local.env_name
   env_subdomain = local.env_subdomain
+  env           = local.env
 
   # AWS VPC setup -----------------------------------------
   # LONDON

--- a/govwifi/wifi/.terraform.lock.hcl
+++ b/govwifi/wifi/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/aws" {
   version = "4.22.0"
   hashes = [
+    "h1:BF8L000SD8CNn13cQdSl9TUC8e+CKkkqwoipjv0X3wM=",
     "h1:RxPzK6VFHz6qZMZUVhE03j9Cf5CvnLr14egtq5yxD1E=",
     "zh:299efb8ba733b7742f0ef1c5c5467819e0c7bf46264f5f36ba6b6674304a5244",
     "zh:4db198a41d248491204d4ca644662c32f748177d5cbe01f3c7adbb957d4d77f0",

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -1,6 +1,7 @@
 locals {
   env_name      = "wifi"
   env_subdomain = "wifi" # Environment specific subdomain to use under the service domain
+  env           = "production"
 
   product_name = "GovWifi"
 }

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -199,6 +199,7 @@ module "frontend" {
   source        = "../../govwifi-frontend"
   env_name      = local.env_name
   env_subdomain = local.env_subdomain
+  env           = local.env
 
   # AWS VPC setup -----------------------------------------
   aws_region         = var.aws_region


### PR DESCRIPTION
### What
Change task-definitions for frontend, database-backups & safe-restarter

### Why
Update image path in the task definitions for the following:
- frontend
- database-backups
- safe-restarter

We are switching our migration pipelines from Concourse to AWS. The docker images for these tasks are now kept our tools account. This updates the task definition to match this new state.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251
