### PR TITLE
Update codebuild build image to v6.0

### DIFF
--- a/govwifi-deploy/alpaca-codebuild-built-apps.tf
+++ b/govwifi-deploy/alpaca-codebuild-built-apps.tf
@@ -12,7 +12,7 @@ resource "aws_codebuild_project" "alpaca_govwifi_codebuild_built_app" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:6.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true

--- a/govwifi-deploy/codebuild-acceptance-tests.tf
+++ b/govwifi-deploy/codebuild-acceptance-tests.tf
@@ -11,7 +11,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_acceptance_tests" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:6.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true

--- a/govwifi-deploy/codebuild-built-apps-production.tf
+++ b/govwifi-deploy/codebuild-built-apps-production.tf
@@ -12,7 +12,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_built_app_production" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:6.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true

--- a/govwifi-deploy/codebuild-built-apps-staging.tf
+++ b/govwifi-deploy/codebuild-built-apps-staging.tf
@@ -12,7 +12,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_built_app" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:6.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true

--- a/govwifi-deploy/codebuild-convert-image.tf
+++ b/govwifi-deploy/codebuild-convert-image.tf
@@ -17,7 +17,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_convert_image_format
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:6.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true

--- a/govwifi-deploy/codebuild-deployed-apps-alpaca.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-alpaca.tf
@@ -16,7 +16,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_al
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:6.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true

--- a/govwifi-deploy/codebuild-deployed-apps-staging.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-staging.tf
@@ -16,7 +16,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_st
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:6.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true

--- a/tools/pipeline-templates/codebuild-deployed-apps-your-env-name.tf
+++ b/tools/pipeline-templates/codebuild-deployed-apps-your-env-name.tf
@@ -16,7 +16,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_yo
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:6.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true

--- a/tools/pipeline-templates/your-env-name-codebuild-built-apps.tf
+++ b/tools/pipeline-templates/your-env-name-codebuild-built-apps.tf
@@ -12,7 +12,7 @@ resource "aws_codebuild_project" "your-env-name_govwifi_codebuild_built_app" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:6.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true


### PR DESCRIPTION
### What
Update the image used by AWS codebuild from 5.0 to 6.0

### Why
AWS will stop maintaining 5.0 at the end of March. This date has since been postponed but it is sensible to continue this work because it will have to be done soon regardless and the preparation had taken place.

### Testing
This has been deployed and tested in AWS Tools. However, it could be retested by terraforming AWS Tools back to a branch prior to the merge of this PR. Then terraform including this PR. Test some of the codebuild projects for successful completion.

### Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-789