### PR TITLE
Add production smoke test stage to pipelines

### DIFF
--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -141,4 +141,26 @@ resource "aws_codepipeline" "admin_pipeline" {
 
   }
 
+
+	stage {
+    name = "Production-Smoketests"
+
+    action {
+      name            = "Production-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
+  }
+
 }

--- a/govwifi-deploy/codepipeline-authentication-api.tf
+++ b/govwifi-deploy/codepipeline-authentication-api.tf
@@ -176,7 +176,27 @@ resource "aws_codepipeline" "authentication_api_pipeline" {
       }
     }
 
+  }
 
+	stage {
+    name = "Production-Smoketests"
+
+    action {
+      name            = "Production-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
   }
 
 }

--- a/govwifi-deploy/codepipeline-logging-api.tf
+++ b/govwifi-deploy/codepipeline-logging-api.tf
@@ -140,7 +140,27 @@ resource "aws_codepipeline" "logging_api_pipeline" {
         ServiceName : "logging-api-service-wifi"
       }
     }
+  }
 
+	stage {
+    name = "Production-Smoketests"
+
+    action {
+      name            = "Production-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
   }
 
 

--- a/govwifi-deploy/codepipeline-user-signup-api.tf
+++ b/govwifi-deploy/codepipeline-user-signup-api.tf
@@ -140,7 +140,27 @@ resource "aws_codepipeline" "user_signup_api_pipeline" {
         ServiceName : "user-signup-api-service-wifi"
       }
     }
+  }
 
+	stage {
+    name = "Production-Smoketests"
+
+    action {
+      name            = "Production-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
   }
 
 


### PR DESCRIPTION
### What
The app pipelines now include a run of smoke tests after they are deployed to production. 

### Why
This is to ensure that the whole system is still working correctly after a deployment of the following apps:
Logging-api
Authentication-api
User-signup-api
Admin

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-597
