### PR TITLE
Add temporary fix to pipeline.

### DIFF
--- a/govwifi-deploy/buildspec_production_deployed_image.yml
+++ b/govwifi-deploy/buildspec_production_deployed_image.yml
@@ -26,5 +26,3 @@ phases:
       - docker push $REPOSITORY_URI:$IMAGE_TAG
       - echo Writing image definitions file...
       - printf '[{"name":"admin","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
-      - echo List ECS Clusters
-      - aws ecs list-clusters

--- a/govwifi-ecs-update-service/buildspec_restart_ecs_cluster.yml
+++ b/govwifi-ecs-update-service/buildspec_restart_ecs_cluster.yml
@@ -1,0 +1,15 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - aws --version
+  build:
+    commands:
+      - echo Build started on `date`
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Writing image definitions file...
+      - echo "Restart ECS Service Admin in PRODUCTION"
+      - aws ecs update-service --force-new-deployment --service $SERVICE_NAME --cluster $CLUSTER_NAME

--- a/govwifi-ecs-update-service/codebuild-restart-ecs-clusters.tf
+++ b/govwifi-ecs-update-service/codebuild-restart-ecs-clusters.tf
@@ -1,0 +1,47 @@
+resource "aws_codebuild_project" "govwifi_codebuild_project_restart_ecs_cluster" {
+  for_each      = toset(var.deployed_app_names)
+  name          = "govwifi-ecs-update-service-${each.key}"
+  description   = "Force restart the service to pick up the latest production image."
+  build_timeout = "60"
+  # service_role  = aws_iam_role.govwifi_codebuild_ecs_restart.arn
+  service_role = "arn:aws:iam::${var.aws_account_id}:role/govwifi-codebuild-role"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    environment_variable {
+      name  = "SERVICE_NAME"
+      value = each.key == "admin" ? "admin-wifi" : "${each.key}-service-${var.env_name}"
+    }
+
+    environment_variable {
+      name  = "CLUSTER_NAME"
+      value = each.key == "admin" ? "${var.env_name}-admin-cluster" : "${var.env_name}-api-cluster"
+    }
+
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "govwifi-codebuild-ecs-update-service"
+      stream_name = "govwifi-codebuild-push-image-to-ecr-log-stream"
+    }
+
+    s3_logs {
+      status = "DISABLED"
+    }
+  }
+
+  source {
+    type      = "NO_SOURCE"
+    buildspec = file("${path.module}/buildspec_restart_ecs_cluster.yml")
+  }
+}

--- a/govwifi-ecs-update-service/main.tf
+++ b/govwifi-ecs-update-service/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/govwifi-ecs-update-service/secrets-manager.tf
+++ b/govwifi-ecs-update-service/secrets-manager.tf
@@ -1,0 +1,15 @@
+data "aws_secretsmanager_secret_version" "tools_account" {
+  secret_id = data.aws_secretsmanager_secret.tools_account.id
+}
+
+data "aws_secretsmanager_secret" "tools_account" {
+  name = "tools/AccountID"
+}
+
+data "aws_secretsmanager_secret_version" "tools_kms_key" {
+  secret_id = data.aws_secretsmanager_secret.tools_kms_key.id
+}
+
+data "aws_secretsmanager_secret" "tools_kms_key" {
+  name = "tools/codepipeline-kms-key-arn"
+}

--- a/govwifi-ecs-update-service/variables.tf
+++ b/govwifi-ecs-update-service/variables.tf
@@ -1,0 +1,8 @@
+variable "deployed_app_names" {
+}
+
+variable "aws_account_id" {
+}
+
+variable "env_name" {
+}

--- a/govwifi-smoke-tests/iam.tf
+++ b/govwifi-smoke-tests/iam.tf
@@ -97,9 +97,8 @@ EOF
 
 }
 
-resource "aws_iam_policy_attachment" "govwifi_codebuild_role_policy" {
-  name       = "govwifi-codebuild-role-policy"
-  roles      = [aws_iam_role.govwifi_codebuild.name]
+resource "aws_iam_role_policy_attachment" "govwifi_codebuild_role_policy" {
+  role       = aws_iam_role.govwifi_codebuild.name
   policy_arn = aws_iam_policy.govwifi_codebuild_role_policy.arn
 }
 
@@ -206,20 +205,23 @@ EOF
 }
 
 
-resource "aws_iam_policy_attachment" "codebuild_vpc" {
-  name       = "govwifi-codebuild-vpc"
-  roles      = [aws_iam_role.govwifi_codebuild.name]
+resource "aws_iam_role_policy_attachment" "crossaccount_tools_ecs_access_ecs_restart" {
+  role       = aws_iam_role.govwifi_codebuild.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
+}
+
+
+resource "aws_iam_role_policy_attachment" "codebuild_vpc" {
+  role       = aws_iam_role.govwifi_codebuild.name
   policy_arn = aws_iam_policy.govwifi_codebuild_vpc_policy.arn
 }
 
-resource "aws_iam_policy_attachment" "codepipeline_ssm_readonly" {
-  name       = "codepipeline-ssm-readonly"
-  roles      = [aws_iam_role.govwifi_codebuild.name]
+resource "aws_iam_role_policy_attachment" "codepipeline_ssm_readonly" {
+  role       = aws_iam_role.govwifi_codebuild.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
 }
 
-resource "aws_iam_policy_attachment" "codebuild_start_build_perm" {
-  name       = "codebuild-startbuild-perm"
-  roles      = [aws_iam_role.govwifi_codebuild.name]
+resource "aws_iam_role_policy_attachment" "codebuild_start_build_perm" {
+  role       = aws_iam_role.govwifi_codebuild.name
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeBuildDeveloperAccess"
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -512,3 +512,17 @@ module "smoke_tests" {
   smoketest_subnet_public_b  = var.smoketest_subnet_public_b
 
 }
+
+module "govwifi-ecs-update-service" {
+  providers = {
+    aws = aws.main
+  }
+
+  source = "../../govwifi-ecs-update-service"
+
+  deployed_app_names = ["user-signup-api", "logging-api", "admin", "authentication-api"]
+
+  env_name = "wifi"
+
+  aws_account_id = local.aws_account_id
+}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -441,3 +441,17 @@ resource "aws_route" "backend_to_frontend_route" {
   destination_cidr_block    = one(data.aws_vpc.dublin_frontend.cidr_block_associations).cidr_block
   vpc_peering_connection_id = aws_vpc_peering_connection.dublin_frontend_to_london_backend.id
 }
+
+module "govwifi-ecs-update-service" {
+  providers = {
+    aws = aws.main
+  }
+
+  source = "../../govwifi-ecs-update-service"
+
+  deployed_app_names = ["authentication-api"]
+
+  env_name = "wifi"
+
+  aws_account_id = local.aws_account_id
+}


### PR DESCRIPTION
### What
Add temporary fix to pipeline

### Why
Add codebuild job to restart ECS tasks in production for: 
user-signup-api
admin
authentication-api
logging-api

This has been added because the ECS deploy mechanism does not work in production. There can only be one ECR source stage per pipeline. Codepipeline does not support having separate production and staging ECR repos.

Jira card: https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-642


