### PR TITLE
Automatically Deploy Apps To Production As Part Of Pipeline

### DIFF
--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -136,4 +136,27 @@ resource "aws_codepipeline" "admin_pipeline" {
       }
     }
   }
+
+  stage {
+    name = "Production-Restart-Service"
+
+    action {
+      name            = "Production-Deploy-test-eu-west-2"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-ecs-update-service-admin"
+      }
+    }
+
+  }
 }

--- a/govwifi-deploy/codepipeline-authentication-api.tf
+++ b/govwifi-deploy/codepipeline-authentication-api.tf
@@ -152,4 +152,47 @@ resource "aws_codepipeline" "authentication_api_pipeline" {
       }
     }
   }
+
+  stage {
+    name = "Production-Restart-Service"
+
+    action {
+      name            = "eu-west-2-deploy"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-ecs-update-service-authentication-api"
+      }
+    }
+
+
+    action {
+      name            = "eu-west-1-deploy"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-1"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-ecs-update-service-authentication-api"
+      }
+    }
+
+  }
+
 }

--- a/govwifi-deploy/codepipeline-logging-api.tf
+++ b/govwifi-deploy/codepipeline-logging-api.tf
@@ -134,4 +134,27 @@ resource "aws_codepipeline" "logging_api_pipeline" {
       }
     }
   }
+
+  stage {
+    name = "Production-Restart-Service"
+
+    action {
+      name            = "eu-west-2-deploy"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-ecs-update-service-logging-api"
+      }
+    }
+  }
+
 }

--- a/govwifi-deploy/codepipeline-test-deployment.tf
+++ b/govwifi-deploy/codepipeline-test-deployment.tf
@@ -1,0 +1,106 @@
+resource "aws_codepipeline" "authentication-api_pipeline_test" {
+  name     = "DO-NOT-USE-auth-pipeline-test"
+  role_arn = aws_iam_role.govwifi_codepipeline_global_role.arn
+
+  artifact_store {
+    region   = "eu-west-2"
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key.arn
+      type = "KMS"
+    }
+  }
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket_ireland.bucket
+    type     = "S3"
+    region   = "eu-west-1"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key_ireland.arn
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "NewECRImagDetectedFor-authentication-api"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        RepositoryName = "govwifi/authentication-api/staging"
+      }
+    }
+  }
+
+
+  stage {
+    name = "authentication-api-convert-imagedetail"
+
+    action {
+      name             = "authentication-api-convert-imagedetail"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["SourceArtifact"]
+      output_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["authentication-api"].name
+      }
+    }
+  }
+
+  stage {
+    name = "Production-Restart-Service"
+
+    action {
+      name            = "Production-Deploy-test-eu-west-2"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-ecs-update-service-authentication-api"
+      }
+    }
+
+
+    action {
+      name            = "Production-Deploy-test-eu-west-1"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-1"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-ecs-update-service-authentication-api"
+      }
+    }
+
+
+  }
+
+}

--- a/govwifi-deploy/codepipeline-user-signup-api.tf
+++ b/govwifi-deploy/codepipeline-user-signup-api.tf
@@ -135,4 +135,27 @@ resource "aws_codepipeline" "user_signup_api_pipeline" {
       }
     }
   }
+
+  stage {
+    name = "Production-Restart-Service"
+
+    action {
+      name            = "eu-west-2-deploy"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-ecs-update-service-user-signup-api"
+      }
+    }
+
+  }
 }

--- a/govwifi-deploy/s3.tf
+++ b/govwifi-deploy/s3.tf
@@ -42,6 +42,7 @@ resource "aws_s3_bucket_policy" "codepipeline_bucket_policy" {
 										"arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-crossaccount-tools-deploy",
 										"arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-codebuild-role",
 										"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy",
+										"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role",
 										"${aws_iam_role.govwifi_codepipeline_global_role.arn}",
 										"${aws_iam_role.govwifi_codebuild_convert.arn}"
 									]
@@ -100,6 +101,7 @@ resource "aws_s3_bucket_policy" "codepipeline_bucket_policy_ireland" {
 										"arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-crossaccount-tools-deploy",
 										"arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-codebuild-role",
 										"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy",
+										"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role",
 										"${aws_iam_role.govwifi_codepipeline_global_role.arn}",
 										"${aws_iam_role.govwifi_codebuild_convert.arn}"
 									]

--- a/govwifi-ecs-update-service/buildspec_restart_ecs_cluster.yml
+++ b/govwifi-ecs-update-service/buildspec_restart_ecs_cluster.yml
@@ -6,10 +6,26 @@ phases:
       - aws --version
   build:
     commands:
-      - echo Build started on `date`
-  post_build:
-    commands:
-      - echo Build completed on `date`
-      - echo Writing image definitions file...
-      - echo "Restart ECS Service Admin in PRODUCTION"
+      - echo "Build started on `date`"
+      - echo "Restart ECS Service $SERVICE_NAME in $ENV_NAME"
       - aws ecs update-service --force-new-deployment --service $SERVICE_NAME --cluster $CLUSTER_NAME
