### PR TITLE
Update app image paths in task def

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -154,7 +154,7 @@ resource "aws_ecs_task_definition" "admin_task" {
           "valueFrom": "${data.aws_secretsmanager_secret.sentry_dsn.arn}"
         }
       ],
-      "image": "${var.admin_docker_image}",
+      "image": "${local.admin_docker_image_new}",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/govwifi-admin/locals.tf
+++ b/govwifi-admin/locals.tf
@@ -1,5 +1,7 @@
 locals {
   admin_db_username = jsondecode(data.aws_secretsmanager_secret_version.admin_db.secret_string)["username"]
+
+  admin_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/admin:latest"
 }
 
 locals {

--- a/govwifi-admin/secrets-manager.tf
+++ b/govwifi-admin/secrets-manager.tf
@@ -65,3 +65,11 @@ data "aws_secretsmanager_secret" "google_service_account_backup_credentials" {
 data "aws_secretsmanager_secret" "sentry_dsn" {
   name = "sentry/admin_dsn"
 }
+
+data "aws_secretsmanager_secret_version" "tools_account" {
+  secret_id = data.aws_secretsmanager_secret.tools_account.id
+}
+
+data "aws_secretsmanager_secret" "tools_account" {
+  name = "tools/AccountID"
+}

--- a/govwifi-api/authentication-api-cluster.tf
+++ b/govwifi-api/authentication-api-cluster.tf
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "authentication_api_task" {
       "links": null,
       "workingDirectory": null,
       "readonlyRootFilesystem": null,
-      "image": "${var.aws_account_id}.dkr.ecr.eu-west-2.amazonaws.com/govwifi/authentication-api:${var.rack_env}",
+      "image": "${local.tools_account_id}.dkr.ecr.eu-west-2.amazonaws.com/govwifi/authentication-api:latest",
 
       "command": null,
       "user": null,

--- a/govwifi-api/locals.tf
+++ b/govwifi-api/locals.tf
@@ -6,4 +6,10 @@ locals {
 
   safe_restart_docker_image_new     = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/${var.env}/safe-restarter:latest"
   backup_rds_to_s3_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/${var.env}/database-backup:latest"
+
+  logging_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/logging-api:latest"
+
+  user_signup_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/user-signup-api:latest"
+
+  tools_account_id = data.aws_secretsmanager_secret_version.tools_account.secret_string
 }

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -97,7 +97,7 @@ resource "aws_ecs_task_definition" "logging_api_task" {
       "links": null,
       "workingDirectory": null,
       "readonlyRootFilesystem": null,
-      "image": "${var.logging_docker_image}",
+      "image": "${local.logging_docker_image_new}",
       "command": null,
       "user": null,
       "dockerLabels": null,

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -537,7 +537,7 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
       "links": null,
       "workingDirectory": null,
       "readonlyRootFilesystem": null,
-      "image": "${var.logging_docker_image}",
+      "image": "${local.logging_docker_image_new}",
       "command": null,
       "user": null,
       "dockerLabels": null,

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -161,7 +161,7 @@ resource "aws_ecs_task_definition" "user_signup_api_task" {
       "links": null,
       "workingDirectory": null,
       "readonlyRootFilesystem": null,
-      "image": "${var.user_signup_docker_image}",
+      "image": "${local.user_signup_docker_image_new}",
       "command": null,
       "user": null,
       "dockerLabels": null,

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -289,7 +289,7 @@ resource "aws_ecs_task_definition" "user_signup_api_scheduled_task" {
       "links": null,
       "workingDirectory": null,
       "readonlyRootFilesystem": null,
-      "image": "${var.user_signup_docker_image}",
+      "image": "${local.user_signup_docker_image_new}",
       "command": null,
       "user": null,
       "dockerLabels": null,


### PR DESCRIPTION
### What
Update app image paths in task def

### Why
This is part of the Concourse migration. The docker images for these tasks are now located in our tools account. Update code to match.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-597
