### PR TITLE
Add development environment called alpaca

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ govwifi-tools: #The name "tools" would be the obvious choice here, but this is a
 staging:
 	$(eval export DEPLOY_ENV=staging)
 	$(eval export REPO=staging)
+alpaca:
+	$(eval export DEPLOY_ENV=alpaca)
+	$(eval export REPO=alpaca)
 wifi-london:
 	$(eval export DEPLOY_ENV=wifi-london)
 	$(eval export REPO=latest)

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -37,13 +37,13 @@ resource "aws_ecs_task_definition" "admin_task" {
       "environment": [
         {
           "name": "DB_NAME",
-          "value": "govwifi_admin_${var.rails_env}"
+          "value": "govwifi_admin_${var.app_env}"
         },{
           "name": "DB_HOST",
           "value": "${aws_db_instance.admin_db.address}"
         },{
           "name": "RAILS_ENV",
-          "value": "${var.rails_env}"
+          "value": "${var.app_env}"
         },{
           "name": "SENTRY_CURRENT_ENV",
           "value": "${var.sentry_current_env}"

--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -54,7 +54,7 @@ resource "aws_db_instance" "admin_db" {
   apply_immediately           = true
   instance_class              = var.db_instance_type
   identifier                  = "wifi-admin-${var.env_name}-db"
-  db_name                     = "govwifi_admin_${var.rails_env}"
+  db_name                     = "govwifi_admin_${var.app_env}"
   username                    = local.admin_db_username
   password                    = local.admin_db_password
   backup_retention_period     = var.db_backup_retention_days

--- a/govwifi-admin/scheduled-tasks.tf
+++ b/govwifi-admin/scheduled-tasks.tf
@@ -109,31 +109,31 @@ resource "aws_cloudwatch_event_rule" "daily_median_metrics" {
   is_enabled          = true
 }
 
- resource "aws_cloudwatch_event_target" "daily_median_metrics" {
-   target_id = "${var.env_name}-daily-median-metrics"
-   arn       = aws_ecs_cluster.admin_cluster.arn
-   rule      = aws_cloudwatch_event_rule.daily_median_metrics.name
-   role_arn  = aws_iam_role.scheduled_task.arn
+resource "aws_cloudwatch_event_target" "daily_median_metrics" {
+  target_id = "${var.env_name}-daily-median-metrics"
+  arn       = aws_ecs_cluster.admin_cluster.arn
+  rule      = aws_cloudwatch_event_rule.daily_median_metrics.name
+  role_arn  = aws_iam_role.scheduled_task.arn
 
-   ecs_target {
-     task_count          = 1
-     task_definition_arn = aws_ecs_task_definition.admin_task.arn
-     launch_type         = "FARGATE"
-     platform_version    = "1.4.0"
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.admin_task.arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
 
-     network_configuration {
-       subnets = var.subnet_ids
+    network_configuration {
+      subnets = var.subnet_ids
 
-       security_groups = concat(
-         [aws_security_group.admin_ec2_in.id],
-         [aws_security_group.admin_ec2_out.id]
-       )
+      security_groups = concat(
+        [aws_security_group.admin_ec2_in.id],
+        [aws_security_group.admin_ec2_out.id]
+      )
 
-       assign_public_ip = true
-     }
-   }
+      assign_public_ip = true
+    }
+  }
 
-   input = <<EOF
+  input = <<EOF
  {
    "containerOverrides": [
      {

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -107,6 +107,9 @@ variable "rr_db_host" {
 variable "rr_db_name" {
 }
 
+variable "app_env" {
+}
+
 variable "user_db_host" {
 }
 

--- a/govwifi-api/certs.tf
+++ b/govwifi-api/certs.tf
@@ -9,7 +9,10 @@ resource "aws_acm_certificate" "api_elb_global" {
 }
 
 resource "aws_acm_certificate_validation" "api_elb_global" {
-  count                   = var.backend_elb_count
+  # Production and staging work slightly differently in regards to certificate validation 
+  # there is work in the pipeline to sync these up. For now we are adding a conditional.
+  count = (var.rack_env == "production") || (var.aws_region_name == "Dublin" && var.rack_env != "production") ? var.backend_elb_count : 0
+
   certificate_arn         = aws_acm_certificate.api_elb_global[0].arn
   validation_record_fqdns = [aws_route53_record.elb_global_cert_validation[0].fqdn]
 }

--- a/govwifi-api/route53.tf
+++ b/govwifi-api/route53.tf
@@ -30,7 +30,10 @@ resource "aws_route53_record" "elb_global" {
 }
 
 resource "aws_route53_record" "elb_global_cert_validation" {
-  count   = var.backend_elb_count
+  # Production and staging work slightly differently in regards to certificate validation 
+  # there is work in the pipeline to sync these up. For now we are adding a conditional.
+  count = (var.rack_env == "production") || (var.aws_region_name == "Dublin" && var.rack_env != "production") ? var.backend_elb_count : 0
+
   name    = one(aws_acm_certificate.api_elb_global[0].domain_validation_options).resource_record_name
   type    = one(aws_acm_certificate.api_elb_global[0].domain_validation_options).resource_record_type
   zone_id = var.route53_zone_id

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -122,7 +122,7 @@ resource "aws_ecs_task_definition" "user_signup_api_task" {
           "value": "${var.user_db_hostname}"
         },{
           "name": "RACK_ENV",
-          "value": "${var.rack_env}"
+          "value": "${var.app_env}"
         },{
           "name": "SENTRY_CURRENT_ENV",
           "value": "${var.sentry_current_env}"

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -188,3 +188,6 @@ variable "alb_permitted_cidr_blocks" {
   type    = list(string)
   default = []
 }
+
+variable "app_env" {
+}

--- a/govwifi-deploy/alpaca-codebuild-built-apps.tf
+++ b/govwifi-deploy/alpaca-codebuild-built-apps.tf
@@ -1,0 +1,63 @@
+resource "aws_codebuild_project" "alpaca_govwifi_codebuild_built_app" {
+  for_each       = toset(var.built_app_names)
+  name           = "${each.key}-push-docker-image-to-alpaca-ECR"
+  description    = "This project builds the ${each.key} image and pushes it to ECR"
+  build_timeout  = "12"
+  service_role   = aws_iam_role.govwifi_codebuild.arn
+  encryption_key = aws_kms_key.codepipeline_key.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    environment_variable {
+      name  = "DOCKER_HUB_AUTHTOKEN_ENV"
+      value = data.aws_secretsmanager_secret_version.docker_hub_authtoken.secret_string
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_USERNAME_ENV"
+      value = data.aws_secretsmanager_secret_version.docker_hub_username.secret_string
+    }
+
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID"
+      value = local.aws_account_id
+    }
+
+    environment_variable {
+      name  = "STAGE"
+      value = "alpaca"
+    }
+
+  }
+
+  source_version = "master"
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/alphagov/govwifi-${each.key}.git"
+    git_clone_depth = 1
+    buildspec       = "buildspec.yml"
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "govwifi-codebuild-${each.key}-group"
+      stream_name = "govwifi-codebuild-${each.key}-stream"
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${aws_s3_bucket.codepipeline_bucket.id}/${each.key}-log"
+    }
+  }
+
+}

--- a/govwifi-deploy/alpaca-codepipeline-admin.tf
+++ b/govwifi-deploy/alpaca-codepipeline-admin.tf
@@ -1,0 +1,105 @@
+resource "aws_codepipeline" "alpaca_admin_pipeline" {
+  name     = "DEV-alpaca-admin-pipeline"
+  role_arn = aws_iam_role.govwifi_codepipeline_global_role.arn
+
+  artifact_store {
+    region   = "eu-west-2"
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key.arn
+      type = "KMS"
+    }
+  }
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket_ireland.bucket
+    type     = "S3"
+    region   = "eu-west-1"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key_ireland.arn
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "NewECRImagDetectedFor-admin"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        RepositoryName = "govwifi/admin/alpaca"
+      }
+    }
+  }
+
+  stage {
+    name = "admin-convert-imagedetail"
+
+    action {
+      name             = "admin-convert-imagedetail"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["SourceArtifact"]
+      output_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["admin"].name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy-to-alpaca"
+
+    action {
+      name            = "Deploy-to-eu-west-2"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+      version         = "1"
+      # This resource lives in the alpaca & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "alpaca-admin-cluster"
+        ServiceName : "admin-alpaca"
+      }
+    }
+
+  }
+
+  stage {
+    name = "alpaca-Smoketests"
+
+    action {
+      name            = "alpaca-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+
+      # This resource lives in the alpaca & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
+  }
+
+}

--- a/govwifi-deploy/alpaca-codepipeline-authentication-api.tf
+++ b/govwifi-deploy/alpaca-codepipeline-authentication-api.tf
@@ -1,0 +1,123 @@
+resource "aws_codepipeline" "alpaca_authentication_api_pipeline" {
+  name     = "DEV-alpaca-authentication-api-pipeline"
+  role_arn = aws_iam_role.govwifi_codepipeline_global_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+    region   = "eu-west-2"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key.arn
+      type = "KMS"
+    }
+  }
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket_ireland.bucket
+    type     = "S3"
+    region   = "eu-west-1"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key_ireland.arn
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "NewECRImagDetectedFor-authentication-api"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        RepositoryName = "govwifi/authentication-api/alpaca"
+      }
+    }
+  }
+
+  stage {
+    name = "authentication-api-convert-imagedetail"
+
+    action {
+      name             = "authentication-api-convert-imagedetail"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["SourceArtifact"]
+      output_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["authentication-api"].name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy-to-alpaca"
+
+    action {
+      name            = "Deploy-to-eu-west-2"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+      version         = "1"
+      region          = "eu-west-2"
+      # This resource lives in the alpaca. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "alpaca-api-cluster"
+        ServiceName : "authentication-api-service-alpaca"
+      }
+    }
+
+    action {
+      name            = "Deploy-to-eu-west-1"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+      version         = "1"
+      region          = "eu-west-1"
+      # This resource lives in the alpaca. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "alpaca-api-cluster"
+        ServiceName : "authentication-api-service-alpaca"
+      }
+    }
+  }
+
+  stage {
+    name = "alpaca-Smoketests"
+
+    action {
+      name            = "alpaca-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+
+      # This resource lives in the alpaca. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
+  }
+}

