### PR TITLE
Change the names of codebuild projects to match a standard

### DIFF
--- a/govwifi-deploy/codebuild-acceptance-tests.tf
+++ b/govwifi-deploy/codebuild-acceptance-tests.tf
@@ -1,5 +1,5 @@
 resource "aws_codebuild_project" "govwifi_codebuild_acceptance_tests" {
-  name           = "govwifi-codebuild-acceptance-tests"
+  name           = "acceptance-tests"
   description    = "This project runs the frontend acceptance tests"
   build_timeout  = "12"
   service_role   = aws_iam_role.govwifi_codebuild.arn

--- a/govwifi-deploy/codebuild-built-apps-production.tf
+++ b/govwifi-deploy/codebuild-built-apps-production.tf
@@ -1,6 +1,6 @@
 resource "aws_codebuild_project" "govwifi_codebuild_built_app_production" {
   for_each       = toset(var.built_app_names)
-  name           = "Push-${each.key}-docker-image-to-production-ECR"
+  name           = "${each.key}-push-docker-image-to-production-ECR"
   description    = "This project builds the ${each.key} production image and pushes it to ECR."
   build_timeout  = "12"
   service_role   = aws_iam_role.govwifi_codebuild.arn

--- a/govwifi-deploy/codebuild-built-apps-staging.tf
+++ b/govwifi-deploy/codebuild-built-apps-staging.tf
@@ -1,6 +1,6 @@
 resource "aws_codebuild_project" "govwifi_codebuild_built_app" {
   for_each       = toset(var.built_app_names)
-  name           = "Push-${each.key}-docker-image-to-staging-ECR"
+  name           = "${each.key}-push-docker-image-to-staging-ECR"
   description    = "This project builds the ${each.key} image and pushes it to ECR"
   build_timeout  = "12"
   service_role   = aws_iam_role.govwifi_codebuild.arn
@@ -64,7 +64,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_built_app" {
 
 resource "aws_codebuild_webhook" "govwifi_built_app_webhook_staging" {
   for_each     = toset(var.built_app_names)
-  project_name = "Push-${each.key}-docker-image-to-staging-ECR"
+  project_name = "${each.key}-push-docker-image-to-staging-ECR"
 
   build_type = "BUILD"
 

--- a/govwifi-deploy/codebuild-convert-image.tf
+++ b/govwifi-deploy/codebuild-convert-image.tf
@@ -3,7 +3,6 @@
 
 resource "aws_codebuild_project" "govwifi_codebuild_project_convert_image_format" {
   for_each      = toset(var.deployed_app_names)
-  # name          = "govwifi-codebuild-convert-image-format-${each.key}"
   name          = "${each.key}-convert-image-format"
   description   = "This job converts the ECR image into a format usable by the ECS deploy stage"
   build_timeout = "5"

--- a/govwifi-deploy/codebuild-convert-image.tf
+++ b/govwifi-deploy/codebuild-convert-image.tf
@@ -3,7 +3,8 @@
 
 resource "aws_codebuild_project" "govwifi_codebuild_project_convert_image_format" {
   for_each      = toset(var.deployed_app_names)
-  name          = "govwifi-codebuild-convert-image-format-${each.key}"
+  # name          = "govwifi-codebuild-convert-image-format-${each.key}"
+  name          = "${each.key}-convert-image-format"
   description   = "This job converts the ECR image into a format usable by the ECS deploy stage"
   build_timeout = "5"
   service_role  = aws_iam_role.govwifi_codebuild_convert.arn

--- a/govwifi-deploy/codebuild-deployed-apps-production.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-production.tf
@@ -58,14 +58,13 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_pr
 
     environment_variable {
       name  = "ACCEPTANCE_TESTS_PROJECT_NAME"
-      value = "govwifi-codebuild-acceptance-tests"
+      value = "acceptance-tests"
     }
 
     environment_variable {
       name  = "APP"
       value = each.key
     }
-
   }
 
   logs_config {
@@ -84,5 +83,4 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_pr
     type      = "CODEPIPELINE"
     buildspec = file("${path.module}/buildspec_production_deployed_image.yml")
   }
-
 }

--- a/govwifi-deploy/codebuild-deployed-apps-staging.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-staging.tf
@@ -56,9 +56,8 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_st
 
     environment_variable {
       name  = "ACCEPTANCE_TESTS_PROJECT_NAME"
-      value = "govwifi-codebuild-acceptance-tests"
+      value = "acceptance-tests"
     }
-
   }
 
   logs_config {
@@ -82,11 +81,11 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_st
     git_clone_depth = 1
     buildspec       = "buildspec.yml"
   }
-
 }
 
 resource "aws_codebuild_webhook" "govwifi_app_webhook_staging" {
   for_each     = toset(var.deployed_app_names)
+
   project_name = aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_staging[each.key].name
 
   build_type = "BUILD"
@@ -102,7 +101,5 @@ resource "aws_codebuild_webhook" "govwifi_app_webhook_staging" {
     #   type    = "HEAD_REF"
     #   pattern = "^refs/heads/buildspec-global-ecr$"
     # }
-
-
   }
 }

--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -55,13 +55,12 @@ resource "aws_codepipeline" "admin_pipeline" {
 
       configuration = {
         ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["admin"].name
-      }
+     }
     }
   }
 
   stage {
     name = "Deploy-to-Staging"
-
 
     action {
       name            = "Deploy-to-eu-west-2"
@@ -81,7 +80,6 @@ resource "aws_codepipeline" "admin_pipeline" {
     }
 
   }
-
 
   stage {
     name = "Staging-Smoketests"
@@ -138,48 +136,4 @@ resource "aws_codepipeline" "admin_pipeline" {
       }
     }
   }
