### PR TITLE
Fix typo in pipeline action name

### DIFF
--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -141,7 +141,7 @@ resource "aws_codepipeline" "admin_pipeline" {
     name = "Production-Restart-Service"
 
     action {
-      name            = "Production-Deploy-test-eu-west-2"
+      name            = "eu-west-2-deploy"
       category        = "Build"
       owner           = "AWS"
       provider        = "CodeBuild"


### PR DESCRIPTION
### What
Fix typo in pipeline action name

### Why
This was a copy paste error. Correcting.
