### PR TITLE
Move smoke test task

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -14,9 +14,9 @@ resource "aws_cloudwatch_event_rule" "daily_user_deletion_event" {
   is_enabled          = true
 }
 
-resource "aws_cloudwatch_event_rule" "smoke_test_user_deletion_event" {
+resource "aws_cloudwatch_event_rule" "daily_smoke_test_cleanup_event" {
   count               = var.event_rule_count
-  name                = "${var.env_name}-smoke-test-user-deletion"
+  name                = "${var.env_name}-smoke-test-cleanup"
   description         = "Triggers daily 23:30 UTC"
   schedule_expression = "cron(30 23 * * ? *)"
   is_enabled          = true

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -447,6 +447,45 @@ EOF
 
 }
 
+resource "aws_cloudwatch_event_target" "smoke_test_cleanup" {
+  count     = var.logging_enabled
+  target_id = "${var.env_name}-smoke-test-cleanup"
+  arn       = aws_ecs_cluster.api_cluster.arn
+  rule      = aws_cloudwatch_event_rule.daily_smoke_test_cleanup_event[0].name
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      subnets = var.subnet_ids
+
+      security_groups = concat(
+        var.backend_sg_list,
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
+      )
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "logging-api",
+      "command": ["bundle", "exec", "rake", "smoke_tests_cleanup"]
+    }
+  ]
+}
+EOF
+
+}
+
 resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
   count                    = var.logging_enabled
   family                   = "logging-api-scheduled-task-${var.env_name}"

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -97,7 +97,7 @@ DOC
 
 resource "aws_cloudwatch_event_target" "user_signup_daily_user_deletion" {
   count     = var.user_signup_enabled
-  target_id = "${var.env_name}-user-signup-daily-user-deletion"
+  target_id = "${var.env_name}-user-signup-daily-cleanup"
   arn       = aws_ecs_cluster.api_cluster.arn
   rule      = aws_cloudwatch_event_rule.daily_user_deletion_event[0].name
   role_arn  = aws_iam_role.user_signup_scheduled_task_role[0].arn
@@ -127,45 +127,6 @@ resource "aws_cloudwatch_event_target" "user_signup_daily_user_deletion" {
     {
       "name": "user-signup-api",
       "command": ["bundle", "exec", "rake", "delete_inactive_users"]
-    }
-  ]
-}
-EOF
-
-}
-
-resource "aws_cloudwatch_event_target" "smoke_test_user_deletion" {
-  count     = var.user_signup_enabled
-  target_id = "${var.env_name}-smoke-test-user-deletion"
-  arn       = aws_ecs_cluster.api_cluster.arn
-  rule      = aws_cloudwatch_event_rule.smoke_test_user_deletion_event[0].name
-  role_arn  = aws_iam_role.user_signup_scheduled_task_role[0].arn
-
-  ecs_target {
-    task_count          = 1
-    task_definition_arn = aws_ecs_task_definition.user_signup_api_scheduled_task[0].arn
-    launch_type         = "FARGATE"
-    platform_version    = "1.4.0"
-
-    network_configuration {
-      subnets = var.subnet_ids
-
-      security_groups = concat(
-        var.backend_sg_list,
-        [aws_security_group.api_in.id],
-        [aws_security_group.api_out.id]
-      )
-
-      assign_public_ip = true
-    }
-  }
-
-  input = <<EOF
-{
-  "containerOverrides": [
-    {
-      "name": "user-signup-api",
-      "command": ["bundle", "exec", "rake", "delete_smoke_test_users"]
     }
   ]
 }


### PR DESCRIPTION
### What
Move the smoke test cleanup scheduled task from the user signup api
to the logging api

### Why
The rake task has been moved from the user signup api to the
logging api so that related session data is also cleaned

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-617