### PR TITLE
Add sns smoke-tests policy permissions

### DIFF
--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -142,7 +142,7 @@ resource "aws_codepipeline" "admin_pipeline" {
   }
 
 
-	stage {
+  stage {
     name = "Production-Smoketests"
 
     action {

--- a/govwifi-deploy/codepipeline-authentication-api.tf
+++ b/govwifi-deploy/codepipeline-authentication-api.tf
@@ -178,7 +178,7 @@ resource "aws_codepipeline" "authentication_api_pipeline" {
 
   }
 
-	stage {
+  stage {
     name = "Production-Smoketests"
 
     action {

--- a/govwifi-deploy/codepipeline-logging-api.tf
+++ b/govwifi-deploy/codepipeline-logging-api.tf
@@ -142,7 +142,7 @@ resource "aws_codepipeline" "logging_api_pipeline" {
     }
   }
 
-	stage {
+  stage {
     name = "Production-Smoketests"
 
     action {

--- a/govwifi-deploy/codepipeline-user-signup-api.tf
+++ b/govwifi-deploy/codepipeline-user-signup-api.tf
@@ -142,7 +142,7 @@ resource "aws_codepipeline" "user_signup_api_pipeline" {
     }
   }
 
-	stage {
+  stage {
     name = "Production-Smoketests"
 
     action {

--- a/govwifi-slack-alerts/main.tf
+++ b/govwifi-slack-alerts/main.tf
@@ -41,7 +41,7 @@ resource "aws_cloudformation_stack" "aws_slack_chatbot" {
           "LoggingLevel" : "NONE",
           "SlackChannelId" : "${local.slack_channel_id}",
           "SlackWorkspaceId" : "${local.slack_workplace_id}",
-          "SnsTopicArns" : [ "${var.critical_notifications_topic_arn}","${var.capacity_notifications_topic_arn}","${var.route53_critical_notifications_topic_arn}" ]
+          "SnsTopicArns" : [ "${var.critical_notifications_topic_arn}","${var.capacity_notifications_topic_arn}","${var.route53_critical_notifications_topic_arn}","${var.smoke_tests_notifications_topic_arn}" ]
         }
       }
     }

--- a/govwifi-slack-alerts/variables.tf
+++ b/govwifi-slack-alerts/variables.tf
@@ -3,3 +3,5 @@ variable "critical_notifications_topic_arn" {}
 variable "capacity_notifications_topic_arn" {}
 
 variable "route53_critical_notifications_topic_arn" {}
+
+variable "smoke_tests_notifications_topic_arn" {}

--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -111,6 +111,7 @@ resource "aws_cloudwatch_event_target" "trigger_smoke_tests" {
 }
 
 resource "aws_cloudwatch_event_rule" "smoke_tests_schedule_rule" {
+  is_enabled          = false
   name                = "smoke-tests-scheduled-build"
   schedule_expression = "cron(0/15 * * * ? *)"
 }

--- a/govwifi-smoke-tests/outputs.tf
+++ b/govwifi-smoke-tests/outputs.tf
@@ -1,0 +1,3 @@
+output "topic_arn" {
+  value = aws_sns_topic.smoke_tests.arn
+}

--- a/govwifi-smoke-tests/sns.tf
+++ b/govwifi-smoke-tests/sns.tf
@@ -19,6 +19,65 @@ EOF
 
 }
 
+
+
+resource "aws_sns_topic_policy" "smoke_tests" {
+  arn = aws_sns_topic.smoke_tests.arn
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Id": "__default_policy_ID",
+  "Statement": [
+    {
+      "Sid": "__default_statement_ID",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "SNS:GetTopicAttributes",
+        "SNS:SetTopicAttributes",
+        "SNS:AddPermission",
+        "SNS:RemovePermission",
+        "SNS:DeleteTopic",
+        "SNS:Subscribe",
+        "SNS:ListSubscriptionsByTopic",
+        "SNS:Publish"
+      ],
+      "Resource": "arn:aws:sns:eu-west-2:${var.aws_account_id}:govwifi-smoke-tests",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceOwner": "${var.aws_account_id}"
+        }
+      }
+    },
+    {
+      "Sid": "eventbridgesmoke",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "sns:Publish",
+      "Resource": "arn:aws:sns:eu-west-2:${var.aws_account_id}:govwifi-smoke-tests"
+    },
+    {
+      "Sid": "AWSEvents_smoke-tests-notification_SendSmoketestsToSNS",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "sns:Publish",
+      "Resource": "arn:aws:sns:eu-west-2:${var.aws_account_id}:govwifi-smoke-tests"
+    }
+  ]
+}
+EOF
+
+}
+
+
+
 resource "aws_cloudwatch_event_target" "sns" {
   rule      = aws_cloudwatch_event_rule.smoke_tests.name
   target_id = "SendSmoketestsToSNS"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -475,6 +475,7 @@ module "govwifi_slack_alerts" {
   critical_notifications_topic_arn         = module.critical_notifications.topic_arn
   capacity_notifications_topic_arn         = module.capacity_notifications.topic_arn
   route53_critical_notifications_topic_arn = module.route53_critical_notifications.topic_arn
+  smoke_tests_notifications_topic_arn      = module.smoke_tests.topic_arn
 }
 
 module "govwifi_elasticsearch" {


### PR DESCRIPTION
### What
Add sns smoke-tests policy permissions
Disable scheduled smoke-tests

### Why
Disabling scheduled smoketests for now as AWS alerting isn't working
