### PR TITLE
Fix Error Caused by Slack Alert URL Secret

### DIFF
--- a/govwifi-smoke-tests/lambda.tf
+++ b/govwifi-smoke-tests/lambda.tf
@@ -11,7 +11,7 @@ resource "aws_lambda_function" "slack_alert" {
 
   environment {
     variables = {
-      URL = data.aws_secretsmanager_secret_version.slack_alert_url.secret_string
+      URL = data.aws_secretsmanager_secret_version.slack_alert_url[0].secret_string
     }
   }
 

--- a/govwifi-smoke-tests/secrets-manager.tf
+++ b/govwifi-smoke-tests/secrets-manager.tf
@@ -23,10 +23,12 @@ data "aws_secretsmanager_secret" "gw_user" {
 }
 
 data "aws_secretsmanager_secret_version" "slack_alert_url" {
-  secret_id = data.aws_secretsmanager_secret.slack_alert_url.id
+  count = (var.create_slack_alert == 1 ? 1 : 0)
+  secret_id = data.aws_secretsmanager_secret.slack_alert_url[0].id
 }
 
 data "aws_secretsmanager_secret" "slack_alert_url" {
+  count = (var.create_slack_alert == 1 ? 1 : 0)
   name = "smoketests/slack-alert-url"
 }
 


### PR DESCRIPTION
### What
Fix Error Caused by Slack Alert URL Secret

### Why
The slack-alert-url secret should only be created in production. This commit adds a conditional to implement that.

