### PR TITLE
Reinstate separate staging and production repos for ECR images

### DIFF
--- a/govwifi-admin/locals.tf
+++ b/govwifi-admin/locals.tf
@@ -1,7 +1,7 @@
 locals {
   admin_db_username = jsondecode(data.aws_secretsmanager_secret_version.admin_db.secret_string)["username"]
 
-  admin_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/admin:latest"
+  admin_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/admin/${var.env}:latest"
 }
 
 locals {

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -1,9 +1,13 @@
 variable "env_name" {
-  description = "E.g. staging"
+  description = "E.g. wifi"
 }
 
 variable "env_subdomain" {
   description = "E.g. staging.wifi"
+}
+
+variable "env" {
+  description = "E.g. production"
 }
 
 variable "aws_region" {

--- a/govwifi-api/authentication-api-cluster.tf
+++ b/govwifi-api/authentication-api-cluster.tf
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "authentication_api_task" {
       "links": null,
       "workingDirectory": null,
       "readonlyRootFilesystem": null,
-      "image": "${local.tools_account_id}.dkr.ecr.eu-west-2.amazonaws.com/govwifi/authentication-api:latest",
+      "image": "${local.tools_account_id}.dkr.ecr.eu-west-2.amazonaws.com/govwifi/authentication-api/${var.env}:latest",
 
       "command": null,
       "user": null,

--- a/govwifi-api/locals.tf
+++ b/govwifi-api/locals.tf
@@ -7,9 +7,9 @@ locals {
   safe_restart_docker_image_new     = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/${var.env}/safe-restarter:latest"
   backup_rds_to_s3_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/${var.env}/database-backup:latest"
 
-  logging_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/logging-api:latest"
+  logging_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/logging-api/${var.env}:latest"
 
-  user_signup_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/user-signup-api:latest"
+  user_signup_docker_image_new = "${data.aws_secretsmanager_secret_version.tools_account.secret_string}.dkr.ecr.${var.aws_region}.amazonaws.com/govwifi/user-signup-api/${var.env}:latest"
 
   tools_account_id = data.aws_secretsmanager_secret_version.tools_account.secret_string
 }

--- a/govwifi-deploy/buildspec_production_deployed_image.yml
+++ b/govwifi-deploy/buildspec_production_deployed_image.yml
@@ -1,0 +1,29 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws --version
+      - echo "AWS_REGION is $AWS_REGION "
+      - REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/$APP/$STAGE
+      - echo "REPOSITORY_URI is $REPOSITORY_URI"
+      - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG="latest"
+      - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+  build:
+    commands:
+      - git clone https://github.com/alphagov/govwifi-$APP.git
+      - cd govwifi-$APP
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker build --build-arg BUNDLE_INSTALL_CMD='bundle install --jobs 20 --retry 5' -t $REPOSITORY_URI:$IMAGE_TAG .
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo Writing image definitions file...
+      - printf '[{"name":"admin","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+      - set +x

--- a/govwifi-deploy/codebuild-deployed-apps-staging.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-staging.tf
@@ -1,6 +1,6 @@
-resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_global" {
+resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_staging" {
   for_each      = toset(var.deployed_app_names)
-  name          = "govwifi-codebuild-global-${each.key}-push-image-to-ecr"
+  name          = "${each.key}-push-image-to-ecr-staging"
   description   = "This project builds the API docker images and pushes them to ECR ${each.key}"
   build_timeout = "12"
   service_role  = aws_iam_role.govwifi_codebuild.arn
@@ -31,10 +31,10 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_gl
       value = "eu-west-2"
     }
 
-    # environment_variable {
-    #   name  = "STAGE"
-    #   value = "staging"
-    # }
+    environment_variable {
+      name  = "STAGE"
+      value = "staging"
+    }
 
     environment_variable {
       name  = "DOCKER_HUB_AUTHTOKEN_ENV"
@@ -73,7 +73,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_gl
     }
   }
 
-  source_version = "temp-pipeline-build"
+  source_version = "master"
 
 
   source {
@@ -85,23 +85,23 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_gl
 
 }
 
-resource "aws_codebuild_webhook" "govwifi_app_webhook_global" {
+resource "aws_codebuild_webhook" "govwifi_app_webhook_staging" {
   for_each     = toset(var.deployed_app_names)
-  project_name = aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_global[each.key].name
+  project_name = aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_staging[each.key].name
 
   build_type = "BUILD"
 
   filter_group {
     filter {
       type    = "EVENT"
-      pattern = "PUSH"
+      pattern = "PULL_REQUEST_MERGED"
     }
 
     ### To test a branch without needing to raise a PR, uncomment the below and change source to the name of your branch
-    filter {
-      type    = "HEAD_REF"
-      pattern = "^refs/heads/temp-pipeline-build$"
-    }
+    # filter {
+    #   type    = "HEAD_REF"
+    #   pattern = "^refs/heads/buildspec-global-ecr$"
+    # }
 
 
   }

--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -161,25 +161,25 @@ resource "aws_codepipeline" "admin_pipeline" {
 
   }
 
-  stage {
-    name = "Production-Smoketests"
-
-    action {
-      name            = "Production-Smoketests"
-      category        = "Test"
-      owner           = "AWS"
-      provider        = "CodeBuild"
-      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
-
-      # This resource lives in the Staging & Production environments. It will always have to
-      # either be hardcoded or retrieved from the AWS secrets or parameter store
-      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
-      version  = "1"
-
-      configuration = {
-        ProjectName = "govwifi-smoke-tests"
-      }
-    }
-  }
+  # stage {
+  #   name = "Production-Smoketests"
+  #
+  #   action {
+  #     name            = "Production-Smoketests"
+  #     category        = "Test"
+  #     owner           = "AWS"
+  #     provider        = "CodeBuild"
+  #     input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+  #
+  #     # This resource lives in the Staging & Production environments. It will always have to
+  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
+  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+  #     version  = "1"
+  #
+  #     configuration = {
+  #       ProjectName = "govwifi-smoke-tests"
+  #     }
+  #   }
+  # }
 
 }

--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -64,7 +64,7 @@ resource "aws_codepipeline" "admin_pipeline" {
 
 
     action {
-      name            = "Deploy-to-eu-west-2-staging"
+      name            = "Deploy-to-eu-west-2"
       category        = "Deploy"
       owner           = "AWS"
       provider        = "ECS"
@@ -80,9 +80,8 @@ resource "aws_codepipeline" "admin_pipeline" {
       }
     }
 
-
-
   }
+
 
   stage {
     name = "Staging-Smoketests"
@@ -105,7 +104,6 @@ resource "aws_codepipeline" "admin_pipeline" {
     }
   }
 
-
   stage {
     name = "Release-to-PRODUCTION"
 
@@ -118,6 +116,28 @@ resource "aws_codepipeline" "admin_pipeline" {
     }
   }
 
+  ###
+  # Update admin image in production. Copy staging docker image to production repo now it has been tested
+  # The way AWS works is that the actual image being deployed by the AWS deploy stage is the asset
+  # that is passed along the code pipe line..However the production task definition must also
+
+  stage {
+    name = "Push-PRODUCTION-image-to-ECR"
+
+    action {
+      name            = "Push-PRODUCTION-image-to-ECR"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+
+      version = "1"
+
+      configuration = {
+        ProjectName = "${aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_production["admin"].name}"
+      }
+    }
+  }
 
   stage {
     name = "PRODUCTION-Deploy"
@@ -140,7 +160,6 @@ resource "aws_codepipeline" "admin_pipeline" {
     }
 
   }
-
 
   stage {
     name = "Production-Smoketests"

--- a/govwifi-deploy/codepipeline-authentication-api.tf
+++ b/govwifi-deploy/codepipeline-authentication-api.tf
@@ -196,25 +196,25 @@ resource "aws_codepipeline" "authentication_api_pipeline" {
 
   }
 
-  stage {
-    name = "Production-Smoketests"
-
-    action {
-      name            = "Production-Smoketests"
-      category        = "Test"
-      owner           = "AWS"
-      provider        = "CodeBuild"
-      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
-
-      # This resource lives in the Staging & Production environments. It will always have to
-      # either be hardcoded or retrieved from the AWS secrets or parameter store
-      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
-      version  = "1"
-
-      configuration = {
-        ProjectName = "govwifi-smoke-tests"
-      }
-    }
-  }
+  # stage {
+  #   name = "Production-Smoketests"
+  #
+  #   action {
+  #     name            = "Production-Smoketests"
+  #     category        = "Test"
+  #     owner           = "AWS"
+  #     provider        = "CodeBuild"
+  #     input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+  #
+  #     # This resource lives in the Staging & Production environments. It will always have to
+  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
+  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+  #     version  = "1"
+  #
+  #     configuration = {
+  #       ProjectName = "govwifi-smoke-tests"
+  #     }
+  #   }
+  # }
 
 }

--- a/govwifi-deploy/codepipeline-authentication-api.tf
+++ b/govwifi-deploy/codepipeline-authentication-api.tf
@@ -136,6 +136,24 @@ resource "aws_codepipeline" "authentication_api_pipeline" {
     }
   }
 
+  stage {
+    name = "Push-PRODUCTION-image-to-ECR"
+
+    action {
+      name            = "Push-PRODUCTION-image-to-ECR"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+
+      version = "1"
+
+      configuration = {
+        ProjectName = "${aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_production["authentication-api"].name}"
+      }
+    }
+  }
+
 
   stage {
     name = "PRODUCTION-Deploy"

--- a/govwifi-deploy/codepipeline-logging-api.tf
+++ b/govwifi-deploy/codepipeline-logging-api.tf
@@ -121,6 +121,25 @@ resource "aws_codepipeline" "logging_api_pipeline" {
 
 
   stage {
+    name = "Push-PRODUCTION-image-to-ECR"
+
+    action {
+      name            = "Push-PRODUCTION-image-to-ECR"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
+
+      version = "1"
+
+      configuration = {
+        ProjectName = "${aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_production["logging-api"].name}"
+      }
+    }
+  }
+
+
+  stage {
     name = "PRODUCTION-Deploy"
 
     action {

--- a/govwifi-deploy/codepipeline-logging-api.tf
+++ b/govwifi-deploy/codepipeline-logging-api.tf
@@ -161,26 +161,26 @@ resource "aws_codepipeline" "logging_api_pipeline" {
     }
   }
 
-  stage {
-    name = "Production-Smoketests"
-
-    action {
-      name            = "Production-Smoketests"
-      category        = "Test"
-      owner           = "AWS"
-      provider        = "CodeBuild"
-      input_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
-
-      # This resource lives in the Staging & Production environments. It will always have to
-      # either be hardcoded or retrieved from the AWS secrets or parameter store
-      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
-      version  = "1"
-
-      configuration = {
-        ProjectName = "govwifi-smoke-tests"
-      }
-    }
-  }
+  # stage {
+  #   name = "Production-Smoketests"
+  #
+  #   action {
+  #     name            = "Production-Smoketests"
+  #     category        = "Test"
+  #     owner           = "AWS"
+  #     provider        = "CodeBuild"
+  #     input_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
+  #
+  #     # This resource lives in the Staging & Production environments. It will always have to
+  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
+  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+  #     version  = "1"
+  #
+  #     configuration = {
+  #       ProjectName = "govwifi-smoke-tests"
+  #     }
+  #   }
+  # }
 
 
 }

--- a/govwifi-deploy/codepipeline-user-signup-api.tf
+++ b/govwifi-deploy/codepipeline-user-signup-api.tf
@@ -121,6 +121,25 @@ resource "aws_codepipeline" "user_signup_api_pipeline" {
 
 
   stage {
+    name = "Push-PRODUCTION-image-to-ECR"
+
+    action {
+      name            = "Push-PRODUCTION-image-to-ECR"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
+
+      version = "1"
+
+      configuration = {
+        ProjectName = "${aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_production["user-signup-api"].name}"
+      }
+    }
+  }
+
+
+  stage {
     name = "PRODUCTION-Deploy"
 
     action {

--- a/govwifi-deploy/codepipeline-user-signup-api.tf
+++ b/govwifi-deploy/codepipeline-user-signup-api.tf
@@ -161,26 +161,26 @@ resource "aws_codepipeline" "user_signup_api_pipeline" {
     }
   }
 
-  stage {
-    name = "Production-Smoketests"
-
-    action {
-      name            = "Production-Smoketests"
-      category        = "Test"
-      owner           = "AWS"
-      provider        = "CodeBuild"
-      input_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
-
-      # This resource lives in the Staging & Production environments. It will always have to
-      # either be hardcoded or retrieved from the AWS secrets or parameter store
-      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
-      version  = "1"
-
-      configuration = {
-        ProjectName = "govwifi-smoke-tests"
-      }
-    }
-  }
+  # stage {
+  #   name = "Production-Smoketests"
+  #
+  #   action {
+  #     name            = "Production-Smoketests"
+  #     category        = "Test"
+  #     owner           = "AWS"
+  #     provider        = "CodeBuild"
+  #     input_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
+  #
+  #     # This resource lives in the Staging & Production environments. It will always have to
+  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
+  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+  #     version  = "1"
+  #
+  #     configuration = {
+  #       ProjectName = "govwifi-smoke-tests"
+  #     }
+  #   }
+  # }
 
 
 }

--- a/govwifi-deploy/ecr.tf
+++ b/govwifi-deploy/ecr.tf
@@ -67,6 +67,17 @@ data "aws_iam_policy_document" "govwifi_ecr_repo_policy_staging" {
 
 }
 
+resource "aws_ecr_repository" "govwifi_ecr_repo_deployed_apps_staging" {
+  for_each = toset(var.deployed_app_names)
+  name     = "govwifi/${each.key}/staging"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_repo_policy_deployed_apps_staging" {
+  for_each   = toset(var.deployed_app_names)
+  repository = aws_ecr_repository.govwifi_ecr_repo_deployed_apps_staging[each.key].name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_staging.json
+}
+
 ### End Staging
 
 ### Begin Production
@@ -137,6 +148,20 @@ data "aws_iam_policy_document" "govwifi_ecr_repo_policy_production" {
   }
 
 }
+
+
+resource "aws_ecr_repository" "govwifi_ecr_repo_deployed_apps_production" {
+  for_each = toset(var.deployed_app_names)
+  name     = "govwifi/${each.key}/production"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_repo_policy_deployed_apps_production" {
+  for_each   = toset(var.deployed_app_names)
+  repository = aws_ecr_repository.govwifi_ecr_repo_deployed_apps_production[each.key].name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_production.json
+}
+
+
 ### End Production
 
 ### Global
@@ -176,5 +201,3 @@ data "aws_iam_policy_document" "govwifi_ecr_repo_policy_global" {
   }
 
 }
-
-### End Global

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -155,6 +155,7 @@ module "london_admin" {
   source        = "../../govwifi-admin"
   env_name      = local.env_name
   env_subdomain = local.env_subdomain
+  env           = local.env
 
   aws_region      = local.london_aws_region
   aws_region_name = local.london_aws_region_name

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -223,6 +223,7 @@ module "govwifi_admin" {
   source        = "../../govwifi-admin"
   env_name      = local.env_name
   env_subdomain = local.env_subdomain
+  env           = local.env
 
   aws_region      = var.aws_region
   aws_region_name = var.aws_region_name


### PR DESCRIPTION
### What
Reinstate separate staging and production repos for ECR images

### Why
In order to ensure that code is not released to production before it is fully tested in staging we need to have two separate image repos for the GovWifi: production and staging. This ensures that if the ECS tasks are restarted in staging before testing is complete, they will not launch with an untested image.

Prior to this commit the task definitions for staging and production pointed at the same image repo.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-642
