### PR TITLE
Add super admin credentials for the smoke tests

### DIFF
--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -41,6 +41,22 @@ resource "aws_codebuild_project" "smoke_tests" {
     }
 
     environment_variable {
+      name  = "GW_SUPER_ADMIN_USER"
+      value = data.aws_secretsmanager_secret_version.gw_super_admin_user.secret_string
+    }
+
+    environment_variable {
+      name  = "GW_SUPER_ADMIN_PASS"
+      value = data.aws_secretsmanager_secret_version.gw_super_admin_pass.secret_string
+    }
+
+    environment_variable {
+      name  = "GW_SUPER_ADMIN_2FA_SECRET"
+      value = data.aws_secretsmanager_secret_version.gw_super_admin_2fa_secret.secret_string
+    }
+
+
+    environment_variable {
       name  = "GOOGLE_API_CREDENTIALS"
       value = data.aws_secretsmanager_secret_version.google_api_credentials.secret_string
     }

--- a/govwifi-smoke-tests/secrets-manager.tf
+++ b/govwifi-smoke-tests/secrets-manager.tf
@@ -14,14 +14,6 @@ data "aws_secretsmanager_secret" "docker_hub_username" {
   name = "deploy/docker_hub_username"
 }
 
-data "aws_secretsmanager_secret_version" "gw_user" {
-  secret_id = data.aws_secretsmanager_secret.gw_user.id
-}
-
-data "aws_secretsmanager_secret" "gw_user" {
-  name = "deploy/gw_user"
-}
-
 data "aws_secretsmanager_secret_version" "slack_alert_url" {
   count     = (var.create_slack_alert == 1 ? 1 : 0)
   secret_id = data.aws_secretsmanager_secret.slack_alert_url[0].id
@@ -32,7 +24,13 @@ data "aws_secretsmanager_secret" "slack_alert_url" {
   name  = "smoketests/slack-alert-url"
 }
 
+data "aws_secretsmanager_secret_version" "gw_user" {
+  secret_id = data.aws_secretsmanager_secret.gw_user.id
+}
 
+data "aws_secretsmanager_secret" "gw_user" {
+  name = "deploy/gw_user"
+}
 
 data "aws_secretsmanager_secret_version" "gw_pass" {
   secret_id = data.aws_secretsmanager_secret.gw_pass.id
@@ -42,13 +40,36 @@ data "aws_secretsmanager_secret" "gw_pass" {
   name = "deploy/gw_pass"
 }
 
-
 data "aws_secretsmanager_secret_version" "gw_2fa_secret" {
   secret_id = data.aws_secretsmanager_secret.gw_2fa_secret.id
 }
 
 data "aws_secretsmanager_secret" "gw_2fa_secret" {
   name = "deploy/gw_2fa_secret"
+}
+
+data "aws_secretsmanager_secret_version" "gw_super_admin_user" {
+  secret_id = data.aws_secretsmanager_secret.gw_super_admin_user.id
+}
+
+data "aws_secretsmanager_secret" "gw_super_admin_user" {
+  name = "deploy/gw_super_admin_user"
+}
+
+data "aws_secretsmanager_secret_version" "gw_super_admin_pass" {
+  secret_id = data.aws_secretsmanager_secret.gw_super_admin_pass.id
+}
+
+data "aws_secretsmanager_secret" "gw_super_admin_pass" {
+  name = "deploy/gw_super_admin_pass"
+}
+
+data "aws_secretsmanager_secret_version" "gw_super_admin_2fa_secret" {
+  secret_id = data.aws_secretsmanager_secret.gw_super_admin_2fa_secret.id
+}
+
+data "aws_secretsmanager_secret" "gw_super_admin_2fa_secret" {
+  name = "deploy/gw_super_admin_2fa_secret"
 }
 
 


### PR DESCRIPTION
### What
Add credentials for a GovWifi smoke test admin user

### Why
The smoke tests need the ability to remove GovWifi end users, which requires super admin credentials. The credentials are 
securely stored in the secrets manager and passed to the smoke tests as environment variables

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-845