### PR TITLE
Ignore task definition changes after initial creation

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -201,7 +201,7 @@ resource "aws_ecs_service" "admin_service" {
   # TODO: Terraform has problems tagging this service due to ARN
   # issues in production, so avoid this by ignoring tag changes
   lifecycle {
-    ignore_changes = [tags_all]
+    ignore_changes = [tags_all, task_definition]
   }
 }
 

--- a/govwifi-api/authentication-api-cluster.tf
+++ b/govwifi-api/authentication-api-cluster.tf
@@ -136,8 +136,9 @@ resource "aws_ecs_service" "authentication_api_service" {
   }
 
   lifecycle {
-    ignore_changes = [desired_count]
+    ignore_changes = [desired_count, task_definition]
   }
+
 }
 
 resource "aws_alb_listener_rule" "static" {

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -155,7 +155,7 @@ resource "aws_ecs_service" "logging_api_service" {
   }
 
   lifecycle {
-    ignore_changes = [desired_count]
+    ignore_changes = [desired_count, task_definition]
   }
 }
 

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -211,6 +211,10 @@ resource "aws_ecs_service" "user_signup_api_service" {
     container_name   = "user-signup-api"
     container_port   = "8080"
   }
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }
 
 resource "aws_alb_target_group" "user_signup_api_tg" {


### PR DESCRIPTION
### What
Ignore task definition changes after initial creation

### Why
As we are now using AWS's native ECS tools to deploy, and they change the task definition version after every deploy, we will need to add an ignore statement to the code so that terrafrom will not try to continually roll back the task definition to an earlier version every time we apply it.

