### PR TITLE
feat: add ImageTagMutability to be mutable for admin codepipline step to show tags in interface

### DIFF
--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -34,10 +34,10 @@ resource "aws_codepipeline" "admin_pipeline" {
       provider         = "ECR"
       version          = "1"
       output_artifacts = ["SourceArtifact"]
+      image_tag_mutability = "MUTABLE"
 
       configuration = {
         RepositoryName     = "govwifi/admin/staging"
-        image_tag_mutability = "MUTABLE"
       }
     }
   }

--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -36,11 +36,11 @@ resource "aws_codepipeline" "admin_pipeline" {
       output_artifacts = ["SourceArtifact"]
 
       configuration = {
-        RepositoryName = "govwifi/admin/staging"
+        RepositoryName     = "govwifi/admin/staging"
+        ImageTagMutability = "MUTABLE"
       }
     }
   }
-
   stage {
     name = "admin-convert-imagedetail"
 

--- a/govwifi-deploy/codepipeline-admin.tf
+++ b/govwifi-deploy/codepipeline-admin.tf
@@ -37,7 +37,7 @@ resource "aws_codepipeline" "admin_pipeline" {
 
       configuration = {
         RepositoryName     = "govwifi/admin/staging"
-        ImageTagMutability = "MUTABLE"
+        image_tag_mutability = "MUTABLE"
       }
     }
   }


### PR DESCRIPTION
### What
Adding ImageTagMutability = "MUTABLE" in admin pipeline

### Why
This will allow us to see the tags an image has been tagged with. In this case we want to see the commit sha


Link to Trello card (if applicable): https://technologyprogramme.atlassian.net/browse/GW-819