--- a/govwifi-deploy/alpaca-codepipeline-logging-api.tf
+++ b/govwifi-deploy/alpaca-codepipeline-logging-api.tf
@@ -1,0 +1,106 @@
+resource "aws_codepipeline" "alpaca_logging_api_pipeline" {
+  name     = "DEV-alpaca-logging-api-pipeline"
+  role_arn = aws_iam_role.govwifi_codepipeline_global_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+    region   = "eu-west-2"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key.arn
+      type = "KMS"
+    }
+  }
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket_ireland.bucket
+    type     = "S3"
+    region   = "eu-west-1"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key_ireland.arn
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "NewECRImagDetectedFor-logging-api"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        RepositoryName = "govwifi/logging-api/alpaca"
+      }
+    }
+  }
+
+  stage {
+    name = "logging-api-convert-imagedetail"
+
+    action {
+      name             = "logging-api-convert-imagedetail"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["SourceArtifact"]
+      output_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["logging-api"].name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy-to-alpaca"
+
+    action {
+      name            = "Deploy-to-eu-west-2"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
+      version         = "1"
+      region          = "eu-west-2"
+      # This resource lives in the alpaca. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "alpaca-api-cluster"
+        ServiceName : "logging-api-service-alpaca"
+      }
+    }
+  }
+
+  stage {
+    name = "alpaca-Smoketests"
+
+    action {
+      name            = "alpaca-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
+
+      # This resource lives in the alpaca. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
+  }
+
+}

