### PR TITLE
Enable Scheduled AWS Smoke Tests In Production

### DIFF
--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -110,8 +110,9 @@ resource "aws_cloudwatch_event_target" "trigger_smoke_tests" {
   role_arn = aws_iam_role.govwifi_codebuild.arn
 }
 
+# Enable scheduled smoke tests in production environment only
 resource "aws_cloudwatch_event_rule" "smoke_tests_schedule_rule" {
-  is_enabled          = false
+  is_enabled          = var.env == "wifi" ? true : false
   name                = "smoke-tests-scheduled-build"
   schedule_expression = "cron(0/15 * * * ? *)"
 }


### PR DESCRIPTION
### What
Enable Scheduled AWS Smoke Tests In Production

### Why
This is part of the Concourse to AWS migration work. The new smoke tests have now been built and tested in production, and have Slack alerting in place, so scheduled smoke tests can now be enabled. The smoke tests in Concourse have been paused so they do not conflict.
