### PR TITLE
Add lambda for slack alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ govwifi/govwifi-staging-bastion-key
 govwifi/govwifi-bastion-key
 govwifi/govwifi-staging-key
 govwifi/govwifi-key.pem
+govwifi-smoke-tests/*.zip
 .terraform
 terraform.tfstate
 terraform.tfstate.*.backup

--- a/govwifi-deploy/codebuild-deployed-apps-staging.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-staging.tf
@@ -84,7 +84,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_st
 }
 
 resource "aws_codebuild_webhook" "govwifi_app_webhook_staging" {
-  for_each     = toset(var.deployed_app_names)
+  for_each = toset(var.deployed_app_names)
 
   project_name = aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_staging[each.key].name
 

--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -55,7 +55,7 @@ resource "aws_codepipeline" "admin_pipeline" {
 
       configuration = {
         ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["admin"].name
-     }
+      }
     }
   }
 

--- a/govwifi-slack-alerts/main.tf
+++ b/govwifi-slack-alerts/main.tf
@@ -41,7 +41,7 @@ resource "aws_cloudformation_stack" "aws_slack_chatbot" {
           "LoggingLevel" : "NONE",
           "SlackChannelId" : "${local.slack_channel_id}",
           "SlackWorkspaceId" : "${local.slack_workplace_id}",
-          "SnsTopicArns" : [ "${var.critical_notifications_topic_arn}","${var.capacity_notifications_topic_arn}","${var.route53_critical_notifications_topic_arn}","${var.smoke_tests_notifications_topic_arn}" ]
+          "SnsTopicArns" : [ "${var.critical_notifications_topic_arn}","${var.capacity_notifications_topic_arn}","${var.route53_critical_notifications_topic_arn}" ]
         }
       }
     }

--- a/govwifi-slack-alerts/variables.tf
+++ b/govwifi-slack-alerts/variables.tf
@@ -3,5 +3,3 @@ variable "critical_notifications_topic_arn" {}
 variable "capacity_notifications_topic_arn" {}
 
 variable "route53_critical_notifications_topic_arn" {}
-
-variable "smoke_tests_notifications_topic_arn" {}

--- a/govwifi-smoke-tests/README.md
+++ b/govwifi-smoke-tests/README.md
@@ -1,0 +1,1 @@
+In depth documentation for this module can be found [here](https://docs.google.com/document/d/1RHNkGxJLr4BPPUlFgqDzCF6mSOXK0Kj2Yfb-GHXXNIA/)

--- a/govwifi-smoke-tests/index.js
+++ b/govwifi-smoke-tests/index.js
@@ -1,0 +1,83 @@
+console.log('Loading function');
+
+const https = require('https');
+
+const postRequest = (payload) => {
+
+    const data = JSON.stringify(payload);
+    console.log(data);
+
+    const options = {
+        hostname: 'hooks.slack.com',
+        path: process.env.URL,
+        port: 443,
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'Content-Length': data.length
+        }
+    };
+
+    return new Promise((resolve, reject) => {
+        const req = https.request(options, res => {
+            let rawData = '';
+
+            res.on('data', chunk => {
+                rawData += chunk;
+            });
+
+            res.on('end', () => {
+                resolve({
+                    statusCode: 200,
+                    body: `${rawData}`
+                });
+            });
+        });
+
+        req.on('error', err => {
+            reject(new Error(err));
+        });
+
+        req.write(data);
+        req.end();
+    });
+};
+
+
+const formatPayload = (snsRecord) => {
+    return {
+        blocks: [
+            // As things stand, we don't need a header block but attempting this caused a series
+            // of 'invalid_blocks' errors from the Slack API. If we do want one, we'll need further
+            // investigation using the reference (https://api.slack.com/reference/block-kit/blocks#header)
+            // and the block builder (https://app.slack.com/block-kit-builder/)
+            {
+                type: "section",
+                fields: [
+                    {
+                        type: "mrkdwn",
+                        text: `*${(new Date(snsRecord.Timestamp)).toUTCString()}*`
+                    },
+                    {
+                        type: "plain_text",
+                        // Next field can only be 150 chars
+                        text: `${snsRecord.Message.replaceAll('"', '')}`
+                    }
+                ]
+             }
+        ]
+    }
+}
+
+
+exports.handler = async (event) => {
+
+    let payload = formatPayload(event.Records[0].Sns);
+    const result = await postRequest(payload);
+    const response = {
+        statusCode: 200,
+        body: result,
+    };
+    console.log(response);
+    return response;
+};

--- a/govwifi-smoke-tests/lambda.tf
+++ b/govwifi-smoke-tests/lambda.tf
@@ -1,0 +1,61 @@
+resource "aws_lambda_function" "slack_alert" {
+  count         = var.create_slack_alert
+  filename      = "../../govwifi-smoke-tests/lambda_function.zip"
+  function_name = "slack_alert_terraformed"
+  role          = aws_iam_role.iam_for_lambda[0].arn
+  handler       = "index.handler"
+  description   = "Alerts slack govwifi-monitoring channel on smoke test failure via SNS"
+
+  runtime       = "nodejs16.x"
+  architectures = ["x86_64"]
+
+  environment {
+    variables = {
+      URL = data.aws_secretsmanager_secret_version.slack_alert_url.secret_string
+    }
+  }
+
+  depends_on = [
+    data.archive_file.lambda_my_function
+  ]
+
+}
+
+resource "aws_iam_role" "slack_alert" {
+  count = var.create_slack_alert
+  name  = "slack_alert"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "lambda.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+
+
+
+data "archive_file" "lambda_my_function" {
+  type             = "zip"
+  source_file      = "../../govwifi-smoke-tests/index.js"
+  output_file_mode = "0666"
+  output_path      = "../../govwifi-smoke-tests/lambda_function.zip"
+}
+
+resource "aws_lambda_permission" "slack_alert_with_sns" {
+  count         = var.create_slack_alert
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.slack_alert[0].function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.smoke_tests[0].arn
+}

--- a/govwifi-smoke-tests/outputs.tf
+++ b/govwifi-smoke-tests/outputs.tf
@@ -1,3 +1,0 @@
-output "topic_arn" {
-  value = aws_sns_topic.smoke_tests.arn
-}

--- a/govwifi-smoke-tests/secrets-manager.tf
+++ b/govwifi-smoke-tests/secrets-manager.tf
@@ -22,6 +22,15 @@ data "aws_secretsmanager_secret" "gw_user" {
   name = "deploy/gw_user"
 }
 
+data "aws_secretsmanager_secret_version" "slack_alert_url" {
+  secret_id = data.aws_secretsmanager_secret.slack_alert_url.id
+}
+
+data "aws_secretsmanager_secret" "slack_alert_url" {
+  name = "smoketests/slack-alert-url"
+}
+
+
 
 data "aws_secretsmanager_secret_version" "gw_pass" {
   secret_id = data.aws_secretsmanager_secret.gw_pass.id

--- a/govwifi-smoke-tests/variables.tf
+++ b/govwifi-smoke-tests/variables.tf
@@ -1,6 +1,9 @@
 variable "aws_account_id" {
 }
 
+variable "aws_region" {
+}
+
 variable "env" {
 }
 
@@ -20,4 +23,7 @@ variable "smoketest_subnet_public_a" {
 }
 
 variable "smoketest_subnet_public_b" {
+}
+
+variable "create_slack_alert" {
 }

--- a/govwifi/staging/.terraform.lock.hcl
+++ b/govwifi/staging/.terraform.lock.hcl
@@ -1,6 +1,24 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:62mVchC1L6vOo5QS9uUf52uu0emsMM+LsPQJ1BEaTms=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version = "4.22.0"
   hashes = [

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -401,5 +401,7 @@ module "london_smoke_tests" {
   smoketest_subnet_private_b = var.smoketest_subnet_private_b
   smoketest_subnet_public_a  = var.smoketest_subnet_public_a
   smoketest_subnet_public_b  = var.smoketest_subnet_public_b
+  aws_region                 = local.london_aws_region
+  create_slack_alert         = 0
 
 }

--- a/govwifi/wifi-london/.terraform.lock.hcl
+++ b/govwifi/wifi-london/.terraform.lock.hcl
@@ -1,6 +1,24 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:62mVchC1L6vOo5QS9uUf52uu0emsMM+LsPQJ1BEaTms=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version = "4.22.0"
   hashes = [

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -476,7 +476,6 @@ module "govwifi_slack_alerts" {
   critical_notifications_topic_arn         = module.critical_notifications.topic_arn
   capacity_notifications_topic_arn         = module.capacity_notifications.topic_arn
   route53_critical_notifications_topic_arn = module.route53_critical_notifications.topic_arn
-  smoke_tests_notifications_topic_arn      = module.smoke_tests.topic_arn
 }
 
 module "govwifi_elasticsearch" {
@@ -500,16 +499,18 @@ module "smoke_tests" {
     aws = aws.main
   }
 
-  source = "../../govwifi-smoke-tests"
+	source = "../../govwifi-smoke-tests"
 
-  aws_account_id             = local.aws_account_id
-  env_subdomain              = local.env_subdomain
-  env                        = local.env
-  smoketests_vpc_cidr        = var.smoketests_vpc_cidr
-  smoketest_subnet_private_a = var.smoketest_subnet_private_a
-  smoketest_subnet_private_b = var.smoketest_subnet_private_b
-  smoketest_subnet_public_a  = var.smoketest_subnet_public_a
-  smoketest_subnet_public_b  = var.smoketest_subnet_public_b
+	aws_account_id             = local.aws_account_id
+	env_subdomain              = local.env_subdomain
+	env                        = local.env_name
+	smoketests_vpc_cidr        = var.smoketests_vpc_cidr
+	smoketest_subnet_private_a = var.smoketest_subnet_private_a
+	smoketest_subnet_private_b = var.smoketest_subnet_private_b
+	smoketest_subnet_public_a  = var.smoketest_subnet_public_a
+	smoketest_subnet_public_b  = var.smoketest_subnet_public_b
+	aws_region                 = var.aws_region
+	create_slack_alert         = 1
 
 }
 


### PR DESCRIPTION
### What
Add a lambda that generates slack alerts when the production smoke tests fail.

### Why
We are replacing our Concourse smoke tests with AWS Codebuild ones. We need to hook this up to our slack alerting system. This addition is fully documented here:
https://docs.google.com/document/d/1RHNkGxJLr4BPPUlFgqDzCF6mSOXK0Kj2Yfb-GHXXNIA/edit

Jira card: https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?label=GovWifi-SRE&selectedIssue=GW-614
