### PR TITLE
Increase timeout of smoke tests to 10 minutes

### DIFF
--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -1,7 +1,7 @@
 resource "aws_codebuild_project" "smoke_tests" {
   name          = "govwifi-smoke-tests"
   description   = "This project runs the govwifi tests at regular intervals"
-  build_timeout = "5"
+  build_timeout = "10"
   service_role  = aws_iam_role.govwifi_codebuild.arn
 
   artifacts {


### PR DESCRIPTION
When attempting to connect to Notify, the smoke tests have a 5 minute timeout set in the code. The job is also set to time out in 5 minutes, which means that the job is usually terminated before the code can time out and print a helpful message making debugging easier

This commit increases the timeout of the AWS task to 10 minutes so that the timeout occurs in the code.

The jobs are run every 15 minutes, so they should still run sequentially.
