### PR TITLE
Add Acceptance Tests To Frontend Build Process

### DIFF
--- a/govwifi-deploy/codebuild-built-apps-production.tf
+++ b/govwifi-deploy/codebuild-built-apps-production.tf
@@ -33,6 +33,11 @@ resource "aws_codebuild_project" "govwifi_codebuild_built_app_production" {
     }
 
     environment_variable {
+      name  = "ACCEPTANCE_TESTS_PROJECT_NAME"
+      value = aws_codebuild_project.govwifi_codebuild_acceptance_tests.name
+    }
+
+    environment_variable {
       name  = "STAGE"
       value = "production"
     }

--- a/govwifi-deploy/codebuild-built-apps-staging.tf
+++ b/govwifi-deploy/codebuild-built-apps-staging.tf
@@ -33,6 +33,11 @@ resource "aws_codebuild_project" "govwifi_codebuild_built_app" {
     }
 
     environment_variable {
+      name  = "ACCEPTANCE_TESTS_PROJECT_NAME"
+      value = aws_codebuild_project.govwifi_codebuild_acceptance_tests.name
+    }
+
+    environment_variable {
       name  = "STAGE"
       value = "staging"
     }


### PR DESCRIPTION
### What
Add Acceptance Tests To Frontend Build Process

### Why
These appear to have been missed in the original migration. Correcting this error.

The frontend acceptance tests are an important part of our testing suite, they check any changes to the [frontend
app](https://github.com/alphagov/govwifi-frontend/) will not break the service.


Link to Trello card (if applicable): 
