### PR TITLE
Add Automatic Snapshot Volume Backups for Prometheus and Grafana

### DIFF
--- a/govwifi-grafana/dlm.tf
+++ b/govwifi-grafana/dlm.tf
@@ -1,0 +1,68 @@
+
+resource "aws_dlm_lifecycle_policy" "grafana_ebs_volume_backup" {
+  description        = "Grafana EBS DLM lifecycle policy"
+  execution_role_arn = "arn:aws:iam::${var.aws_account_id}:role/grafana-dlm-lifecycle-role"
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    schedule {
+      name = "Grafana EBS Volume"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = ["04:00"]
+      }
+
+      retain_rule {
+        count = 7
+      }
+
+      tags_to_add = {
+        SnapshotCreator = "DLM"
+      }
+
+      copy_tags = false
+    }
+
+    target_tags = {
+      Name = "${var.env_name} Grafana volume"
+    }
+  }
+}
+
+resource "aws_dlm_lifecycle_policy" "grafana_root_volume_backup" {
+  description        = "Grafana Root DLM lifecycle policy"
+  execution_role_arn = "arn:aws:iam::${var.aws_account_id}:role/grafana-dlm-lifecycle-role"
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    schedule {
+      name = "Grafana Root Volume"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = ["04:00"]
+      }
+
+      retain_rule {
+        count = 7
+      }
+
+      tags_to_add = {
+        SnapshotCreator = "DLM"
+      }
+
+      copy_tags = false
+    }
+
+    target_tags = {
+      Name = "${var.env_name} Grafana Root Volume"
+    }
+  }
+}

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -48,6 +48,12 @@ resource "aws_instance" "grafana_instance" {
     Name = "${title(var.env_name)} Grafana-Server"
   }
 
+  root_block_device {
+    tags = {
+      Name = "${title(var.env_name)} Grafana Root Volume"
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
 

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -76,3 +76,6 @@ variable "critical_notifications_arn" {
   description = "Arn of the critical-nofications sns topic"
   type        = string
 }
+
+variable "aws_account_id" {
+}

--- a/govwifi-prometheus/dlm.tf
+++ b/govwifi-prometheus/dlm.tf
@@ -1,0 +1,74 @@
+resource "aws_iam_policy_attachment" "prometheus_dlm_lifecycle" {
+  count      = (var.aws_region == "eu-west-2" ? 1 : 0)
+  name       = aws_iam_policy.prometheus_dlm_lifecycle[0].name
+  roles      = [aws_iam_role.dlm_prometheus_lifecycle_role[0].name]
+  policy_arn = aws_iam_policy.prometheus_dlm_lifecycle[0].arn
+}
+
+resource "aws_dlm_lifecycle_policy" "prometheus_ebs_volume_backup" {
+  description        = "Prometheus EBS DLM lifecycle policy"
+  execution_role_arn = "arn:aws:iam::${var.aws_account_id}:role/prometheus-dlm-lifecycle-role"
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    schedule {
+      name = "Prometheus EBS Volume"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = ["04:00"]
+      }
+
+      retain_rule {
+        count = 7
+      }
+
+      tags_to_add = {
+        SnapshotCreator = "DLM"
+      }
+
+      copy_tags = false
+    }
+
+    target_tags = {
+      Name = "${var.env_name} Prometheus volume"
+    }
+  }
+}
+
+resource "aws_dlm_lifecycle_policy" "prometheus_root_volume_backup" {
+  description        = "Prometheus Root DLM lifecycle policy"
+  execution_role_arn = "arn:aws:iam::${var.aws_account_id}:role/prometheus-dlm-lifecycle-role"
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    schedule {
+      name = "Prometheus Root Volume"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = ["04:00"]
+      }
+
+      retain_rule {
+        count = 7
+      }
+
+      tags_to_add = {
+        SnapshotCreator = "DLM"
+      }
+
+      copy_tags = false
+    }
+
+    target_tags = {
+      Name = "${var.env_name} Prometheus Root Volume"
+    }
+  }
+}

--- a/govwifi-prometheus/iam-roles.tf
+++ b/govwifi-prometheus/iam-roles.tf
@@ -51,3 +51,54 @@ EOF
 
 }
 
+data "aws_iam_policy_document" "prometheus_assume_role" {
+  count = (var.aws_region == "eu-west-2" ? 1 : 0)
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["dlm.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "dlm_prometheus_lifecycle_role" {
+  count              = (var.aws_region == "eu-west-2" ? 1 : 0)
+  name               = "prometheus-dlm-lifecycle-role"
+  assume_role_policy = data.aws_iam_policy_document.prometheus_assume_role[0].json
+}
+
+data "aws_iam_policy_document" "prometheus_dlm_lifecycle" {
+  count = (var.aws_region == "eu-west-2" ? 1 : 0)
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateSnapshot",
+      "ec2:CreateSnapshots",
+      "ec2:DeleteSnapshot",
+      "ec2:DescribeInstances",
+      "ec2:DescribeVolumes",
+      "ec2:DescribeSnapshots",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["ec2:CreateTags"]
+    resources = ["arn:aws:ec2:*::snapshot/*"]
+  }
+}
+
+resource "aws_iam_policy" "prometheus_dlm_lifecycle" {
+  count  = (var.aws_region == "eu-west-2" ? 1 : 0)
+  name   = "PrometheusDLMlifecyclePolicy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.prometheus_dlm_lifecycle[0].json
+}
+

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -53,6 +53,13 @@ resource "aws_instance" "prometheus_instance" {
     Name = "${title(var.env_name)} Prometheus-Server"
   }
 