--- a/govwifi-deploy/alpaca-codepipeline-user-signup-api.tf
+++ b/govwifi-deploy/alpaca-codepipeline-user-signup-api.tf
@@ -1,0 +1,105 @@
+resource "aws_codepipeline" "alpaca_user_signup_api_pipeline" {
+  name     = "DEV-alpaca-user-signup-api-pipeline"
+  role_arn = aws_iam_role.govwifi_codepipeline_global_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+    region   = "eu-west-2"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key.arn
+      type = "KMS"
+    }
+  }
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket_ireland.bucket
+    type     = "S3"
+    region   = "eu-west-1"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key_ireland.arn
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "NewECRImagDetectedFor-user-signup-api"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        RepositoryName = "govwifi/user-signup-api/alpaca"
+      }
+    }
+  }
+
+  stage {
+    name = "user-signup-api-convert-imagedetail"
+
+    action {
+      name             = "user-signup-api-convert-imagedetail"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["SourceArtifact"]
+      output_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["user-signup-api"].name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy-to-Alpaca"
+
+    action {
+      name            = "Deploy-to-eu-west-2"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
+      version         = "1"
+      region          = "eu-west-2"
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "alpaca-api-cluster"
+        ServiceName : "user-signup-api-service-alpaca"
+      }
+    }
+  }
+
+  stage {
+    name = "Alpaca-Smoketests"
+
+    action {
+      name            = "Alpaca-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
+  }
+}

--- a/govwifi-deploy/codebuild-deployed-apps-alpaca.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-alpaca.tf
@@ -1,0 +1,105 @@
+resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_alpaca" {
+  for_each      = toset(var.deployed_app_names)
+  name          = "${each.key}-push-image-to-ecr-alpaca"
+  description   = "This project builds the API docker images and pushes them to ECR ${each.key}"
+  build_timeout = "12"
+  service_role  = aws_iam_role.govwifi_codebuild.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  cache {
+    type     = "S3"
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID"
+      value = local.aws_account_id
+    }
+
+    environment_variable {
+      name  = "AWS_REGION"
+      value = "eu-west-2"
+    }
+
+    environment_variable {
+      name  = "STAGE"
+      value = "alpaca"
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_AUTHTOKEN_ENV"
+      value = "/govwifi-cd/pipelines/main/docker_hub_authtoken"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_USERNAME_ENV"
+      value = "/govwifi-cd/pipelines/main/docker_hub_username"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "WORDLIST_BUCKET_NAME"
+      value = "/govwifi-cd/pipelines/main/wordlist_bucket_name"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "ACCEPTANCE_TESTS_PROJECT_NAME"
+      value = "acceptance-tests"
+    }
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "govwifi-codebuild-push-image-to-ecr-log-group"
+      stream_name = "govwifi-codebuild-push-image-to-ecr-log-stream"
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${aws_s3_bucket.codepipeline_bucket.id}/build-log"
+    }
+  }
+
+  source_version = "master"
+
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/alphagov/govwifi-${each.key}.git"
+    git_clone_depth = 1
+    buildspec       = "buildspec.yml"
+  }
+}
+
+resource "aws_codebuild_webhook" "govwifi_app_webhook_alpaca" {
+  for_each = toset(var.deployed_app_names)
+
+  project_name = aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_alpaca[each.key].name
+
+  build_type = "BUILD"
+
+  filter_group {
+    filter {
+      type    = "EVENT"
+      pattern = "PULL_REQUEST_MERGED"
+    }
+
+    ### To test a branch without needing to raise a PR, uncomment the below and change source to the name of your branch
+    # filter {
+    #   type    = "HEAD_REF"
+    #   pattern = "^refs/heads/buildspec-global-ecr$"
+    # }
+  }
+}

