### PR TITLE
Update Documentation For New Environments & Add Pipeline Template Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,10 +326,10 @@ Follow the instructions [here](https://govwifi-dev-docs.cloudapps.digital/infras
 ## Updating task definitions 
 
 This affects the following apps: 
-[admin](https://github.com/alphagov/govwifi-admin)
-[authentication-api](https://github.com/alphagov/govwifi-authentication-api)
-[user-api](https://github.com/alphagov/govwifi-user-signup-api)
-[logging-api](https://github.com/alphagov/govwifi-logging-api)
+- [admin](https://github.com/alphagov/govwifi-admin)
+- [authentication-api](https://github.com/alphagov/govwifi-authentication-api)
+- [user-api](https://github.com/alphagov/govwifi-user-signup-api)
+- [logging-api](https://github.com/alphagov/govwifi-logging-api)
 
 Once the task definitions for the above apps have been created by terraform, they are then managed by Codepipeline.  When the pipelines run for the first time after their initial creation, they store a copy of the task definition for that application in memory. If you create a new version of a task definition, **Codepipeline will still use the previous one AND CONTINUE to deploy the old one**. To get Codepipeline to use new task definitions you need to recreate the  pipelines. This is a flaw on AWS's part. Instructions for a work around are below:
  

--- a/README.md
+++ b/README.md
@@ -194,8 +194,36 @@ The SES ruleset must be manually activated.
 1. Select  “GovWifiRuleSet” from the list
 1. Select the "Set as active" button
 
-#### Setting Up The Deployment Pipelines
+#### Setting Up Deployment Pipelines For A New GovWifi Environment
 
+Our deploy pipelines exist in a separate account. You can access it with the following command:
+
+` gds aws govwifi-tools -l`
+
+In order to deploy applications you will need to create a new set of pipelines for that environment.
+- There are set of template terraform files for creating pipelines for a new environment in govwifi-terraform/tools/pipeline-templates. You can copy these across manually and change the names or you can use the commands below. ** All commands are run from the govwifi-terraform root directory **
+- Copy all the pipeline terraform template files in `govwifi-terraform/tools/pipeline-templates` to the govwifi-deploy directory:
+
+```
+for filename in tools/pipeline-templates/*your-env-name*;  do cp -Rp $filename ./govwifi-deploy/$(basename $filename) ; done
+
+```
+
+- Update the names of the terraform resources in the template files to match your new environment
+
+```
+for filename in ./govwifi-deploy/*your-env-name* ; do sed -i '' 's/your-env-name/<ENV_NAME>/g' $filename ; done
+```
+
+- Change the names of the files to match your new environment (change  **<NEW-ENV-NAME>** to your new environment name e.g. "dev")
+
+```
+for filename in ./govwifi-deploy/*your-env-name* ; do mv $filename ${filename/your-env-name/<NEW-ENV-NAME>}  ; done
+```
+
+##### Updating Other Pipeline files:
+
+You will also need to add 
 
 
 ## Rotating ELB Certificates

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ For historical use of secrets  please see: [GovWifi build](https://github.com/al
 Initialise terraform if running for the first time:
 
 ```
-gds aws <ENV> -- make <ENV> init-backend
-gds aws <ENV> -- make <ENV> plan
+gds-cli aws <ENV> -- make <ENV> init-backend
+gds-cli aws <ENV> -- make <ENV> plan
 ```
 
 Example ENVs are: `wifi`, `wifi-london` and `staging`.
@@ -54,8 +54,8 @@ Example ENVs are: `wifi`, `wifi-london` and `staging`.
 ## Running terraform
 
 ```
-gds aws <ENV> -- make <ENV> plan
-gds aws <ENV> -- make <ENV> apply
+gds-cli aws <ENV> -- make <ENV> plan
+gds-cli aws <ENV> -- make <ENV> apply
 ```
 
 ### Running terraform target
@@ -67,7 +67,7 @@ We've incorporated this functionality into our `make` commands. **Note**: this s
 To retrieve a module name, run a `terraform plan` and copy the module name (EXCLUDING "module.") from the Terraform output:
 
 ```bash
-$ gds aws <ENV> -- make staging plan
+$ gds-cli aws <ENV> -- make staging plan
 ...
 
 An execution plan has been generated and is shown below.
@@ -85,14 +85,14 @@ In this case, the module name would be `api.aws_iam_role_policy.some_policy`
 To `plan`/`apply` a specific resource use the standard `make <ENV> plan | apply` followed by a space separated list of one or more modules:
 
 ```
-$ gds aws <ENV> -- make <ENV> plan modules="backend.some.resource api.some.resource"
-$ gds aws <ENV> -- make <ENV> apply modules="frontend.some.resource"
+$ gds-cli aws <ENV> -- make <ENV> plan modules="backend.some.resource api.some.resource"
+$ gds-cli aws <ENV> -- make <ENV> apply modules="frontend.some.resource"
 ```
 
 If combining other Terraform commands (e.g., `-var` or `-replace`) with targeting a resource, use the `terraform_target` command:
 
 ```bash
-$ gds aws <ENV> -- make <ENV> terraform_target terraform_cmd="<plan | apply> -replace <your command>"
+$ gds-cli aws <ENV> -- make <ENV> terraform_target terraform_cmd="<plan | apply> -replace <your command>"
 ```
 
 #### Deriving module names
@@ -201,19 +201,19 @@ This holds information related to the terraform state, and must be created manua
 An example command for creating the bucket in the Staging environment for the London region would be:
 
 ```
-gds aws govwifi-staging -- aws s3api create-bucket --bucket govwifi-staging-london-accesslogs --region eu-west-2 
+gds-cli aws govwifi-staging -- aws s3api create-bucket --bucket govwifi-staging-london-accesslogs --region eu-west-2 
 ```
 
 ### Setting Up Remote State
 We use remote state, but there is a chicken and egg problem of creating a state bucket in which to store the remote state. When you are first creating a new environment (or migrating an environment not using remote state to use remote state) you will need to do the following
 
 #### Manually Create S3 State Bucket 
-gds aws <ENV> -- aws s3api create-bucket --bucket govwifi-<ENV>-tfstate-eu-west-2 --region eu-west-2 --create-bucket-configuration LocationConstraint=eu-west-2
+gds-cli aws <ENV> -- aws s3api create-bucket --bucket govwifi-<ENV>-tfstate-eu-west-2 --region eu-west-2 --create-bucket-configuration LocationConstraint=eu-west-2
 
 #### Initialize The Backend
 
 ```
-gds aws <ENV> -- make <ENV> init-backend
+gds-cli aws <ENV> -- make <ENV> init-backend
 ```
 
 #### Import S3 State bucket 
@@ -232,19 +232,19 @@ The first time terraform is run in a new environment the replication configurati
 Now run
 
 ```
-gds aws <ENV> -- make <ENV> plan
+gds-cli aws <ENV> -- make <ENV> plan
 ```
 
 For example
 
 ```
-gds aws govwifi-development -- make alpaca plan
+gds-cli aws govwifi-development -- make alpaca plan
 ```
 
 And then
 
 ```
-gds aws <ENV> -- make <ENV> apply
+gds-cli aws <ENV> -- make <ENV> apply
 ```
 
 After you have finished terraforming follow the manual steps below to complete the setup. 
@@ -256,7 +256,7 @@ After you have finished terraforming follow the manual steps below to complete t
 #### DNS Setup
 - Create a hosted zone in your new environment in the following format `<your_new_env>.wifi.service.gov.uk` (for example `foobar.wifi.service.gov.uk` )
 - Copy the NS records for the newly created hosted zone.
-- Log into the GovWifi Production AWS account `gds aws govwifi -l`
+- Log into the GovWifi Production AWS account `gds-cli aws govwifi -l`
 - In the production account in Route53 go to the `wifi.service.gov.uk` hosted zone.
 - Add a NS record for your new environment with the copied NS records. 
 - Validate DNS delegation is complete:
@@ -276,7 +276,7 @@ The SES ruleset must be manually activated.
 
 Our deploy pipelines exist in a separate account. You can access it with the following command:
 
-` gds aws govwifi-tools -l`
+` gds-cli aws govwifi-tools -l`
 
 In order to deploy applications you will need to create a new set of pipelines for that environment.
 - There are set of template terraform files for creating pipelines for a new environment in govwifi-terraform/tools/pipeline-templates. You can copy these across manually and change the names or you can use the commands below. **All commands are run from the govwifi-terraform root directory**
@@ -331,7 +331,7 @@ Once the task definitions for the above apps have been created by terraform, the
 - First apply your task definition change.
 - Remove the "ignore_task" attribute for the service you are modifying. For example if you were changing the admin task [you would remove the task_definition element in this array](https://github.com/alphagov/govwifi-terraform/blob/5482ac674b74b946b66040e158101bd4aa703a44/govwifi-admin/cluster.tf#L207). For example change the line so it reads `ignore_changes = [tags_all, task_definition]`)  
 - Using terraform destroy pipeline for the particular application you are changing the task definition for. For example, if you were changing the task definition for the admin pipeline, [comment out this entire file](https://github.com/alphagov/govwifi-terraform/blob/5482ac674b74b946b66040e158101bd4aa703a44/govwifi-deploy/alpaca-codepipeline-admin.tf). 
-  - Run terraform the govwifi tools account with `gds aws govwifi-tools -- make govwifi-tools apply`
+  - Run terraform the govwifi tools account with `gds-cli aws govwifi-tools -- make govwifi-tools apply`
 - Recreate the pipeline  using terraform 
   - Uncomment previously commented lines
 	- Run terraform in tools again

--- a/README.md
+++ b/README.md
@@ -210,12 +210,17 @@ gds-cli aws govwifi-staging -- aws s3api create-bucket --bucket govwifi-staging-
 ```
 
 ### Setting Up Remote State
-We use remote state, but there is a chicken and egg problem of creating a state bucket in which to store the remote state. When you are first creating a new environment (or migrating an environment not using remote state to use remote state) you will need to do the following
+We use remote state, but there is a chicken and egg problem of creating a state bucket in which to store the remote state. When you are first creating a new environment (or migrating an environment not using remote state to use remote state) you will need to run the following commands. Anywhere you see the `<ENV>` replace this with the name of your environment e.g. `staging`.
 
 #### Manually Create S3 State Bucket 
 
 ```
 gds-cli aws <ENV> -- aws s3api create-bucket --bucket govwifi-<ENV>-tfstate-eu-west-2 --region eu-west-2 --create-bucket-configuration LocationConstraint=eu-west-2
+```
+For example:
+
+```
+gds-cli aws govwifi-staging -- aws s3api create-bucket --bucket govwifi-staging-tfstate-eu-west-2 --region eu-west-2 --create-bucket-configuration LocationConstraint=eu-west-2
 ```
 
 #### Initialize The Backend

--- a/README.md
+++ b/README.md
@@ -255,6 +255,15 @@ After you have finished terraforming follow the manual steps below to complete t
 
 ### Manual Steps Needed to Set Up a New Environment
 
+#### DNS Setup
+- Create a hosted zone in your new environment in the following format `<your_new_env>.wifi.service.gov.uk` (for example `foobar.wifi.service.gov.uk` )
+- Copy the NS records for the newly created hosted zone.
+- Log into the GovWifi Production AWS account `gds aws govwifi -l`
+- In the production account in Route53 go to the `wifi.service.gov.uk` hosted zone.
+- Add a NS record for your new environment with the copied NS records. 
+- Validate DNS delegation is complete:
+  - Verify DNS delegation is complete ` dig -t NS <your_env>.wifi.service.gov.uk`  The result should match the your new environments NS records.
+
 #### Add DKIM Authentication
 Ensure you are in the eu-west-1 region (Ireland) and follow the instructions here(https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim-easy-setup-domain.html) to verify your new subdomain (e.g. staging.wifi.service.gov.uk)
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,16 @@ for filename in ./govwifi-deploy/*your-env-name* ; do mv $filename ${filename/yo
 
 ##### Updating Other Pipeline files:
 
-You will also need to add 
+You will also need to do the following in the tools account: 
+
+- Add the new environment's account number to AWS Secrets Manager, and then add it to terraform, [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-d94ff418330c275e25ef2b45b9d7d2dd4a9ef3720db62dd38073bd72773562d4). 
+- Add your new AWS account ID as a local variable in the govwifi-deploy module, [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-80629d600c5574b9e7d4dc7ba991ce39068d32cabd1046130d5e8e4827460f77). 
+- An ECR repository for your new environment,  [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-62eed9657e3fa19b6a5801b47b549ab70711b54c5997c50fb90a395653cccf9d).
+- Give the GovWifi Tools account permission to deploy things in your new environment
+  - Add appropriate S3 access: [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-d94ff418330c275e25ef2b45b9d7d2dd4a9ef3720db62dd38073bd72773562d4).
+  - Add appropriate codepipeline permissions [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-02cf364873b2fce26391e6e2b6d9ed222ce8e8f23f7d745e5c8024b02a932389).
+  - Allow your new environment to access the KMS keys used by Codepipeline [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-8a01e39d3fd4d4d2ee124f9f0c45495bb36677f5384040c59ff023b3f517032d).
+  
 
 
 ## Rotating ELB Certificates

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ For historical use of secrets please see: [GovWifi build](https://github.com/alp
 Initialise terraform if running for the first time:
 
 ```
-make <ENV> init-backend
-make <ENV> plan
+gds aws <ENV> -- make <ENV> init-backend
+gds aws <ENV> -- make <ENV> plan
 ```
 
 Example ENVs are: `wifi`, `wifi-london` and `staging`.
@@ -54,8 +54,8 @@ Example ENVs are: `wifi`, `wifi-london` and `staging`.
 ## Running terraform
 
 ```
-make <ENV> plan
-make <ENV> apply
+gds aws <ENV> -- make <ENV> plan
+gds aws <ENV> -- make <ENV> apply
 ```
 
 ### Running terraform target
@@ -67,7 +67,7 @@ We've incorporated this functionality into our `make` commands. **Note**: this s
 To retrieve a module name, run a `terraform plan` and copy the module name (EXCLUDING "module.") from the Terraform output:
 
 ```bash
-$ make staging plan
+$ gds aws <ENV> -- make staging plan
 ...
 
 An execution plan has been generated and is shown below.
@@ -85,14 +85,14 @@ In this case, the module name would be `api.aws_iam_role_policy.some_policy`
 To `plan`/`apply` a specific resource use the standard `make <ENV> plan | apply` followed by a space separated list of one or more modules:
 
 ```
-$ make <ENV> plan modules="backend.some.resource api.some.resource"
-$ make <ENV> apply modules="frontend.some.resource"
+$ gds aws <ENV> -- make <ENV> plan modules="backend.some.resource api.some.resource"
+$ gds aws <ENV> -- make <ENV> apply modules="frontend.some.resource"
 ```
 
 If combining other Terraform commands (e.g., `-var` or `-replace`) with targeting a resource, use the `terraform_target` command:
 
 ```bash
-$ make <ENV> terraform_target terraform_cmd="<plan | apply> -replace <your command>"
+$ gds aws <ENV> -- make <ENV> terraform_target terraform_cmd="<plan | apply> -replace <your command>"
 ```
 
 #### Deriving module names
@@ -184,6 +184,9 @@ This should then copy the state file to s3, which will be used for all operation
 
 ### Manual Steps Needed to Set Up a New Environment
 
+#### Add DKIM Authentication
+Ensure you are in the eu-west-1 region (Ireland) and follow the instructions here(https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim-easy-setup-domain.html) to verify your new subdomain (e.g. staging.wifi.service.gov.uk)
+
 #### Activate SES Rulesets
 The SES ruleset must be manually activated. 
 1. Login to the AWS console and ensure you are in the eu-west-1 region (Ireland).
@@ -191,8 +194,9 @@ The SES ruleset must be manually activated.
 1. Select  “GovWifiRuleSet” from the list
 1. Select the "Set as active" button
 
-#### Configure SES to Send Email
-Ensure you are in the eu-west-1 region (Ireland) and follow the instructions here(https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim-easy-setup-domain.html) to verify your new subdomain (e.g. staging.wifi.service.gov.uk)
+#### Setting Up The Deployment Pipelines
+
+
 
 ## Rotating ELB Certificates
 

--- a/README.md
+++ b/README.md
@@ -187,23 +187,6 @@ After this is done import them into terraform using the following command:
 make <environment-name> terraform terraform_cmd="import <name_of_terraform_resource> <ip_address>"
 ```
 
-#### Confirm SNS subscriptions
-At present confirming SNS subscriptions needs to be done manually. To do this follow the steps below:
-1. Ensure you have fully created the infrastructure for the [Logging API](https://github.com/alphagov/govwifi-logging-api).
-1. Ensure the Logging API app has been deployed to the new environment via our [CI/CD pipeline](https://docs.google.com/document/d/1ORrF2HwrqUu3tPswSlB0Duvbi3YHzvESwOqEY9-w6IQ/).
-1. Login to the AWS Console and navigate to the Cloudwatch section. Locate the User API logs.
-1. Search the logs for the word "SubscriptionConfirmation"
-1. The result will be a long string which begins similarly to:
-```
-{
-  "Type" : "SubscriptionConfirmation",
-  "MessageId" : "165545c9-2a5c-472c-8df2-7ff2be2b3b1b",
-  "Token" : "2336412f37...",
-```
-1. Copy the value for `Token`
-1. Go to SNS, select the subscription you need to confirm, select the "Confirm Subscription" button and paste the token into the input field.
-1. You can find detailed information about this process in [AWS's documentation](https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html).
-
 #### Configure SES Rulesets
 Terraform currently does not provide a way to do this for us.
 1. Login to the AWS console and ensure you are in the eu-west-1 region (Ireland).

--- a/README.md
+++ b/README.md
@@ -172,21 +172,6 @@ This should then copy the state file to s3, which will be used for all operation
 
 ### Manual Steps Needed to Set Up a New Environment
 
-#### Create RADIUS EIPs
-We currently need to create the Radius EIPs manually and then import them into terraform using the following command:
-```
-make <environment-name> terraform terraform_cmd="import module.frontend.aws_eip.radius_eips[0] <ip_address>"
-```
-Create six new EIPs (see here for more information [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html#using-instance-addressing-eips-allocating)). Three in the eu-west-1 region (Ireland) and three in the eu-west-2 (London) region. These values then need to be added to the govwifi-build repo under the `non-encrypted` directory for your environment (see [here](https://github.com/alphagov/govwifi-build/blob/21bf25b34ed12995b3246016b0193cf46e2c8d2d/non-encrypted/secrets-to-copy/govwifi/wifi-london/variables.auto.tfvars#L33-L37) for an example).
-
-#### Create Prometheus & Grafana EIPs
-Follow the process outlined above to create the Prometheus & Grafana EIPs manually. Create three new EIPs, one in the eu-west-1 region, two in the eu-west-2 region. These values then need to be added to the govwifi-build repo under the non-encrypted variables directory for your environment (see [here](https://github.com/alphagov/govwifi-build/blob/21bf25b34ed12995b3246016b0193cf46e2c8d2d/non-encrypted/secrets-to-copy/govwifi/staging-london-temp/variables.auto.tfvars#L29-L33) for an example).
-
-After this is done import them into terraform using the following command:
-```
-make <environment-name> terraform terraform_cmd="import <name_of_terraform_resource> <ip_address>"
-```
-
 #### Configure SES Rulesets
 Terraform currently does not provide a way to do this for us.
 1. Login to the AWS console and ensure you are in the eu-west-1 region (Ireland).

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ It should look like this, `module.backend.aws_instance.management`:
 Follow the steps below to create a brand new GovWifi environment:
 
 #### Duplicate & Rename All The Files Used For Our Staging Environment
-Edit, then run following command from the root of the govwifi-terraform directory to copy all the files you need for a new environment (replace `<NEW-ENV-NAME>` with the name of your new environment e.g. `foo`):
+Edit, then run the following command from the root of the govwifi-terraform directory to copy all the files you need for a new environment (replace `<NEW-ENV-NAME>` with the name of your new environment e.g. `foo`):
 
 
 ```
@@ -153,9 +153,14 @@ Do a search for `app_env` in the london.tf and dublin.f files for your new envir
 Also set the `user_db_name` variable in the london_admin module of the london.tf file for your environment to `govwifi_staging_users` [see here for an example commit](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-adf1083457d3aaad1753c8b333a2dbae1f1aff6f202d4b2390a983cef0389f88R189).
 
 
-Due to the way the GovWifi Ruby applications have been built the apps will expect to be running in one of 
+Due to the way the GovWifi Ruby applications have been built the apps will expect to be running in one of the following environments:
+- production
+- staging
+- development
 
-The APP_ENV environment variable for any new GovWifi environment should be set to `staging`, unless this is a real diaster recovery of production. The `dev` setting is only used when the app containers are run on a developers local machine.
+This is based on the way the Ruby configuration files are set up. You can see an example [here](https://github.com/alphagov/govwifi-admin/blob/1ed0271fcb800b228d9e421772f1983784777883/config/database.yml).
+
+The APP_ENV environment variable for any new GovWifi environment should be set to `staging`, unless this is a real diaster recovery of production (in which case set the APP_ENV to `production`). The `dev` setting is only used when the app containers are run on a developers' local machine.
 
 There is work planned to improve this process, and make the apps more environment agnostic.
 
@@ -321,10 +326,10 @@ Follow the instructions [here](https://govwifi-dev-docs.cloudapps.digital/infras
 ## Updating task definitions 
 
 This affects the following apps: 
-admin
-authentication-api
-user-api
-logging-api apps
+[admin](https://github.com/alphagov/govwifi-admin)
+[authentication-api](https://github.com/alphagov/govwifi-authentication-api)
+[user-api](https://github.com/alphagov/govwifi-user-signup-api)
+[logging-api](https://github.com/alphagov/govwifi-logging-api)
 
 Once the task definitions for the above apps have been created by terraform, they are then managed by Codepipeline.  When the pipelines run for the first time after their initial creation, they store a copy of the task definition for that application in memory. If you create a new version of a task definition, **Codepipeline will still use the previous one AND CONTINUE to deploy the old one**. To get Codepipeline to use new task definitions you need to recreate the  pipelines. This is a flaw on AWS's part. Instructions for a work around are below:
  

--- a/README.md
+++ b/README.md
@@ -123,7 +123,22 @@ It should look like this, `module.backend.aws_instance.management`:
 | module  | backend | aws_instance | management |
 
 ## Bootstrapping terraform
-You will need to run terraform in the **eu-west-2 (London) region** first. If you try to run terraform in the eu-west-1 region first, you will encounter errors because the Dublin Terraform looks up outputs from the London region statefile.
+
+### Prepare The AWS Environment
+If you are running terraform in a brand new AWS account, then you will need to ensure the following steps have been completed before terraform will execute without error.
+
+#### AWS Secret Manager
+Ensure all required secrets have been entered into AWS Secrets manager in region eu-west-2 of your of your new account ([replicate over any secrets needed by resources in eu-west-1](https://docs.aws.amazon.com/secretsmanager/latest/userguide/create-manage-multi-region-secrets.html)). The name of the credentials in Secrets Manager MUST match the names of the secrets that already exist in the code. 
+
+There is work planned to autogenerate the bulk of these secrets, however at present this is a manual process, which generally takes around 2 hours. You can look at the secrets in pre-existing environments for a guide. 
+
+#### Increase The Default AWS Quotas
+Terraform needs to create a larger number of resources than AWS allows out of the box. Luckily it is easy to get these limits increased. 
+- [Follow the instructions from AWS to request an increase](https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html).
+- Increase the quotas in your new account so they match the following
+  - Elastic IPs 22
+  - VPCs per Region 10
+
 
 ### Create The Access Logs S3 Bucket
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ It should look like this, `module.backend.aws_instance.management`:
 ## Bootstrapping terraform
 You will need to run terraform in the **eu-west-2 (London) region** first. If you try to run terraform in the eu-west-1 region first, you will encounter errors because the Dublin Terraform looks up outputs from the London region statefile.
 
+### Create The Access Logs S3 Bucket
+
+This holds information related to the terraform state, and must be created manually before the initial terraform run in a new environment. You will need to create two S3 buckets. One in eu-west-1 and one in eu-west-2. The bucket name must match this naming convention:
+
+`govwifi-<ENV>-<AWS-REGION-NAME>-accesslogs`
+
+An example command for creating the bucket in the Staging environment for the London region would be:
+
+```
+gds aws govwifi-staging -- aws s3api create-bucket --bucket govwifi-staging-london-accesslogs --region eu-west-2 
+```
+
 ### Setting Up Remote State
 We use remote state, but there is a chicken and egg problem of creating a state bucket in which to store the remote state. When you are first creating a new environment (or migrating an environment not using remote state to use remote state) you will need to do the following
 
@@ -145,12 +157,12 @@ The first time terraform is run in a new environment the replication configurati
 Now run
 
 ```
-make <ENV> plan
+gds aws <ENV> -- make <ENV> plan
 ```
 And then
 
 ```
-make <ENV> apply
+gds aws <ENV> -- make <ENV> apply
 ```
 
 This should create the remote state bucket for you if migrating, or create the
@@ -159,13 +171,13 @@ entire infrastructure with a local state file if creating a new env
 Then uncomment the backend section in main.tf and run
 
 ```
-make <ENV> init-backend
+gds aws <ENV> -- make <ENV> init-backend
 ```
 
 Then run
 
 ```
-make <ENV> apply
+gds aws <ENV> -- make <ENV> apply
 ```
 
 This should then copy the state file to s3, which will be used for all operations. Once you have run terraform in both regions, and the S3 buckets used for the access log replication have been created, uncomment the replication configuration sections in govwifi-terraform/terraform-state/accesslogs.tf and govwifi-terraform/terraform-state/tfstate.tf.

--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ There is work planned to autogenerate the bulk of these secrets, however at pres
 Terraform needs to create a larger number of resources than AWS allows out of the box. Luckily it is easy to get these limits increased. 
 - [Follow the instructions from AWS to request an increase](https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html).
 - Increase the quotas in your new account so they match the following
-  - Elastic IPs 22
-  - VPCs per Region 10
+  - **22** Elastic IPs
+  - **10** VPCs per Region
 
 #### Create The Access Logs S3 Bucket
 
@@ -213,7 +213,10 @@ gds-cli aws govwifi-staging -- aws s3api create-bucket --bucket govwifi-staging-
 We use remote state, but there is a chicken and egg problem of creating a state bucket in which to store the remote state. When you are first creating a new environment (or migrating an environment not using remote state to use remote state) you will need to do the following
 
 #### Manually Create S3 State Bucket 
+
+```
 gds-cli aws <ENV> -- aws s3api create-bucket --bucket govwifi-<ENV>-tfstate-eu-west-2 --region eu-west-2 --create-bucket-configuration LocationConstraint=eu-west-2
+```
 
 #### Initialize The Backend
 
@@ -222,8 +225,10 @@ gds-cli aws <ENV> -- make <ENV> init-backend
 ```
 
 #### Import S3 State bucket 
-gds-cli aws <ENV> -- make <ENV> terraform terraform_cmd="import module.tfstate.aws_s3_bucket.state_bucket govwifi-<env>-tfstate-eu-west-2"
 
+```
+gds-cli aws <ENV> -- make <ENV> terraform terraform_cmd="import module.tfstate.aws_s3_bucket.state_bucket govwifi-<env>-tfstate-eu-west-2"
+```
 
 Then comment out the lines related to replication configuration in govwifi-terraform/terraform-state/accesslogs.tf and govwifi-terraform/terraform-state/tfstate.tf.
 ```

--- a/README.md
+++ b/README.md
@@ -172,11 +172,12 @@ This should then copy the state file to s3, which will be used for all operation
 
 ### Manual Steps Needed to Set Up a New Environment
 
-#### Configure SES Rulesets
-Terraform currently does not provide a way to do this for us.
+#### Activate SES Rulesets
+The SES ruleset must be manually activated. 
 1. Login to the AWS console and ensure you are in the eu-west-1 region (Ireland).
 1. Go to the SES section and select "Email receiving”.
-1. Select “Create rule set” and enter the name “GovWifiRuleSet”.
+1. Select  “GovWifiRuleSet” from the list
+1. Select the "Set as active" button
 
 #### Configure SES to Send Email
 Ensure you are in the eu-west-1 region (Ireland) and follow the instructions here(https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim-easy-setup-domain.html) to verify your new subdomain (e.g. staging.wifi.service.gov.uk)

--- a/tools/pipeline-templates/codebuild-deployed-apps-your-env-name.tf
+++ b/tools/pipeline-templates/codebuild-deployed-apps-your-env-name.tf
@@ -1,0 +1,105 @@
+resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_your-env-name" {
+  for_each      = toset(var.deployed_app_names)
+  name          = "${each.key}-push-image-to-ecr-your-env-name"
+  description   = "This project builds the API docker images and pushes them to ECR ${each.key}"
+  build_timeout = "12"
+  service_role  = aws_iam_role.govwifi_codebuild.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  cache {
+    type     = "S3"
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID"
+      value = local.aws_account_id
+    }
+
+    environment_variable {
+      name  = "AWS_REGION"
+      value = "eu-west-2"
+    }
+
+    environment_variable {
+      name  = "STAGE"
+      value = "your-env-name"
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_AUTHTOKEN_ENV"
+      value = "/govwifi-cd/pipelines/main/docker_hub_authtoken"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_USERNAME_ENV"
+      value = "/govwifi-cd/pipelines/main/docker_hub_username"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "WORDLIST_BUCKET_NAME"
+      value = "/govwifi-cd/pipelines/main/wordlist_bucket_name"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "ACCEPTANCE_TESTS_PROJECT_NAME"
+      value = "acceptance-tests"
+    }
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "govwifi-codebuild-push-image-to-ecr-log-group"
+      stream_name = "govwifi-codebuild-push-image-to-ecr-log-stream"
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${aws_s3_bucket.codepipeline_bucket.id}/build-log"
+    }
+  }
+
+  source_version = "master"
+
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/alphagov/govwifi-${each.key}.git"
+    git_clone_depth = 1
+    buildspec       = "buildspec.yml"
+  }
+}
+
+resource "aws_codebuild_webhook" "govwifi_app_webhook_your-env-name" {
+  for_each = toset(var.deployed_app_names)
+
+  project_name = aws_codebuild_project.govwifi_codebuild_project_push_image_to_ecr_your-env-name[each.key].name
+
+  build_type = "BUILD"
+
+  filter_group {
+    filter {
+      type    = "EVENT"
+      pattern = "PULL_REQUEST_MERGED"
+    }
+
+    ### To test a branch without needing to raise a PR, uncomment the below and change source to the name of your branch
+    # filter {
+    #   type    = "HEAD_REF"
+    #   pattern = "^refs/heads/buildspec-global-ecr$"
+    # }
+  }
+}

--- a/tools/pipeline-templates/your-env-name-codebuild-built-apps.tf
+++ b/tools/pipeline-templates/your-env-name-codebuild-built-apps.tf
@@ -1,0 +1,63 @@
+resource "aws_codebuild_project" "your-env-name_govwifi_codebuild_built_app" {
+  for_each       = toset(var.built_app_names)
+  name           = "${each.key}-push-docker-image-to-your-env-name-ECR"
+  description    = "This project builds the ${each.key} image and pushes it to ECR"
+  build_timeout  = "12"
+  service_role   = aws_iam_role.govwifi_codebuild.arn
+  encryption_key = aws_kms_key.codepipeline_key.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    environment_variable {
+      name  = "DOCKER_HUB_AUTHTOKEN_ENV"
+      value = data.aws_secretsmanager_secret_version.docker_hub_authtoken.secret_string
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_USERNAME_ENV"
+      value = data.aws_secretsmanager_secret_version.docker_hub_username.secret_string
+    }
+
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID"
+      value = local.aws_account_id
+    }
+
+    environment_variable {
+      name  = "STAGE"
+      value = "your-env-name"
+    }
+
+  }
+
+  source_version = "master"
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/alphagov/govwifi-${each.key}.git"
+    git_clone_depth = 1
+    buildspec       = "buildspec.yml"
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "govwifi-codebuild-${each.key}-group"
+      stream_name = "govwifi-codebuild-${each.key}-stream"
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${aws_s3_bucket.codepipeline_bucket.id}/${each.key}-log"
+    }
+  }
+
+}

--- a/tools/pipeline-templates/your-env-name-codepipeline-admin.tf
+++ b/tools/pipeline-templates/your-env-name-codepipeline-admin.tf
@@ -1,0 +1,105 @@
+resource "aws_codepipeline" "your-env-name_admin_pipeline" {
+  name     = "DEV-your-env-name-admin-pipeline"
+  role_arn = aws_iam_role.govwifi_codepipeline_global_role.arn
+
+  artifact_store {
+    region   = "eu-west-2"
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key.arn
+      type = "KMS"
+    }
+  }
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket_ireland.bucket
+    type     = "S3"
+    region   = "eu-west-1"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key_ireland.arn
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "NewECRImagDetectedFor-admin"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        RepositoryName = "govwifi/admin/your-env-name"
+      }
+    }
+  }
+
+  stage {
+    name = "admin-convert-imagedetail"
+
+    action {
+      name             = "admin-convert-imagedetail"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["SourceArtifact"]
+      output_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["admin"].name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy-to-your-env-name"
+
+    action {
+      name            = "Deploy-to-eu-west-2"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+      version         = "1"
+      # This resource lives in the your-env-name & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_your-env-name_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "your-env-name-admin-cluster"
+        ServiceName : "admin-your-env-name"
+      }
+    }
+
+  }
+
+  stage {
+    name = "your-env-name-Smoketests"
+
+    action {
+      name            = "your-env-name-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["govwifi-build-admin-convert-imagedetail-amended"]
+
+      # This resource lives in the your-env-name & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_your-env-name_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
+  }
+
+}

--- a/tools/pipeline-templates/your-env-name-codepipeline-authentication-api.tf
+++ b/tools/pipeline-templates/your-env-name-codepipeline-authentication-api.tf
@@ -1,0 +1,123 @@
+resource "aws_codepipeline" "your-env-name_authentication_api_pipeline" {
+  name     = "DEV-your-env-name-authentication-api-pipeline"
+  role_arn = aws_iam_role.govwifi_codepipeline_global_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+    region   = "eu-west-2"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key.arn
+      type = "KMS"
+    }
+  }
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket_ireland.bucket
+    type     = "S3"
+    region   = "eu-west-1"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key_ireland.arn
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "NewECRImagDetectedFor-authentication-api"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        RepositoryName = "govwifi/authentication-api/your-env-name"
+      }
+    }
+  }
+
+  stage {
+    name = "authentication-api-convert-imagedetail"
+
+    action {
+      name             = "authentication-api-convert-imagedetail"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["SourceArtifact"]
+      output_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["authentication-api"].name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy-to-your-env-name"
+
+    action {
+      name            = "Deploy-to-eu-west-2"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+      version         = "1"
+      region          = "eu-west-2"
+      # This resource lives in the your-env-name. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_your-env-name_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "your-env-name-api-cluster"
+        ServiceName : "authentication-api-service-your-env-name"
+      }
+    }
+
+    action {
+      name            = "Deploy-to-eu-west-1"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+      version         = "1"
+      region          = "eu-west-1"
+      # This resource lives in the your-env-name. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_your-env-name_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "your-env-name-api-cluster"
+        ServiceName : "authentication-api-service-your-env-name"
+      }
+    }
+  }
+
+  stage {
+    name = "your-env-name-Smoketests"
+
+    action {
+      name            = "your-env-name-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-authentication-api-convert-imagedetail-amended"]
+
+      # This resource lives in the your-env-name. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_your-env-name_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
+  }
+}

--- a/tools/pipeline-templates/your-env-name-codepipeline-logging-api.tf
+++ b/tools/pipeline-templates/your-env-name-codepipeline-logging-api.tf
@@ -1,0 +1,106 @@
+resource "aws_codepipeline" "your-env-name_logging_api_pipeline" {
+  name     = "DEV-your-env-name-logging-api-pipeline"
+  role_arn = aws_iam_role.govwifi_codepipeline_global_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+    region   = "eu-west-2"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key.arn
+      type = "KMS"
+    }
+  }
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket_ireland.bucket
+    type     = "S3"
+    region   = "eu-west-1"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key_ireland.arn
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "NewECRImagDetectedFor-logging-api"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        RepositoryName = "govwifi/logging-api/your-env-name"
+      }
+    }
+  }
+
+  stage {
+    name = "logging-api-convert-imagedetail"
+
+    action {
+      name             = "logging-api-convert-imagedetail"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["SourceArtifact"]
+      output_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["logging-api"].name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy-to-your-env-name"
+
+    action {
+      name            = "Deploy-to-eu-west-2"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
+      version         = "1"
+      region          = "eu-west-2"
+      # This resource lives in the your-env-name. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_your-env-name_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "your-env-name-api-cluster"
+        ServiceName : "logging-api-service-your-env-name"
+      }
+    }
+  }
+
+  stage {
+    name = "your-env-name-Smoketests"
+
+    action {
+      name            = "your-env-name-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-logging-api-convert-imagedetail-amended"]
+
+      # This resource lives in the your-env-name. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_your-env-name_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
+  }
+
+}

--- a/tools/pipeline-templates/your-env-name-codepipeline-user-signup-api.tf
+++ b/tools/pipeline-templates/your-env-name-codepipeline-user-signup-api.tf
@@ -1,0 +1,105 @@
+resource "aws_codepipeline" "your-env-name_user_signup_api_pipeline" {
+  name     = "DEV-your-env-name-user-signup-api-pipeline"
+  role_arn = aws_iam_role.govwifi_codepipeline_global_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+    region   = "eu-west-2"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key.arn
+      type = "KMS"
+    }
+  }
+
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket_ireland.bucket
+    type     = "S3"
+    region   = "eu-west-1"
+
+    encryption_key {
+      id   = aws_kms_key.codepipeline_key_ireland.arn
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "NewECRImagDetectedFor-user-signup-api"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["SourceArtifact"]
+
+      configuration = {
+        RepositoryName = "govwifi/user-signup-api/your-env-name"
+      }
+    }
+  }
+
+  stage {
+    name = "user-signup-api-convert-imagedetail"
+
+    action {
+      name             = "user-signup-api-convert-imagedetail"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["SourceArtifact"]
+      output_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.govwifi_codebuild_project_convert_image_format["user-signup-api"].name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy-to-Alpaca"
+
+    action {
+      name            = "Deploy-to-eu-west-2"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "ECS"
+      input_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
+      version         = "1"
+      region          = "eu-west-2"
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_your-env-name_account_id}:role/govwifi-crossaccount-tools-deploy"
+
+      configuration = {
+        ClusterName : "your-env-name-api-cluster"
+        ServiceName : "user-signup-api-service-your-env-name"
+      }
+    }
+  }
+
+  stage {
+    name = "Alpaca-Smoketests"
+
+    action {
+      name            = "Alpaca-Smoketests"
+      category        = "Test"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      region          = "eu-west-2"
+      input_artifacts = ["govwifi-build-user-signup-api-convert-imagedetail-amended"]
+
+      # This resource lives in the Staging & Production environments. It will always have to
+      # either be hardcoded or retrieved from the AWS secrets or parameter store
+      role_arn = "arn:aws:iam::${local.aws_your-env-name_account_id}:role/govwifi-codebuild-role"
+      version  = "1"
+
+      configuration = {
+        ProjectName = "govwifi-smoke-tests"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What
This now includes improved documentation on:
- Creating Terraform remote state files
- Setting up DNS
- Setting up pipelines
- Setting up secrets 
- Preparing an AWS account for terraforming a GovWifi environment

### Why
Whilst conducting a DR (Disaster Recovery) exercise, we discovered that many parts of the documentation were outdated.

Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-755