+  root_block_device {
+
+    tags = {
+      Name = "${title(var.env_name)} Prometheus Root Volume"
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
 

--- a/govwifi-prometheus/variables.tf
+++ b/govwifi-prometheus/variables.tf
@@ -33,3 +33,9 @@ variable "dublin_radius_ip_addresses" {
   default = []
 }
 
+variable "aws_region" {
+}
+
+variable "aws_account_id" {
+}
+

--- a/govwifi-smoke-tests/secrets-manager.tf
+++ b/govwifi-smoke-tests/secrets-manager.tf
@@ -23,13 +23,13 @@ data "aws_secretsmanager_secret" "gw_user" {
 }
 
 data "aws_secretsmanager_secret_version" "slack_alert_url" {
-  count = (var.create_slack_alert == 1 ? 1 : 0)
+  count     = (var.create_slack_alert == 1 ? 1 : 0)
   secret_id = data.aws_secretsmanager_secret.slack_alert_url[0].id
 }
 
 data "aws_secretsmanager_secret" "slack_alert_url" {
   count = (var.create_slack_alert == 1 ? 1 : 0)
-  name = "smoketests/slack-alert-url"
+  name  = "smoketests/slack-alert-url"
 }
 
 

--- a/govwifi/alpaca/dublin.tf
+++ b/govwifi/alpaca/dublin.tf
@@ -311,8 +311,10 @@ module "dublin_prometheus" {
     aws = aws.dublin
   }
 
-  source   = "../../govwifi-prometheus"
-  env_name = local.env_name
+  source         = "../../govwifi-prometheus"
+  env_name       = local.env_name
+  aws_region     = local.london_aws_region
+  aws_account_id = local.aws_account_id
 
   ssh_key_name = var.ssh_key_name
 

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -318,8 +318,10 @@ module "london_prometheus" {
     aws = aws.london
   }
 
-  source   = "../../govwifi-prometheus"
-  env_name = local.env_name
+  source         = "../../govwifi-prometheus"
+  env_name       = local.env_name
+  aws_region     = local.london_aws_region
+  aws_account_id = local.aws_account_id
 
   ssh_key_name = var.ssh_key_name
 
@@ -343,6 +345,7 @@ module "london_grafana" {
   env_name                   = local.env_name
   env_subdomain              = local.env_subdomain
   aws_region                 = local.london_aws_region
+  aws_account_id             = local.aws_account_id
   critical_notifications_arn = module.london_notifications.topic_arn
 
   route53_zone_id = data.aws_route53_zone.main.zone_id

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -311,8 +311,10 @@ module "dublin_prometheus" {
     aws = aws.dublin
   }
 
-  source   = "../../govwifi-prometheus"
-  env_name = local.env_name
+  source         = "../../govwifi-prometheus"
+  env_name       = local.env_name
+  aws_region     = local.dublin_aws_region
+  aws_account_id = local.aws_account_id
 
   ssh_key_name = var.ssh_key_name
 

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -318,8 +318,11 @@ module "london_prometheus" {
     aws = aws.london
   }
 
-  source   = "../../govwifi-prometheus"
-  env_name = local.env_name
+  source         = "../../govwifi-prometheus"
+  env_name       = local.env_name
+  aws_region     = local.london_aws_region
+  aws_account_id = local.aws_account_id
+
 
   ssh_key_name = var.ssh_key_name
 
@@ -362,6 +365,7 @@ module "london_grafana" {
     module.london_prometheus.eip_public_ip,
     module.dublin_prometheus.eip_public_ip
   ]
+  aws_account_id = local.aws_account_id
 
 }
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -429,6 +429,10 @@ module "govwifi_prometheus" {
 
   fe_admin_in = module.frontend.fe_admin_in
 
+  aws_region = var.aws_region
+
+  aws_account_id = local.aws_account_id
+
   wifi_frontend_subnet       = module.frontend.frontend_subnet_id
   london_radius_ip_addresses = var.london_radius_ip_addresses
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
@@ -445,6 +449,7 @@ module "govwifi_grafana" {
   env_name                   = local.env_name
   env_subdomain              = local.env_subdomain
   aws_region                 = var.aws_region
+  aws_account_id             = local.aws_account_id
   critical_notifications_arn = module.critical_notifications.topic_arn
 
   route53_zone_id = data.aws_route53_zone.main.zone_id

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -371,8 +371,10 @@ module "govwifi_prometheus" {
     aws = aws.main
   }
 
-  source   = "../../govwifi-prometheus"
-  env_name = local.env_name
+  source         = "../../govwifi-prometheus"
+  env_name       = local.env_name
+  aws_region     = var.aws_region
+  aws_account_id = local.aws_account_id
 
   ssh_key_name = var.ssh_key_name
 


### PR DESCRIPTION
### What

Add Automatic Snapshot Volume Backups for Prometheus and Grafana. This enables the data for Prometheus, and the Grafana configuration to be recovered if the volumes or instances are deleted. The snapshots are created and managed using Amazon Data Lifecycle Manager, which incurs no extra cost (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html).

### Why

It is best practice to have a backup of our data

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-858