-
-  # stage {
-  #   name = "PRODUCTION-Deploy"
-	#
-  #   action {
-  #     name            = "Deploy-to-eu-west-2-production"
-  #     category        = "Deploy"
-  #     owner           = "AWS"
-  #     provider        = "ECS"
-  #     input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
-  #     version         = "1"
-  #     # This resource lives in the Staging & Production environments. It will always have to
-  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
-  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy"
-	#
-  #     configuration = {
-  #       ClusterName : "wifi-admin-cluster"
-  #       ServiceName : "admin-wifi"
-  #     }
-  #   }
-	#
-  # }
-
-  # stage {
-  #   name = "Production-Smoketests"
-  #
-  #   action {
-  #     name            = "Production-Smoketests"
-  #     category        = "Test"
-  #     owner           = "AWS"
-  #     provider        = "CodeBuild"
-  #     input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
-  #
-  #     # This resource lives in the Staging & Production environments. It will always have to
-  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
-  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
-  #     version  = "1"
-  #
-  #     configuration = {
-  #       ProjectName = "govwifi-smoke-tests"
-  #     }
-  #   }
-  # }
-
 }

--- a/govwifi-deploy/codepipeline-authentication-api.tf
+++ b/govwifi-deploy/codepipeline-authentication-api.tf
@@ -11,7 +11,6 @@ resource "aws_codepipeline" "authentication_api_pipeline" {
       id   = aws_kms_key.codepipeline_key.arn
       type = "KMS"
     }
-
   }
 
   artifact_store {
@@ -153,68 +152,4 @@ resource "aws_codepipeline" "authentication_api_pipeline" {
       }
     }
   }
-
-
-  # stage {
-  #   name = "PRODUCTION-Deploy"
-	#
-  #   action {
-  #     name            = "Deploy-to-eu-west-2-production"
-  #     category        = "Deploy"
-  #     owner           = "AWS"
-  #     provider        = "ECS"
-  #     input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
-  #     version         = "1"
-  #     region          = "eu-west-2"
-  #     # This resource lives in the Staging & Production environments. It will always have to
-  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
-  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy"
-	#
-  #     configuration = {
-  #       ClusterName : "wifi-api-cluster"
-  #       ServiceName : "authentication-api-service-wifi"
-  #     }
-  #   }
-	#
-  #   action {
-  #     name            = "Deploy-to-eu-west-1-production"
-  #     category        = "Deploy"
-  #     owner           = "AWS"
-  #     provider        = "ECS"
-  #     input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
-  #     version         = "1"
-  #     region          = "eu-west-1"
-  #     # This resource lives in the Staging & Production environments. It will always have to
-  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
-  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy"
-	#
-  #     configuration = {
-  #       ClusterName : "wifi-api-cluster"
-  #       ServiceName : "authentication-api-service-wifi"
-  #     }
-  #   }
-	#
-  # }
-
-  # stage {
-  #   name = "Production-Smoketests"
-  #
-  #   action {
-  #     name            = "Production-Smoketests"
-  #     category        = "Test"
-  #     owner           = "AWS"
-  #     provider        = "CodeBuild"
-  #     input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
-  #
-  #     # This resource lives in the Staging & Production environments. It will always have to
-  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
-  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
-  #     version  = "1"
-  #
-  #     configuration = {
-  #       ProjectName = "govwifi-smoke-tests"
-  #     }
-  #   }
-  # }
-
 }

--- a/govwifi-deploy/codepipeline-logging-api.tf
+++ b/govwifi-deploy/codepipeline-logging-api.tf
@@ -11,7 +11,6 @@ resource "aws_codepipeline" "logging_api_pipeline" {
       id   = aws_kms_key.codepipeline_key.arn
       type = "KMS"
     }
