### PR TITLE
Remove radius IPS from secrets for smoke tests.

### DIFF
--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -74,7 +74,7 @@ resource "aws_codebuild_project" "smoke_tests" {
 
     environment_variable {
       name  = "RADIUS_IPS"
-      value = data.aws_secretsmanager_secret_version.radius_ips.secret_string
+      value = join(",", var.radius_ip_addresses)
     }
 
     environment_variable {
@@ -114,12 +114,12 @@ resource "aws_codebuild_project" "smoke_tests" {
 
     # IDs of the two PRIVATE subnets
     subnets = [
-      "${aws_subnet.smoke_tests_private_a.id}",
-      "${aws_subnet.smoke_tests_private_b.id}",
+      aws_subnet.smoke_tests_private_a.id,
+      aws_subnet.smoke_tests_private_b.id,
     ] #
 
     security_group_ids = [
-      "${aws_vpc.smoke_tests.default_security_group_id}"
+      aws_vpc.smoke_tests.default_security_group_id
     ] #The default vpc security group goes here. Lets all traffic in and out (this is what all the codebuild jobs do anyway)
   }
 

--- a/govwifi-smoke-tests/secrets-manager.tf
+++ b/govwifi-smoke-tests/secrets-manager.tf
@@ -107,16 +107,6 @@ data "aws_secretsmanager_secret" "radius_key" {
   name = "deploy/radius_key"
 }
 
-
-
-data "aws_secretsmanager_secret_version" "radius_ips" {
-  secret_id = data.aws_secretsmanager_secret.radius_ips.id
-}
-
-data "aws_secretsmanager_secret" "radius_ips" {
-  name = "deploy/radius_ips"
-}
-
 data "aws_secretsmanager_secret_version" "tools_account" {
   secret_id = data.aws_secretsmanager_secret.tools_account.id
 }

--- a/govwifi-smoke-tests/variables.tf
+++ b/govwifi-smoke-tests/variables.tf
@@ -30,3 +30,8 @@ variable "create_slack_alert" {
 
 variable "govwifi_phone_number" {
 }
+
+variable "radius_ip_addresses" {
+  description = "List of all external radius IP addresses"
+  type        = list(string)
+}

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -402,4 +402,5 @@ module "london_smoke_tests" {
   aws_region                 = local.london_aws_region
   create_slack_alert         = 0
   govwifi_phone_number       = "+447860003687"
+  radius_ip_addresses = concat(module.london_frontend.eip_public_ips, module.dublin_frontend.eip_public_ips)
 }

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -403,6 +403,7 @@ module "london_smoke_tests" {
   aws_region                 = local.london_aws_region
   create_slack_alert         = 0
   govwifi_phone_number       = "+447537417039"
+  radius_ip_addresses = concat(module.london_frontend.eip_public_ips, module.dublin_frontend.eip_public_ips)
 }
 
 module "london_sync_certs" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -521,6 +521,7 @@ module "smoke_tests" {
   aws_region                 = var.aws_region
   create_slack_alert         = 1
   govwifi_phone_number       = "+447537417417"
+  radius_ip_addresses = concat(var.london_radius_ip_addresses, var.dublin_radius_ip_addresses)
 }
 
 module "govwifi-ecs-update-service" {


### PR DESCRIPTION
### What
Remove radius IPS from secrets for smoke tests.
### Why
The radius IPs are already in the Govwifi-build repo and replicating them in secrets can only introduce errors.
It Staging and development, they can be derived from the frontend module. At a later data we can hopefully remove them as constants altogether.

