### PR TITLE
Update AMI For Prometheus & Grafana

### DIFF
--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -3,7 +3,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210315"]
+    values = ["ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-20230324.1"]
   }
 
   filter {

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -3,7 +3,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210315"]
+    values = ["ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-20230324.1"]
   }
 
   filter {


### PR DESCRIPTION
### What
Update AMI For Prometheus & Grafana

### Why
AWS has removed the old one from it's catalogue and it is no longer available for use. This commit replaces the AMI with the closest alternative. There is work in the schedule to eventually replace these instances with ECS containers.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-832
