### PR TITLE
Add elasticsearch endpoint variable to the admin portal

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -110,6 +110,9 @@ resource "aws_ecs_task_definition" "admin_task" {
         },{
           "name": "GOOGLE_MAPS_PUBLIC_API_KEY",
           "value": "${var.public_google_api_key}"
+        },{
+          "name": "ELASTICSEARCH_ENDPOINT",
+          "value": "https://${var.elasticsearch_endpoint}"
         }
       ],
       "secrets": [

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -124,3 +124,6 @@ variable "public_google_api_key" {
 
 variable "bastion_server_ip" {
 }
+
+variable "elasticsearch_endpoint" {
+}

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -203,6 +203,8 @@ module "london_admin" {
   bastion_server_ip = module.london_backend.bastion_public_ip
 
   notification_arn = module.london_notifications.topic_arn
+
+  elasticsearch_endpoint = module.london_elasticsearch.endpoint
 }
 
 module "london_api" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -271,6 +271,8 @@ module "govwifi_admin" {
   zendesk_api_user     = var.zendesk_api_user
 
   bastion_server_ip = var.bastion_server_ip
+
+  elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
 }
 
 module "api" {


### PR DESCRIPTION
### What
The admin portal is going to send statistics to our Elasticsearch instance to visualise organisation metrics in Grafana. This change adds the value of the Elasticsearch endpoint as an environment variable to the Admin portal

### Why
We want the admin portal to be able to access Elasticsearch

Link to Jira card (if applicable): 
GW-604