### PR TITLE
Promote staging docker image to production image

### DIFF
--- a/govwifi-deploy/buildspec_production_deployed_image.yml
+++ b/govwifi-deploy/buildspec_production_deployed_image.yml
@@ -6,23 +6,17 @@ phases:
       - echo Logging in to Amazon ECR...
       - aws --version
       - echo "AWS_REGION is $AWS_REGION "
-      - REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/$APP/$STAGE
+      - STAGING_REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/$APP/staging
+      - PRODUCTION_REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/$APP/production
       - echo "REPOSITORY_URI is $REPOSITORY_URI"
       - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
-      - IMAGE_TAG="latest"
       - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
   build:
     commands:
-      - git clone https://github.com/alphagov/govwifi-$APP.git
-      - cd govwifi-$APP
-      - echo Build started on `date`
-      - echo Building the Docker image...
-      - docker build --build-arg BUNDLE_INSTALL_CMD='bundle install --jobs 20 --retry 5' -t $REPOSITORY_URI:$IMAGE_TAG .
+      - docker pull $STAGING_REPOSITORY_URI:latest
+      - docker tag $STAGING_REPOSITORY_URI:latest $PRODUCTION_REPOSITORY_URI:latest
+      - docker push $PRODUCTION_REPOSITORY_URI:latest
   post_build:
     commands:
-      - echo Build completed on `date`
-      - echo Pushing the Docker images...
-      - docker push $REPOSITORY_URI:$IMAGE_TAG
-      - echo Writing image definitions file...
-      - printf '[{"name":"admin","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+      - echo Push completed on `date`

--- a/govwifi-deploy/codebuild-deployed-apps-production.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-production.tf
@@ -6,9 +6,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_pr
   service_role  = aws_iam_role.govwifi_codebuild.arn
 
   artifacts {
-    type                = "CODEPIPELINE"
-    packaging           = "ZIP"
-    encryption_disabled = true
+    type = "NO_ARTIFACTS"
   }
 
   cache {
@@ -34,11 +32,6 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_pr
     }
 
     environment_variable {
-      name  = "STAGE"
-      value = "production"
-    }
-
-    environment_variable {
       name  = "DOCKER_HUB_AUTHTOKEN_ENV"
       value = "/govwifi-cd/pipelines/main/docker_hub_authtoken"
       type  = "PARAMETER_STORE"
@@ -48,17 +41,6 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_pr
       name  = "DOCKER_HUB_USERNAME_ENV"
       value = "/govwifi-cd/pipelines/main/docker_hub_username"
       type  = "PARAMETER_STORE"
-    }
-
-    environment_variable {
-      name  = "WORDLIST_BUCKET_NAME"
-      value = "/govwifi-cd/pipelines/main/wordlist_bucket_name"
-      type  = "PARAMETER_STORE"
-    }
-
-    environment_variable {
-      name  = "ACCEPTANCE_TESTS_PROJECT_NAME"
-      value = "acceptance-tests"
     }
 
     environment_variable {
@@ -80,7 +62,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_pr
   }
 
   source {
-    type      = "CODEPIPELINE"
+    type      = "NO_SOURCE"
     buildspec = file("${path.module}/buildspec_production_deployed_image.yml")
   }
 }


### PR DESCRIPTION
### What

This change affects the following apps:

- user-signup-api
- logging-api
- authentication-api
- admin

Make a clone of existing staging docker image to use in production rather than create a new one. 

### Why
This is best practice and ensures we are using a previously tested image in production.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-673
