### PR TITLE
Add variables to allow the smoke tests to test the sms journey [do not merge yet]

### DIFF
--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -50,7 +50,6 @@ resource "aws_codebuild_project" "smoke_tests" {
       value = data.aws_secretsmanager_secret_version.google_api_token_data.secret_string
     }
 
-
     environment_variable {
       name  = "RADIUS_KEY"
       value = data.aws_secretsmanager_secret_version.radius_key.secret_string
@@ -66,6 +65,60 @@ resource "aws_codebuild_project" "smoke_tests" {
       value = var.env_subdomain
     }
 
+    environment_variable {
+      name  = "GOVWIFI_PHONE_NUMBER"
+      value = var.govwifi_phone_number
+    }
+
+    environment_variable {
+      name  = "NOTIFY_GO_TEMPLATE_ID"
+      value = local.notify_go_template_id
+    }
+
+    environment_variable {
+      name  = "NOTIFY_SMOKETEST_API_KEY"
+      value = data.aws_secretsmanager_secret_version.notify_smoketest_api_key.secret_string
+    }
+
+    environment_variable {
+      name  = "SESSION_DB_PASSWORD"
+      value = jsondecode(data.aws_secretsmanager_secret_version.session_db.secret_string)["password"]
+    }
+
+    environment_variable {
+      name  = "SESSION_DB_USERNAME"
+      value = jsondecode(data.aws_secretsmanager_secret_version.session_db.secret_string)["username"]
+    }
+
+    environment_variable {
+      name  = "SESSION_DB_NAME"
+      value = "govwifi_${var.env}"
+    }
+
+    environment_variable {
+      name  = "SESSION_DB_HOST"
+      value = var.db_hostname
+    }
+
+    environment_variable {
+      name  = "USER_DB_PASSWORD"
+      value = jsondecode(data.aws_secretsmanager_secret_version.users_db.secret_string)["password"]
+    }
+
+    environment_variable {
+      name  = "USER_DB_USERNAME"
+      value = jsondecode(data.aws_secretsmanager_secret_version.users_db.secret_string)["username"]
+    }
+
+    environment_variable {
+      name  = "USER_DB_NAME"
+      value = "govwifi_${var.env}_users"
+    }
+
+    environment_variable {
+      name  = "USER_DB_HOST"
+      value = var.user_db_hostname
+    }
   }
 
   source {

--- a/govwifi-smoke-tests/locals.tf
+++ b/govwifi-smoke-tests/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  notify_go_template_id = "ab004ebd-c74f-43e3-95bc-60c9bd325a83"
+}

--- a/govwifi-smoke-tests/secrets-manager.tf
+++ b/govwifi-smoke-tests/secrets-manager.tf
@@ -32,7 +32,13 @@ data "aws_secretsmanager_secret" "slack_alert_url" {
   name = "smoketests/slack-alert-url"
 }
 
+data "aws_secretsmanager_secret_version" "notify_smoketest_api_key" {
+  secret_id = data.aws_secretsmanager_secret.notify_smoketest_api_key.id
+}
 
+data "aws_secretsmanager_secret" "notify_smoketest_api_key" {
+  name = "smoketests/notify_smoketest_api_key"
+}
 
 data "aws_secretsmanager_secret_version" "gw_pass" {
   secret_id = data.aws_secretsmanager_secret.gw_pass.id
@@ -79,8 +85,6 @@ data "aws_secretsmanager_secret" "radius_key" {
   name = "deploy/radius_key"
 }
 
-
-
 data "aws_secretsmanager_secret_version" "radius_ips" {
   secret_id = data.aws_secretsmanager_secret.radius_ips.id
 }
@@ -103,4 +107,20 @@ data "aws_secretsmanager_secret_version" "tools_kms_key" {
 
 data "aws_secretsmanager_secret" "tools_kms_key" {
   name = "tools/codepipeline-kms-key-arn"
+}
+
+data "aws_secretsmanager_secret_version" "session_db" {
+  secret_id = data.aws_secretsmanager_secret.session_db.id
+}
+
+data "aws_secretsmanager_secret" "session_db" {
+  name = "rds/session-db/credentials"
+}
+
+data "aws_secretsmanager_secret_version" "users_db" {
+  secret_id = data.aws_secretsmanager_secret.users_db.id
+}
+
+data "aws_secretsmanager_secret" "users_db" {
+  name = "rds/users-db/credentials"
 }

--- a/govwifi-smoke-tests/variables.tf
+++ b/govwifi-smoke-tests/variables.tf
@@ -27,3 +27,13 @@ variable "smoketest_subnet_public_b" {
 
 variable "create_slack_alert" {
 }
+
+variable "govwifi_phone_number" {
+}
+
+variable "db_hostname" {
+}
+
+variable "user_db_hostname" {
+}
+

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -389,6 +389,8 @@ module "london_smoke_tests" {
   source = "../../govwifi-smoke-tests"
 
   aws_account_id             = local.aws_account_id
+  db_hostname                = "db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
+  user_db_hostname           = "users-db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
   env_subdomain              = local.env_subdomain
   env                        = local.env_name
   smoketests_vpc_cidr        = var.smoketests_vpc_cidr
@@ -398,5 +400,5 @@ module "london_smoke_tests" {
   smoketest_subnet_public_b  = var.smoketest_subnet_public_b
   aws_region                 = local.london_aws_region
   create_slack_alert         = 0
-
+  govwifi_phone_number       = "+447860003687"
 }

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -389,6 +389,8 @@ module "london_smoke_tests" {
   source = "../../govwifi-smoke-tests"
 
   aws_account_id             = local.aws_account_id
+  db_hostname                = "db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
+  user_db_hostname           = "users-db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
   env_subdomain              = local.env_subdomain
   env                        = local.env_name
   smoketests_vpc_cidr        = var.smoketests_vpc_cidr
@@ -398,7 +400,7 @@ module "london_smoke_tests" {
   smoketest_subnet_public_b  = var.smoketest_subnet_public_b
   aws_region                 = local.london_aws_region
   create_slack_alert         = 0
-
+  govwifi_phone_number       = "+447537417039"
 }
 
 module "london_sync_certs" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -506,6 +506,8 @@ module "smoke_tests" {
   source = "../../govwifi-smoke-tests"
 
   aws_account_id             = local.aws_account_id
+  db_hostname                = "db.${lower(var.aws_region_name)}.${local.env_subdomain}.service.gov.uk"
+  user_db_hostname           = "users-db.${lower(var.aws_region_name)}.${local.env_subdomain}.service.gov.uk"
   env_subdomain              = local.env_subdomain
   env                        = local.env_name
   smoketests_vpc_cidr        = var.smoketests_vpc_cidr
@@ -515,7 +517,7 @@ module "smoke_tests" {
   smoketest_subnet_public_b  = var.smoketest_subnet_public_b
   aws_region                 = var.aws_region
   create_slack_alert         = 1
-
+  govwifi_phone_number       = "+447537417417"
 }
 
 module "govwifi-ecs-update-service" {


### PR DESCRIPTION
The Smoke Test repository will add tests to excersise the SMS journey. This requires a number of environment variables set.

These include a variables to access the Sessions database and the User Details database, which are necessary to clean the data before the tests are run

Jira: https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-845