### PR TITLE
increase timeout to 20 mins to cover acceptance tests

### DIFF
--- a/govwifi-deploy/codebuild-built-apps-production.tf
+++ b/govwifi-deploy/codebuild-built-apps-production.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_built_app_production" {
   for_each       = toset(var.built_app_names)
   name           = "${each.key}-push-docker-image-to-production-ECR"
   description    = "This project builds the ${each.key} production image and pushes it to ECR."
-  build_timeout  = "12"
+  build_timeout  = "20"
   service_role   = aws_iam_role.govwifi_codebuild.arn
   encryption_key = aws_kms_key.codepipeline_key.arn
 

--- a/govwifi-deploy/codebuild-built-apps-staging.tf
+++ b/govwifi-deploy/codebuild-built-apps-staging.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_built_app" {
   for_each       = toset(var.built_app_names)
   name           = "${each.key}-push-docker-image-to-staging-ECR"
   description    = "This project builds the ${each.key} image and pushes it to ECR"
-  build_timeout  = "12"
+  build_timeout  = "20"
   service_role   = aws_iam_role.govwifi_codebuild.arn
   encryption_key = aws_kms_key.codepipeline_key.arn
 

--- a/govwifi-deploy/codebuild-deployed-apps-alpaca.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-alpaca.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_al
   for_each      = toset(var.deployed_app_names)
   name          = "${each.key}-push-image-to-ecr-alpaca"
   description   = "This project builds the API docker images and pushes them to ECR ${each.key}"
-  build_timeout = "12"
+  build_timeout = "20"
   service_role  = aws_iam_role.govwifi_codebuild.arn
 
   artifacts {

--- a/govwifi-deploy/codebuild-deployed-apps-production.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-production.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_pr
   for_each      = toset(var.deployed_app_names)
   name          = "${each.key}-push-image-to-ecr-production"
   description   = "This project builds the API docker images and pushes them to ECR ${each.key}"
-  build_timeout = "12"
+  build_timeout = "20"
   service_role  = aws_iam_role.govwifi_codebuild.arn
 
   artifacts {

--- a/govwifi-deploy/codebuild-deployed-apps-staging.tf
+++ b/govwifi-deploy/codebuild-deployed-apps-staging.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_push_image_to_ecr_st
   for_each      = toset(var.deployed_app_names)
   name          = "${each.key}-push-image-to-ecr-staging"
   description   = "This project builds the API docker images and pushes them to ECR ${each.key}"
-  build_timeout = "12"
+  build_timeout = "20"
   service_role  = aws_iam_role.govwifi_codebuild.arn
 
   artifacts {

--- a/tools/pipeline-templates/your-env-name-codebuild-built-apps.tf
+++ b/tools/pipeline-templates/your-env-name-codebuild-built-apps.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "your-env-name_govwifi_codebuild_built_app" {
   for_each       = toset(var.built_app_names)
   name           = "${each.key}-push-docker-image-to-your-env-name-ECR"
   description    = "This project builds the ${each.key} image and pushes it to ECR"
-  build_timeout  = "12"
+  build_timeout  = "20"
   service_role   = aws_iam_role.govwifi_codebuild.arn
   encryption_key = aws_kms_key.codepipeline_key.arn
 


### PR DESCRIPTION
### What
Increase the timeout for AWS codebuild apps from 12m to 20m

### Why
Acceptance tests taking 8-9 mins so the build task is aborting after 12m. Testing showed the build completes successfully given a few extra mins.


Link to Trello card (if applicable): n/a

### Testing
Testing carried out with 12mins and 20mins. To replicate, change the timeout value and terraform, run the job and note the results.
