### PR TITLE
Fix the task to retieve the median time for an org to create an ip

### DIFF
--- a/govwifi-admin/scheduled-tasks.tf
+++ b/govwifi-admin/scheduled-tasks.tf
@@ -138,7 +138,7 @@ resource "aws_cloudwatch_event_rule" "daily_median_metrics" {
    "containerOverrides": [
      {
        "name": "admin",
-       "command": ["bundle", "exec", "rake", "cleanup:metrics"]
+       "command": ["bundle", "exec", "rake", "elasticsearch:publish_metrics"]
      }
    ]
  }


### PR DESCRIPTION
The scheduled task did not call the correct rake task and now does