### PR TITLE
Tighten permissions on s3 buckets related to pipelines

### DIFF
--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -216,7 +216,8 @@ resource "aws_iam_policy" "crossaccount_tools" {
         {
             "Effect": "Allow",
             "Action": [
-                "s3:*"
+                "s3:GetObject",
+                "s3:ListBucket"
             ],
             "Resource": [
                 "arn:aws:s3:::govwifi-codepipeline-bucket",

--- a/govwifi-deploy/s3.tf
+++ b/govwifi-deploy/s3.tf
@@ -39,18 +39,19 @@ resource "aws_s3_bucket_policy" "codepipeline_bucket_policy" {
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-										"arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-crossaccount-tools-deploy",
-										"arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-codebuild-role",
-										"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy",
-										"arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role",
-                    "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-crossaccount-tools-deploy",
-                    "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-codebuild-role",
-										"${aws_iam_role.govwifi_codepipeline_global_role.arn}",
-										"${aws_iam_role.govwifi_codebuild_convert.arn}"
+                      "arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-crossaccount-tools-deploy",
+                      "arn:aws:iam::${local.aws_staging_account_id}:role/govwifi-codebuild-role",
+                      "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-crossaccount-tools-deploy",
+                      "arn:aws:iam::${local.aws_production_account_id}:role/govwifi-codebuild-role",
+                      "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-crossaccount-tools-deploy",
+                      "arn:aws:iam::${local.aws_alpaca_account_id}:role/govwifi-codebuild-role",
+                      "${aws_iam_role.govwifi_codepipeline_global_role.arn}",
+                      "${aws_iam_role.govwifi_codebuild_convert.arn}"
 									]
             },
             "Action": [
-                "s3:*"
+                "s3:GetObject",
+                "s3:ListBucket"
             ],
             "Resource": [
 								"${aws_s3_bucket.codepipeline_bucket.arn}/*", "${aws_s3_bucket.codepipeline_bucket.arn}"
@@ -61,11 +62,6 @@ resource "aws_s3_bucket_policy" "codepipeline_bucket_policy" {
 POLICY
 
 }
-
-
-
-
-
 
 resource "aws_s3_bucket" "codepipeline_bucket_ireland" {
   provider = aws.dublin

--- a/govwifi-smoke-tests/iam.tf
+++ b/govwifi-smoke-tests/iam.tf
@@ -40,6 +40,21 @@ resource "aws_iam_policy" "govwifi_codebuild_role_policy" {
         },
         {
             "Action": [
+                "s3:GetBucketAcl",
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:PutObject"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+              "${aws_s3_bucket.smoke_tests_bucket.arn}",
+              "${aws_s3_bucket.smoke_tests_bucket.arn}/*"
+            ],
+            "Sid": "SmoketestsStoreLogsPolicy"
+        },
+        {
+            "Action": [
                 "codecommit:GitPull"
             ],
             "Effect": "Allow",
@@ -48,47 +63,15 @@ resource "aws_iam_policy" "govwifi_codebuild_role_policy" {
         },
         {
             "Action": [
-                "s3:GetObject",
-                "s3:GetObjectVersion"
-            ],
-            "Effect": "Allow",
-            "Resource": "*",
-            "Sid": "S3GetObjectPolicy"
-        },
-        {
-            "Action": [
-                "s3:PutObject"
-            ],
-            "Effect": "Allow",
-            "Resource": "*",
-            "Sid": "S3PutObjectPolicy"
-        },
-        {
-            "Action": [
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:GetDownloadUrlForLayer",
-                "ecr:BatchGetImage"
+                "ecr:BatchGetImage",
+                "ecr:GetAuthorizationToken"
+
             ],
             "Effect": "Allow",
             "Resource": "*",
             "Sid": "ECRPullPolicy"
-        },
-        {
-            "Action": [
-                "ecr:GetAuthorizationToken"
-            ],
-            "Effect": "Allow",
-            "Resource": "*",
-            "Sid": "ECRAuthPolicy"
-        },
-        {
-            "Action": [
-                "s3:GetBucketAcl",
-                "s3:GetBucketLocation"
-            ],
-            "Effect": "Allow",
-            "Resource": "*",
-            "Sid": "S3BucketIdentity"
         }
     ],
     "Version": "2012-10-17"
@@ -120,9 +103,7 @@ resource "aws_iam_policy" "crossaccount_tools" {
             "Effect": "Allow",
             "Action": [
                 "s3:Get*",
-                "s3:List*",
-                "s3:PutObject",
-                "s3:PutObjectAcl"
+                "s3:List*"
             ],
             "Resource": [
                 "arn:aws:s3:::govwifi-codepipeline-bucket",


### PR DESCRIPTION
### What
All cross account roles now only have read only access to pipeline assets.

### Why
The previous permissions were insecure and theoretically allowed a staging role to edit a production asset.

**More details:** 
The native Codepipeline deployment stage ( see code here: https://github.com/alphagov/govwifi-terraform/blob/master/govwifi-deploy/codepipeline-admin.tf#L62-L82) requires access to the codepipeline bucket which lives in the govwifi-tools AWS account. There is not a way to reliably grant cross account roles access to specific objects in the bucket, whilst denying them access to others AND having a pipeline that will deploy to multiple environments...e.g. staging through to production.

If Codepipeline allowed us to set up directories in which you could place assets relating to each specific STAGE of the pipeline, then we could create staging assets in a staging directory, and production assets in a production directory, and so on. We could also restrict the cross account role to specific directories (e.g. govwifi-codepipeline-bucket/adminpipeline/staging). Unfortunately Codepipeline does not work this way.

The names of the directories in the asset bucket are autogenerated, and any assets are lumped into a randomly named directory, there is no way of distinguishing between staging and production assets that are part of the same pipeline. Hence giving all the cross account roles read only access is the next best solution. The assets themselves do not contain any production credentials or secrets, so there is no risk of credential breaching if they are accessed by other accounts.

**Link to Jira card (if applicable):** 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-859