-
   }
 
   artifact_store {
@@ -80,7 +79,6 @@ resource "aws_codepipeline" "logging_api_pipeline" {
         ServiceName : "logging-api-service-staging"
       }
     }
-
   }
 
   stage {
@@ -119,7 +117,6 @@ resource "aws_codepipeline" "logging_api_pipeline" {
     }
   }
 
-
   stage {
     name = "Push-PRODUCTION-image-to-ECR"
 
@@ -137,50 +134,4 @@ resource "aws_codepipeline" "logging_api_pipeline" {
       }
     }
   }
-
-
-  # stage {
-  #   name = "PRODUCTION-Deploy"
-	#
-  #   action {
-  #     name            = "Deploy-to-eu-west-2-production"
-  #     category        = "Deploy"
-  #     owner           = "AWS"
-  #     provider        = "ECS"
-  #     input_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
-  #     version         = "1"
-  #     region          = "eu-west-2"
-  #     # This resource lives in the Staging & Production environments. It will always have to
-  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
-  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy"
-	#
-  #     configuration = {
-  #       ClusterName : "wifi-api-cluster"
-  #       ServiceName : "logging-api-service-wifi"
-  #     }
-  #   }
-  # }
-
-  # stage {
-  #   name = "Production-Smoketests"
-  #
-  #   action {
-  #     name            = "Production-Smoketests"
-  #     category        = "Test"
-  #     owner           = "AWS"
-  #     provider        = "CodeBuild"
-  #     input_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
-  #
-  #     # This resource lives in the Staging & Production environments. It will always have to
-  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
-  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
-  #     version  = "1"
-  #
-  #     configuration = {
-  #       ProjectName = "govwifi-smoke-tests"
-  #     }
-  #   }
-  # }
-
-
 }

--- a/govwifi-deploy/codepipeline-user-signup-api.tf
+++ b/govwifi-deploy/codepipeline-user-signup-api.tf
@@ -1,5 +1,5 @@
 resource "aws_codepipeline" "user_signup_api_pipeline" {
-  name     = "user-signup-api-global-pipeline"
+  name     = "user-signup-api-pipeline"
   role_arn = aws_iam_role.govwifi_codepipeline_global_role.arn
 
   artifact_store {
@@ -11,7 +11,6 @@ resource "aws_codepipeline" "user_signup_api_pipeline" {
       id   = aws_kms_key.codepipeline_key.arn
       type = "KMS"
     }
-
   }
 
   artifact_store {
@@ -80,7 +79,6 @@ resource "aws_codepipeline" "user_signup_api_pipeline" {
         ServiceName : "user-signup-api-service-staging"
       }
     }
-
   }
 
   stage {
@@ -119,7 +117,6 @@ resource "aws_codepipeline" "user_signup_api_pipeline" {
     }
   }
 
-
   stage {
     name = "Push-PRODUCTION-image-to-ECR"
 
@@ -134,53 +131,8 @@ resource "aws_codepipeline" "user_signup_api_pipeline" {
 
       configuration = {
         ProjectName = "${aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_production["user-signup-api"].name}"
+
       }
     }
   }
-
-
-  # stage {
-  #   name = "PRODUCTION-Deploy"
-	#
-  #   action {
-  #     name            = "Deploy-to-eu-west-2-production"
-  #     category        = "Deploy"
-  #     owner           = "AWS"
-  #     provider        = "ECS"
-  #     input_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
-  #     version         = "1"
-  #     region          = "eu-west-2"
-  #     # This resource lives in the Staging & Production environments. It will always have to
-  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
-  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy"
-	#
-  #     configuration = {
-  #       ClusterName : "wifi-api-cluster"
-  #       ServiceName : "user-signup-api-service-wifi"
-  #     }
-  #   }
-  # }
-
-  # stage {
-  #   name = "Production-Smoketests"
-  #
-  #   action {
-  #     name            = "Production-Smoketests"
-  #     category        = "Test"
-  #     owner           = "AWS"
-  #     provider        = "CodeBuild"
-  #     input_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
-  #
-  #     # This resource lives in the Staging & Production environments. It will always have to
-  #     # either be hardcoded or retrieved from the AWS secrets or parameter store
-  #     role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
-  #     version  = "1"
-  #
-  #     configuration = {
-  #       ProjectName = "govwifi-smoke-tests"
-  #     }
-  #   }
-  # }
-
-
 }


### PR DESCRIPTION
### What
Change the name of codebuild projects to match a standard.
Remove extraneous white space in some files.
Remove comments used during development.

### Why
It was slow to find a project in a list and not sustainable when we add say our new Development environment and another set of projects.
A naming standard permits sorting by name to group a project tasks together.


### Link to Trello card: https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-675