--- a/govwifi-deploy/ecr.tf
+++ b/govwifi-deploy/ecr.tf
@@ -1,3 +1,87 @@
+### Begin Alpaca
+
+resource "aws_ecr_repository" "govwifi_ecr_repo_deployed_apps_alpaca" {
+  for_each = toset(var.deployed_app_names)
+  name     = "govwifi/${each.key}/alpaca"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_repo_policy_deployed_apps_alpaca" {
+  for_each   = toset(var.deployed_app_names)
+  repository = aws_ecr_repository.govwifi_ecr_repo_deployed_apps_alpaca[each.key].name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_alpaca.json
+}
+
+resource "aws_ecr_repository" "govwifi_frontend_alpaca" {
+  for_each = toset(var.frontend_docker_images)
+  name     = "govwifi/alpaca/${each.key}"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_frontend_policy_alpaca" {
+  for_each   = toset(var.frontend_docker_images)
+  repository = aws_ecr_repository.govwifi_frontend_alpaca[each.key].name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_alpaca.json
+}
+
+resource "aws_ecr_repository" "govwifi_frontend_alpaca_ire" {
+  provider = aws.dublin
+  for_each = toset(var.frontend_docker_images)
+  name     = "govwifi/alpaca/${each.key}"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_frontend_policy_alpaca_ire" {
+  provider   = aws.dublin
+  for_each   = toset(var.frontend_docker_images)
+  repository = aws_ecr_repository.govwifi_frontend_alpaca[each.key].name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_alpaca.json
+}
+
+resource "aws_ecr_repository" "safe_restarter_ecr_alpaca" {
+  name = "govwifi/alpaca/safe-restarter"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_saferestater_policy_alpaca" {
+  repository = aws_ecr_repository.safe_restarter_ecr_alpaca.name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_alpaca.json
+}
+
+resource "aws_ecr_repository" "database_backup_ecr_alpaca" {
+  name = "govwifi/alpaca/database-backup"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_database_backup_policy_alpaca" {
+  repository = aws_ecr_repository.database_backup_ecr_alpaca.name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_alpaca.json
+}
+
+data "aws_iam_policy_document" "govwifi_ecr_repo_policy_alpaca" {
+  statement {
+    sid = "AllowPushPull"
+
+    effect = "Allow"
+
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.aws_alpaca_account_id}:root"]
+    }
+
+  }
+
+}
+
+
+### End Alpaca
+
+
 ### Begin Staging
 
 resource "aws_ecr_repository" "govwifi_frontend_staging" {

--- a/govwifi-deploy/iam-codepipeline.tf
+++ b/govwifi-deploy/iam-codepipeline.tf
@@ -52,6 +52,8 @@ resource "aws_iam_role_policy" "codepipeline_global_policy" {
             "Resource": [
 								"arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-crossaccount-tools-deploy",
 								"arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-codebuild-role",
+                "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-crossaccount-tools-deploy",
+								"arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-codebuild-role",
 								"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy",
 								"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role"
 							],

--- a/govwifi-deploy/kms.tf
+++ b/govwifi-deploy/kms.tf
@@ -32,6 +32,7 @@ resource "aws_kms_key" "codepipeline_key" {
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
+										"arn:aws:iam::${local.aws_alpaca_account_id}:root",
 										"arn:aws:iam::${local.aws_staging_account_id}:root",
 								 		"arn:aws:iam::${local.aws_production_account_id}:root"
 									]
@@ -56,6 +57,7 @@ resource "aws_kms_key" "codepipeline_key" {
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
+										"arn:aws:iam::${local.aws_alpaca_account_id}:root",
 										"arn:aws:iam::${local.aws_staging_account_id}:root",
 										"arn:aws:iam::${local.aws_production_account_id}:root"
 									]
@@ -120,6 +122,7 @@ resource "aws_kms_key" "codepipeline_key_ireland" {
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
+										"arn:aws:iam::${local.aws_alpaca_account_id}:root",
 										"arn:aws:iam::${local.aws_staging_account_id}:root",
 								 		"arn:aws:iam::${local.aws_production_account_id}:root"
 									]
@@ -144,6 +147,7 @@ resource "aws_kms_key" "codepipeline_key_ireland" {
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
+										"arn:aws:iam::${local.aws_alpaca_account_id}:root",
 										"arn:aws:iam::${local.aws_staging_account_id}:root",
 										"arn:aws:iam::${local.aws_production_account_id}:root"
 									]

--- a/govwifi-deploy/locals.tf
+++ b/govwifi-deploy/locals.tf
@@ -6,6 +6,10 @@ locals {
   aws_production_account_id = jsondecode(data.aws_secretsmanager_secret_version.production_aws_account_no.secret_string)["account-id"]
 }
 
+locals {
+  aws_alpaca_account_id = jsondecode(data.aws_secretsmanager_secret_version.alpaca_aws_account_no.secret_string)["account-id"]
+}
+
 data "aws_caller_identity" "current" {}
 
 locals {

--- a/govwifi-deploy/s3.tf
+++ b/govwifi-deploy/s3.tf
@@ -43,6 +43,8 @@ resource "aws_s3_bucket_policy" "codepipeline_bucket_policy" {
 										"arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-codebuild-role",
 										"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy",
 										"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role",
+                    "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-crossaccount-tools-deploy",
+                    "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-codebuild-role",
 										"${aws_iam_role.govwifi_codepipeline_global_role.arn}",
 										"${aws_iam_role.govwifi_codebuild_convert.arn}"
 									]
@@ -102,6 +104,8 @@ resource "aws_s3_bucket_policy" "codepipeline_bucket_policy_ireland" {
 										"arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-codebuild-role",
 										"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy",
 										"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role",
+                    "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-crossaccount-tools-deploy",
+                    "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-codebuild-role",
 										"${aws_iam_role.govwifi_codepipeline_global_role.arn}",
 										"${aws_iam_role.govwifi_codebuild_convert.arn}"
 									]

--- a/govwifi-deploy/secrets-manager.tf
+++ b/govwifi-deploy/secrets-manager.tf
@@ -14,6 +14,14 @@ data "aws_secretsmanager_secret" "staging_aws_account_no" {
   name = "staging/AccountID"
 }
 
+data "aws_secretsmanager_secret_version" "alpaca_aws_account_no" {
+  secret_id = data.aws_secretsmanager_secret.alpaca_aws_account_no.id
+}
+
+data "aws_secretsmanager_secret" "alpaca_aws_account_no" {
+  name = "alpaca/AccountID"
+}
+
 data "aws_secretsmanager_secret_version" "production_aws_account_no" {
   secret_id = data.aws_secretsmanager_secret.production_aws_account_no.id
 }

--- a/govwifi/alpaca/.terraform.lock.hcl
+++ b/govwifi/alpaca/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "h1:62mVchC1L6vOo5QS9uUf52uu0emsMM+LsPQJ1BEaTms=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.50.0"
+  hashes = [
+    "h1:g7fn+osqp+sxM2ExA4CfKLEBxBmkPWctKnsIRmq0l+E=",
+    "h1:jYbnOsQkAQ2O2eiZU3B5LACcEz0eoqX4cZNEjzMar8Q=",
+    "zh:03a5795ea9ed3eb80e0d5e0c5234dc76455aa4437e5546399127939c24a60973",
+    "zh:24556a15eb4a69955857b3a52322f099e68031e6f9a3df2cfdb6f6351cc4885e",
+    "zh:2c2a18f3da3c06f9da5f2aca485d0b324c8510f2afb70fc1470bcb31485db061",
+    "zh:37f194e62f7b433b7235b6e4f6954dd9352554ad044007802d3fa9b80a7a7331",
+    "zh:4591157be7c8ec8160186a74789c44f214c7142f400e2c147b710e25abe15be0",
+    "zh:53e0f9ca106a9691c20535500cdcf9e4255993536e19ef2fc4c6353bfc7e2e5b",
+    "zh:54eb4c288adfafe866b3b1fcc0550ddd025f59843cfa6dd3310fed85c766b950",
+    "zh:56e887eba5bb6dd60eb2c72d09eba34232b59a0c83ac1f3693e4064ebd2af02f",
+    "zh:57858a160b5dc3c454697798d38e528662c9234f9ab1742f6c5b3bd0414e0578",
+    "zh:6ce0a31d9b1bf2dc069414c7aeae0a660aa60b58a59e97a1c575786b120a0104",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b70d22fa41bb30536fb1be5242701b19b0be8bb50ec6ba03bb5396be3cdac8c6",
+    "zh:ece8726967858c44a5ae458f7a8438e825128d356fbf1893d41ccb172bb263d9",
+    "zh:f0f2a8be772add8d0cdadf77fda7ed1c0dfbbeab9801a0d2d8820148653aa8f4",
+    "zh:fc93015058e9592810aa4b3e7834df1717ba8d6aec4679997d16c030c885d6fc",
+  ]
+}

--- a/govwifi/alpaca/data.tf
+++ b/govwifi/alpaca/data.tf
@@ -1,0 +1,6 @@
+# TODO This should probably be managed by Terraform at some point
+data "aws_route53_zone" "main" {
+  name = "${local.env_subdomain}.service.gov.uk."
+}
+
+data "aws_caller_identity" "current" {}

--- a/govwifi/alpaca/dublin.tf
+++ b/govwifi/alpaca/dublin.tf
@@ -83,7 +83,7 @@ module "dublin_backend" {
   }
 
   source        = "../../govwifi-backend"
-  env           = "staging"
+  env           = "alpaca"
   env_name      = local.env_name
   env_subdomain = local.env_subdomain
 
@@ -102,7 +102,7 @@ module "dublin_backend" {
 
   bastion_instance_type     = "t2.micro"
   bastion_server_ip         = module.london_backend.bastion_public_ip
-  bastion_ssh_key_name      = "staging-bastion-20200717"
+  bastion_ssh_key_name      = "govwifi-alpaca-bastion-20230120"
   enable_bastion_monitoring = false
   aws_account_id            = local.aws_account_id
 
@@ -120,7 +120,7 @@ module "dublin_backend" {
   rr_storage_gb    = 0
 
   user_db_replica_count  = 1
-  user_replica_source_db = "arn:aws:rds:eu-west-2:${local.aws_account_id}:db:wifi-staging-user-db"
+  user_replica_source_db = "arn:aws:rds:eu-west-2:${local.aws_account_id}:db:wifi-alpaca-user-db"
   user_rr_instance_type  = "db.t2.small"
 
   # TODO This should happen inside the module
@@ -168,7 +168,7 @@ module "dublin_keys" {
 
   source = "../../govwifi-keys"
 
-  govwifi_bastion_key_name = "staging-bastion-20200717"
+  govwifi_bastion_key_name = "govwifi-alpaca-bastion-20230120"
   govwifi_bastion_key_pub  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDL5wGVJ8aXL0QUhIvfLV2BMLC9Tk74jnChC40R9ipzK0AuatcaXdj0PEm8sh8sHlXEmdmVDq/4s8XaEkF7MDl38qbjxxHRTpCgcTrYzJGad3xgr1+zhpD8Kfnepex/2pR7z7kOCv7EDx4vRTc8vu1ttcmJiniBmgjc1xVk1A5aB72GxffZrow7B0iopP16vEPvllUjsDoOaeLJukDzsbZaP2RRYBqIA4qXunfJpuuu/o+T+YR4LkTB+9UBOOGrX50T80oTtJMKD9ndQ9CC9sqlrOzE9GiZz9db7D9iOzIZoTT6dBbgEOfCGmkj7WS2NjF+D/pEN/edkIuNGvE+J/HqQ179Xm/VCx5Kr6ARG+xk9cssCQbEFwR46yitaPA7B4mEiyD9XvUW2tUeVKdX5ybUFqV++2c5rxTczuH4gGlEGixIqPeltRvkVrN6qxnrbDAXE2bXymcnEN6BshwGKR+3OUKTS8c53eWmwiol6xwCp8VUI8/66tC/bCTmeur07z2LfQsIo745GzPuinWfUm8yPkZOD3LptkukO1aIfgvuNmlUKTwKSLIIwwsqTZ2FcK39A8g3Iq3HRV+4JwOowLJcylRa3QcSH9wdjd69SqPrZb0RhW0BN1mTX2tEBl1ryUUpKsqpMbvjl28tn6MGsU/sRhBLqliduOukGubD29LlAQ== "
 
   create_production_bastion_key = 0
@@ -195,8 +195,8 @@ module "dublin_frontend" {
   aws_region_name    = local.dublin_aws_region_name
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = local.dublin_frontend_vpc_cidr_block
-  rack_env           = "staging"
-  sentry_current_env = "secondary-staging"
+  rack_env           = "alpaca"
+  sentry_current_env = "secondary-alpaca"
 
   backend_vpc_id = module.dublin_backend.backend_vpc_id
 
@@ -212,12 +212,12 @@ module "dublin_frontend" {
   ssh_key_name = var.ssh_key_name
 
   frontend_docker_image = format(
-    "%s/frontend:staging",
+    "%s/frontend:alpaca",
     replace(local.docker_image_path, local.london_aws_region, local.dublin_aws_region)
   )
 
   raddb_docker_image = format(
-    "%s/raddb:staging",
+    "%s/raddb:alpaca",
     replace(local.docker_image_path, local.london_aws_region, local.dublin_aws_region)
   )
 
@@ -249,8 +249,8 @@ module "dublin_api" {
   }
 
   source        = "../../govwifi-api"
-  env           = "staging"
-  env_name      = "staging"
+  env           = "alpaca"
+  env_name      = "alpaca"
   env_subdomain = local.env_subdomain
 
   backend_elb_count      = 1
@@ -284,9 +284,9 @@ module "dublin_api" {
   ## TODO This should depend on the resource
   user_rr_hostname = "users-rr.${lower(local.dublin_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
 
-  rack_env                = "staging"
+  rack_env                = "alpaca"
   app_env                 = "staging"
-  sentry_current_env      = "secondary-staging"
+  sentry_current_env      = "secondary-alpaca"
   radius_server_ips       = local.frontend_radius_ips
   subnet_ids              = module.dublin_backend.backend_subnet_ids
   private_subnet_ids      = module.dublin_backend.backend_private_subnet_ids
@@ -334,7 +334,7 @@ module "dublin_route53_notifications" {
 
   source = "../../sns-notification"
 
-  topic_name = "govwifi-staging-dublin"
+  topic_name = "govwifi-alpaca-dublin"
   emails     = [var.notification_email]
 }
 
@@ -345,6 +345,6 @@ module "dublin_notifications" {
 
   source = "../../sns-notification"
 
-  topic_name = "govwifi-staging"
+  topic_name = "govwifi-alpaca"
   emails     = [var.notification_email]
 }

--- a/govwifi/alpaca/firewall-variables.tf
+++ b/govwifi/alpaca/firewall-variables.tf
@@ -1,0 +1,2 @@
+variable "administrator_cidrs" {
+}

--- a/govwifi/alpaca/locals.tf
+++ b/govwifi/alpaca/locals.tf
@@ -1,0 +1,23 @@
+locals {
+  env_name      = "alpaca"
+  env_subdomain = "alpaca.wifi" # Environment specific subdomain to use under the service domain
+  env           = "alpaca"
+  product_name  = "GovWifi"
+
+  backup_mysql_rds = true
+}
+
+locals {
+  aws_account_id = data.aws_caller_identity.current.account_id
+}
+
+locals {
+  docker_image_path = nonsensitive(jsondecode(data.aws_secretsmanager_secret_version.docker_image_path.secret_string)["path"])
+}
+
+locals {
+  frontend_radius_ips = concat(
+    module.london_frontend.eip_public_ips,
+    module.dublin_frontend.eip_public_ips
+  )
+}

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -21,13 +21,13 @@ module "london_keys" {
 
   source = "../../govwifi-keys"
 
-  govwifi_bastion_key_name = "staging-bastion-20200717"
-  govwifi_bastion_key_pub  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDL5wGVJ8aXL0QUhIvfLV2BMLC9Tk74jnChC40R9ipzK0AuatcaXdj0PEm8sh8sHlXEmdmVDq/4s8XaEkF7MDl38qbjxxHRTpCgcTrYzJGad3xgr1+zhpD8Kfnepex/2pR7z7kOCv7EDx4vRTc8vu1ttcmJiniBmgjc1xVk1A5aB72GxffZrow7B0iopP16vEPvllUjsDoOaeLJukDzsbZaP2RRYBqIA4qXunfJpuuu/o+T+YR4LkTB+9UBOOGrX50T80oTtJMKD9ndQ9CC9sqlrOzE9GiZz9db7D9iOzIZoTT6dBbgEOfCGmkj7WS2NjF+D/pEN/edkIuNGvE+J/HqQ179Xm/VCx5Kr6ARG+xk9cssCQbEFwR46yitaPA7B4mEiyD9XvUW2tUeVKdX5ybUFqV++2c5rxTczuH4gGlEGixIqPeltRvkVrN6qxnrbDAXE2bXymcnEN6BshwGKR+3OUKTS8c53eWmwiol6xwCp8VUI8/66tC/bCTmeur07z2LfQsIo745GzPuinWfUm8yPkZOD3LptkukO1aIfgvuNmlUKTwKSLIIwwsqTZ2FcK39A8g3Iq3HRV+4JwOowLJcylRa3QcSH9wdjd69SqPrZb0RhW0BN1mTX2tEBl1ryUUpKsqpMbvjl28tn6MGsU/sRhBLqliduOukGubD29LlAQ== "
+  govwifi_bastion_key_name = "govwifi-alpaca-bastion-20230120"
+  govwifi_bastion_key_pub  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC/cSxMbS72i6FoirL80CP9GLU7fZ1mtwIg0hi8v8OuCKyR8JjYQejZpyCGSIb3KOXIQf51bUI2+GB8B+h+UpWwUIN5Ysepc4YKuTjped4Av7ybrHFsqkl+66/uQgDwGloU6UuksTiwLVK9sf2JcDztm8Bbef/5cunLfhR+yrvzebF9kK0tnZxORwS0gCXA0bdgoqCUfJHxogLaZV3A517bn60rHcdq55qgIjI4IxNxdKLcrWjwJPbgvqepX+YbeDWqXe6VoVkwCB+daM8SGMvmZyfu7fsJFkoga4D9ksGTKNFFlLPlp4RqEkYqHqZAX70XVg6z32yHZ99iP36wCYhw3AjhdUMDFpoXv2iPMkFNx+EyOC1DtQdrLa96QDPKk2FSmhE6kz0524TWogS/x/2zFtXZbyqhAfzoU36YgFm8RYeS6mSUkxP7IynKvHbjuMqsh34sWRRSl4OxDA8K2ps2Hu2O2lFM44Sr02TeKqnKJza07ZRcAl8AWjoyaarHZ6iHft7n4CjXHLy2CmstVCIsEfmv+aZvMe8qZ1tWSoE50/6XyDn9B1UMQNmSIX8InYvh0pXIA6q+Y7/PAROfOcT3rKLSUyFS6D/PGfbq/P8GbJIAImSGBhBs4GgawtR7+hIpjsQ2dWEXwzdWGFkvmWyai6SUkclBYJkQYd0VyQb61w== david.pye@GDS10381"
 
   create_production_bastion_key = 0
 
   govwifi_key_name     = var.ssh_key_name
-  govwifi_key_name_pub = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDOxYtGJARr+ZUB9wMWMX/H+myTidFKx+qcBsXuri5zavQ6K4c0WhSkypXfET9BBtC1ZU77B98mftegxKdKcKmFbCVlv39pIX+xj2vjuCzHlzezI1vB4mdAXNhc8b4ArvFJ8lG2GLa1ZD8H/8akpv6EcplwyUv6ZgQMPl6wfMF6d0Qe/eOJ/bV570icX9NYLGkdLRbudkRc12krt6h451qp1vO7f2FQOnPR2cnyLGd/FxhrmAOqJsDk9CRNSwHJe1lsSCz6TkQk1bfCTxZ7g2hWSNRBdWPj0RJbbezy3X3/pz4cFL8mCC1esJ+nptUZ7CXeyirtCObIepniXIItwtdIVqixaMSjfagUGd0L1zFEVuH0bct3mh3u3TyVbNHP4o4pFHvG0sm5R1iDB8/xe2NJdxmAsn3JqeXdsQ6uI/oz31OueFRPyZI0VeDw7B4bhBMZ0w/ncrYJ9jFjfPvzhAVZgQX5Pxtp5MUCeU9+xIdAN2bESmIvaoSEwno7WJ4z61d83pLMFUuS9vNRW4ykgd1BzatLYSkLp/fn/wYNn6DBk7Da6Vs1Y/jgkiDJPGeFlEhW3rqOjTKrpKJBw6LBsMyI0BtkKoPoUTDlKSEX5JlNWBX2z5eSEhe+WEQjc4ZnbLUOKRB5+xNOGahVyk7/VF8ZaZ3/GXWY7MEfZ8TIBBcAjw== GovWifi-DevOps@digital.cabinet-office.gov.uk"
+  govwifi_key_name_pub = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC/cSxMbS72i6FoirL80CP9GLU7fZ1mtwIg0hi8v8OuCKyR8JjYQejZpyCGSIb3KOXIQf51bUI2+GB8B+h+UpWwUIN5Ysepc4YKuTjped4Av7ybrHFsqkl+66/uQgDwGloU6UuksTiwLVK9sf2JcDztm8Bbef/5cunLfhR+yrvzebF9kK0tnZxORwS0gCXA0bdgoqCUfJHxogLaZV3A517bn60rHcdq55qgIjI4IxNxdKLcrWjwJPbgvqepX+YbeDWqXe6VoVkwCB+daM8SGMvmZyfu7fsJFkoga4D9ksGTKNFFlLPlp4RqEkYqHqZAX70XVg6z32yHZ99iP36wCYhw3AjhdUMDFpoXv2iPMkFNx+EyOC1DtQdrLa96QDPKk2FSmhE6kz0524TWogS/x/2zFtXZbyqhAfzoU36YgFm8RYeS6mSUkxP7IynKvHbjuMqsh34sWRRSl4OxDA8K2ps2Hu2O2lFM44Sr02TeKqnKJza07ZRcAl8AWjoyaarHZ6iHft7n4CjXHLy2CmstVCIsEfmv+aZvMe8qZ1tWSoE50/6XyDn9B1UMQNmSIX8InYvh0pXIA6q+Y7/PAROfOcT3rKLSUyFS6D/PGfbq/P8GbJIAImSGBhBs4GgawtR7+hIpjsQ2dWEXwzdWGFkvmWyai6SUkclBYJkQYd0VyQb61w== david.pye@GDS10381"
 
 }
 
@@ -37,7 +37,7 @@ module "london_backend" {
   }
 
   source        = "../../govwifi-backend"
-  env           = "staging"
+  env           = "alpaca"
   env_name      = local.env_name
   env_subdomain = local.env_subdomain
 
@@ -52,7 +52,7 @@ module "london_backend" {
 
   bastion_ami               = "ami-096cb92bb3580c759"
   bastion_instance_type     = "t2.micro"
-  bastion_ssh_key_name      = "staging-bastion-20200717"
+  bastion_ssh_key_name      = "govwifi-alpaca-bastion-20230120"
   enable_bastion_monitoring = false
   aws_account_id            = local.aws_account_id
   db_instance_count         = 1
@@ -106,8 +106,8 @@ module "london_frontend" {
   aws_region_name    = local.london_aws_region_name
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.102.0.0/16"
-  rack_env           = "staging"
-  sentry_current_env = "secondary-staging"
+  rack_env           = "alpaca"
+  sentry_current_env = "secondary-alpaca"
 
   backend_vpc_id = module.london_backend.backend_vpc_id
 
@@ -121,8 +121,8 @@ module "london_frontend" {
 
   ami                   = "ami-2218f945"
   ssh_key_name          = var.ssh_key_name
-  frontend_docker_image = format("%s/frontend:staging", local.docker_image_path)
-  raddb_docker_image    = format("%s/raddb:staging", local.docker_image_path)
+  frontend_docker_image = format("%s/frontend:alpaca", local.docker_image_path)
+  raddb_docker_image    = format("%s/raddb:alpaca", local.docker_image_path)
   create_ecr            = 1
 
   admin_app_data_s3_bucket_name = module.london_admin.app_data_s3_bucket_name
@@ -166,10 +166,10 @@ module "london_admin" {
 
   route53_zone_id = data.aws_route53_zone.main.zone_id
 
-  admin_docker_image   = format("%s/admin:staging", local.docker_image_path)
-  rails_env            = "staging"
+  admin_docker_image   = format("%s/admin:alpaca", local.docker_image_path)
+  rails_env            = "alpaca"
   app_env              = "staging"
-  sentry_current_env   = "secondary-staging"
+  sentry_current_env   = "alpaca"
   ecr_repository_count = 1
 
   subnet_ids = module.london_backend.backend_subnet_ids
@@ -182,8 +182,8 @@ module "london_admin" {
   db_backup_window         = "03:42-04:42"
   db_monitoring_interval   = 60
 
-  rr_db_host = "db.london.staging.wifi.service.gov.uk"
-  rr_db_name = "govwifi_staging"
+  rr_db_host = "db.london.alpaca.wifi.service.gov.uk"
+  rr_db_name = "govwifi_alpaca"
 
   user_db_host = "users-db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
   user_db_name = "govwifi_staging_users"
@@ -214,8 +214,8 @@ module "london_api" {
   }
 
   source        = "../../govwifi-api"
-  env           = "staging"
-  env_name      = "staging"
+  env           = "alpaca"
+  env_name      = "alpaca"
   env_subdomain = local.env_subdomain
 
   backend_elb_count      = 1
@@ -233,10 +233,10 @@ module "london_api" {
   devops_notifications_arn   = module.london_notifications.topic_arn
   notification_arn           = module.london_notifications.topic_arn
 
-  user_signup_docker_image      = format("%s/user-signup-api:staging", local.docker_image_path)
-  logging_docker_image          = format("%s/logging-api:staging", local.docker_image_path)
-  safe_restart_docker_image     = format("%s/safe-restarter:staging", local.docker_image_path)
-  backup_rds_to_s3_docker_image = format("%s/database-backup:staging", local.docker_image_path)
+  user_signup_docker_image      = format("%s/user-signup-api:alpaca", local.docker_image_path)
+  logging_docker_image          = format("%s/logging-api:alpaca", local.docker_image_path)
+  safe_restart_docker_image     = format("%s/safe-restarter:alpaca", local.docker_image_path)
+  backup_rds_to_s3_docker_image = format("%s/database-backup:alpaca", local.docker_image_path)
 
   create_wordlist_bucket = true
   wordlist_file_path     = "../wordlist-short"
@@ -247,9 +247,9 @@ module "london_api" {
   user_db_hostname = "users-db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
   user_rr_hostname = "users-db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
 
-  rack_env                  = "staging"
+  rack_env                  = "alpaca"
   app_env                   = "staging"
-  sentry_current_env        = "secondary-staging"
+  sentry_current_env        = "alpaca"
   radius_server_ips         = local.frontend_radius_ips
   subnet_ids                = module.london_backend.backend_subnet_ids
   private_subnet_ids        = module.london_backend.backend_private_subnet_ids
@@ -289,7 +289,7 @@ module "london_route53_notifications" {
 
   source = "../../sns-notification"
 
-  topic_name = "govwifi-staging-london"
+  topic_name = "govwifi-alpaca-london"
   emails     = [var.notification_email]
 }
 
@@ -300,7 +300,7 @@ module "london_notifications" {
 
   source = "../../sns-notification"
 
-  topic_name = "govwifi-staging"
+  topic_name = "govwifi-alpaca"
   emails     = [var.notification_email]
 }
 

--- a/govwifi/alpaca/main.tf
+++ b/govwifi/alpaca/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_version = "~> 1.1.8"
+
+  backend "s3" {
+    bucket = "govwifi-alpaca-tfstate-eu-west-2"
+
+    key    = "alpaca-tfstate"
+    region = "eu-west-2"
+  }
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Environment = title(local.env_name)
+    }
+  }
+}
+
+module "tfstate" {
+  providers = {
+    aws             = aws.london
+    aws.replication = aws.dublin
+  }
+
+  source   = "../../new-terraform-state"
+  env_name = local.env_name
+}

--- a/govwifi/alpaca/secrets-manager.tf
+++ b/govwifi/alpaca/secrets-manager.tf
@@ -1,0 +1,7 @@
+data "aws_secretsmanager_secret_version" "docker_image_path" {
+  secret_id = data.aws_secretsmanager_secret.docker_image_path.id
+}
+
+data "aws_secretsmanager_secret" "docker_image_path" {
+  name = "aws/ecr/docker-image-path/govwifi"
+}

--- a/govwifi/alpaca/variables.tf
+++ b/govwifi/alpaca/variables.tf
@@ -1,0 +1,38 @@
+variable "ssh_key_name" {
+  type    = string
+  default = "govwifi-alpaca-bastion-20230120"
+}
+
+variable "notify_ips" {
+}
+
+# Secrets
+
+variable "public_google_api_key" {
+  type    = string
+  default = "xxxxxxxxxxxxxxxxxxxxx"
+}
+
+variable "zendesk_api_user" {
+  type        = string
+  description = "Username for authenticating with Zendesk API"
+}
+
+variable "notification_email" {
+}
+
+variable "smoketests_vpc_cidr" {
+}
+
+
+variable "smoketest_subnet_private_a" {
+}
+
+variable "smoketest_subnet_private_b" {
+}
+
+variable "smoketest_subnet_public_a" {
+}
+
+variable "smoketest_subnet_public_b" {
+}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -236,6 +236,7 @@ module "govwifi_admin" {
 
   admin_docker_image   = format("%s/admin:production", local.docker_image_path)
   rails_env            = "production"
+  app_env              = "production"
   sentry_current_env   = "production"
   ecr_repository_count = 1
 
@@ -310,6 +311,7 @@ module "api" {
 
   db_hostname               = "db.${lower(var.aws_region_name)}.${local.env_subdomain}.service.gov.uk"
   rack_env                  = "production"
+  app_env                   = "production"
   sentry_current_env        = "production"
   radius_server_ips         = local.frontend_radius_ips
   subnet_ids                = module.backend.backend_subnet_ids

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -290,6 +290,7 @@ module "api" {
 
   db_hostname              = "db.${lower(var.aws_region_name)}.${local.env_subdomain}.service.gov.uk"
   rack_env                 = "production"
+  app_env                  = "production"
   sentry_current_env       = "production"
   radius_server_ips        = local.frontend_radius_ips
   user_signup_docker_image = ""


### PR DESCRIPTION
### What
Add development environment called alpaca

### Why
This will be used by the devs to test the device wifi work

A few variables were added in order to make the new environment work correctly whilst retaining existing functionality for Staging and Production. New development environments will work as clones of staging.


Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-706
