### PR TITLE
Make smoke test public ips available to Logging API

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -72,6 +72,9 @@ resource "aws_ecs_task_definition" "logging_api_task" {
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
         },{
+          "name": "SMOKE_TEST_IPS",
+          "value": "${join(",", var.smoke_test_ips)}"
+        },{
           "name": "VOLUMETRICS_ENDPOINT",
           "value": "https://${var.elasticsearch_endpoint}"
         }

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -191,3 +191,8 @@ variable "alb_permitted_cidr_blocks" {
 
 variable "app_env" {
 }
+
+variable "smoke_test_ips" {
+  type    = list(string)
+  default = []
+}

--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -88,7 +88,7 @@ resource "aws_codebuild_project" "smoke_tests" {
     }
 
     environment_variable {
-      name = "SMOKETEST_PHONE_NUMBER"
+      name  = "SMOKETEST_PHONE_NUMBER"
       value = local.smoketest_phone_number
     }
 

--- a/govwifi-smoke-tests/locals.tf
+++ b/govwifi-smoke-tests/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  notify_go_template_id = "ab004ebd-c74f-43e3-95bc-60c9bd325a83"
+  notify_go_template_id  = "ab004ebd-c74f-43e3-95bc-60c9bd325a83"
   smoketest_phone_number = "+447860003343"
 }

--- a/govwifi-smoke-tests/outputs.tf
+++ b/govwifi-smoke-tests/outputs.tf
@@ -1,0 +1,3 @@
+output "eip_public_ips" {
+  value = [aws_eip.smoke_tests_a.public_ip, aws_eip.smoke_tests_b.public_ip]
+}

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -280,6 +280,7 @@ module "london_api" {
   low_cpu_threshold = 0.3
 
   elasticsearch_endpoint = module.london_elasticsearch.endpoint
+  smoke_test_ips         = module.london_smoke_tests.eip_public_ips
 }
 
 module "london_route53_notifications" {

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -280,6 +280,7 @@ module "london_api" {
   low_cpu_threshold = 0.3
 
   elasticsearch_endpoint = module.london_elasticsearch.endpoint
+  smoke_test_ips         = module.london_smoke_tests.eip_public_ips
 }
 
 module "london_route53_notifications" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -346,6 +346,7 @@ module "api" {
   low_cpu_threshold = 10
 
   elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
+  smoke_test_ips         = module.smoke_tests.eip_public_ips
 }
 
 module "critical_notifications" {


### PR DESCRIPTION
### What
Make smoke test public ips available to Logging API
### Why
The Logging API needs these to be able to clean the Session DB of data created during the smoke tests. This data does not reflect real users and real activity and so should not pollute the Database.

See also: https://github.com/alphagov/govwifi-logging-api/pull/649

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-895