+
+
+      - echo "Waiting for tasks to reach a steady state"
+      - sleep 1m
+      - CURRENT_SERVICE_STATUS=$(aws ecs describe-services --service $SERVICE_NAME --cluster $CLUSTER_NAME | jq -r '.services[].events[0].message')
+      - echo "CURRENT_SERVICE_STATUS is $CURRENT_SERVICE_STATUS"
+      - DESIRED_SERVICE_STATUS="(service $SERVICE_NAME) has reached a steady state."
+      - echo "DESIRED_SERVICE_STATUS is $DESIRED_SERVICE_STATUS"
+      - |
+        while [ "$CURRENT_SERVICE_STATUS" != "$DESIRED_SERVICE_STATUS" ] ; do
+            sleep 15s
+            echo "Waiting for service to reach a steady state"
+            CURRENT_SERVICE_STATUS=$(aws ecs describe-services --service $SERVICE_NAME --cluster $CLUSTER_NAME | jq -r '.services[].events[0].message')
+            echo "CURRENT_SERVICE_STATUS is: $CURRENT_SERVICE_STATUS"
+            if [ "$CURRENT_SERVICE_STATUS" = "$DESIRED_SERVICE_STATUS" ]
+            then
+              exit 0;
+              break
+            fi
+          done

--- a/govwifi-ecs-update-service/codebuild-restart-ecs-clusters.tf
+++ b/govwifi-ecs-update-service/codebuild-restart-ecs-clusters.tf
@@ -2,9 +2,8 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_restart_ecs_cluster"
   for_each      = toset(var.deployed_app_names)
   name          = "govwifi-ecs-update-service-${each.key}"
   description   = "Force restart the service to pick up the latest production image."
-  build_timeout = "60"
-  # service_role  = aws_iam_role.govwifi_codebuild_ecs_restart.arn
-  service_role = "arn:aws:iam::${var.aws_account_id}:role/govwifi-codebuild-role"
+  build_timeout = "10"
+  service_role  = "arn:aws:iam::${var.aws_account_id}:role/govwifi-codebuild-role"
 
   artifacts {
     type = "NO_ARTIFACTS"
@@ -19,12 +18,17 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_restart_ecs_cluster"
 
     environment_variable {
       name  = "SERVICE_NAME"
-      value = each.key == "admin" ? "admin-wifi" : "${each.key}-service-${var.env_name}"
+      value = each.key == "admin" ? "admin-${var.env_name}" : "${each.key}-service-${var.env_name}"
     }
 
     environment_variable {
       name  = "CLUSTER_NAME"
       value = each.key == "admin" ? "${var.env_name}-admin-cluster" : "${var.env_name}-api-cluster"
+    }
+
+    environment_variable {
+      name  = "ENV_NAME"
+      value = var.env_name
     }
 
   }

--- a/govwifi-smoke-tests/iam.tf
+++ b/govwifi-smoke-tests/iam.tf
@@ -102,6 +102,11 @@ resource "aws_iam_role_policy_attachment" "govwifi_codebuild_role_policy" {
   policy_arn = aws_iam_policy.govwifi_codebuild_role_policy.arn
 }
 
+resource "aws_iam_role_policy_attachment" "govwifi_codebuild_role_deploy_policy" {
+  role       = aws_iam_role.govwifi_codebuild.name
+  policy_arn = "arn:aws:iam::${var.aws_account_id}:policy/govwifi-crossaccount-tools-deploy"
+}
+
 resource "aws_iam_policy" "crossaccount_tools" {
   name        = "govwifi-crossaccount-tools-run-smoke-tests"
   path        = "/"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -499,18 +499,18 @@ module "smoke_tests" {
     aws = aws.main
   }
 
-	source = "../../govwifi-smoke-tests"
+  source = "../../govwifi-smoke-tests"
 
-	aws_account_id             = local.aws_account_id
-	env_subdomain              = local.env_subdomain
-	env                        = local.env_name
-	smoketests_vpc_cidr        = var.smoketests_vpc_cidr
-	smoketest_subnet_private_a = var.smoketest_subnet_private_a
-	smoketest_subnet_private_b = var.smoketest_subnet_private_b
-	smoketest_subnet_public_a  = var.smoketest_subnet_public_a
-	smoketest_subnet_public_b  = var.smoketest_subnet_public_b
-	aws_region                 = var.aws_region
-	create_slack_alert         = 1
+  aws_account_id             = local.aws_account_id
+  env_subdomain              = local.env_subdomain
+  env                        = local.env_name
+  smoketests_vpc_cidr        = var.smoketests_vpc_cidr
+  smoketest_subnet_private_a = var.smoketest_subnet_private_a
+  smoketest_subnet_private_b = var.smoketest_subnet_private_b
+  smoketest_subnet_public_a  = var.smoketest_subnet_public_a
+  smoketest_subnet_public_b  = var.smoketest_subnet_public_b
+  aws_region                 = var.aws_region
+  create_slack_alert         = 1
 
 }
 


### PR DESCRIPTION
### What
This commit automates the manual fix put in place in this PR: https://github.com/alphagov/govwifi-terraform/pull/761, which forms part of a larger bugfix. Please see the Jira card link below for more information.  Also edit buildspec script so that it verifies that the restarted ECS clusters have actually reached a steady state before marking the run as successfully completed.

### Why
This brings us closer to a fully automated one press deploy process.

Jira: https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?label=GovWifi-SRE&selectedIssue=GW-674

