### PR TITLE
Add variables to enable the SMS Signup Journey smoke tests.

### DIFF
--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -82,6 +82,25 @@ resource "aws_codebuild_project" "smoke_tests" {
       value = var.env_subdomain
     }
 
+    environment_variable {
+      name  = "GOVWIFI_PHONE_NUMBER"
+      value = var.govwifi_phone_number
+    }
+
+    environment_variable {
+      name = "SMOKETEST_PHONE_NUMBER"
+      value = local.smoketest_phone_number
+    }
+
+    environment_variable {
+      name  = "NOTIFY_GO_TEMPLATE_ID"
+      value = local.notify_go_template_id
+    }
+
+    environment_variable {
+      name  = "NOTIFY_SMOKETEST_API_KEY"
+      value = data.aws_secretsmanager_secret_version.notify_smoketest_api_key.secret_string
+    }
   }
 
   source {

--- a/govwifi-smoke-tests/locals.tf
+++ b/govwifi-smoke-tests/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  notify_go_template_id = "ab004ebd-c74f-43e3-95bc-60c9bd325a83"
+  smoketest_phone_number = "+447860003343"
+}

--- a/govwifi-smoke-tests/secrets-manager.tf
+++ b/govwifi-smoke-tests/secrets-manager.tf
@@ -72,6 +72,13 @@ data "aws_secretsmanager_secret" "gw_super_admin_2fa_secret" {
   name = "deploy/gw_super_admin_2fa_secret"
 }
 
+data "aws_secretsmanager_secret_version" "notify_smoketest_api_key" {
+  secret_id = data.aws_secretsmanager_secret.notify_smoketest_api_key.id
+}
+
+data "aws_secretsmanager_secret" "notify_smoketest_api_key" {
+  name = "smoketests/notify_smoketest_api_key"
+}
 
 data "aws_secretsmanager_secret_version" "google_api_credentials" {
   secret_id = data.aws_secretsmanager_secret.google_api_credentials.id

--- a/govwifi-smoke-tests/variables.tf
+++ b/govwifi-smoke-tests/variables.tf
@@ -27,3 +27,6 @@ variable "smoketest_subnet_public_b" {
 
 variable "create_slack_alert" {
 }
+
+variable "govwifi_phone_number" {
+}

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -401,5 +401,5 @@ module "london_smoke_tests" {
   smoketest_subnet_public_b  = var.smoketest_subnet_public_b
   aws_region                 = local.london_aws_region
   create_slack_alert         = 0
-
+  govwifi_phone_number       = "+447860003687"
 }

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -402,7 +402,7 @@ module "london_smoke_tests" {
   smoketest_subnet_public_b  = var.smoketest_subnet_public_b
   aws_region                 = local.london_aws_region
   create_slack_alert         = 0
-
+  govwifi_phone_number       = "+447537417039"
 }
 
 module "london_sync_certs" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -520,7 +520,7 @@ module "smoke_tests" {
   smoketest_subnet_public_b  = var.smoketest_subnet_public_b
   aws_region                 = var.aws_region
   create_slack_alert         = 1
-
+  govwifi_phone_number       = "+447537417417"
 }
 
 module "govwifi-ecs-update-service" {


### PR DESCRIPTION
### What
Add variables to enable the SMS Signup Journey smoke tests.

### Why
The Smoke tests need access to the GovWifi-smoketest Notify service account, and
so we need to set a number of Environment Variables.

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-845