### PR TITLE
Move SMOKE_TEST_IPS variable to scheduled task

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -72,9 +72,6 @@ resource "aws_ecs_task_definition" "logging_api_task" {
           "name": "S3_PUBLISHED_LOCATIONS_IPS_OBJECT_KEY",
           "value": "ips-and-locations.json"
         },{
-          "name": "SMOKE_TEST_IPS",
-          "value": "${join(",", var.smoke_test_ips)}"
-        },{
           "name": "VOLUMETRICS_ENDPOINT",
           "value": "https://${var.elasticsearch_endpoint}"
         }

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -553,6 +553,9 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
         },{
           "name": "VOLUMETRICS_ENDPOINT",
           "value": "https://${var.elasticsearch_endpoint}"
+        },{
+          "name": "SMOKE_TEST_IPS",
+          "value": "${join(",", var.smoke_test_ips)}"
         }
       ],
       "secrets": [


### PR DESCRIPTION
The session deletion scheduled task uses this, not the actual logging app
