### PR TITLE
Revert "    Give FIDUS Access To Our EC2 Instances"

### DIFF
--- a/govwifi-frontend/security_groups.tf
+++ b/govwifi-frontend/security_groups.tf
@@ -47,7 +47,7 @@ resource "aws_security_group" "fe_admin_in" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["${var.bastion_server_ip}/32", "${var.fidus_ips[0]}", "${var.fidus_ips[1]}", "${var.fidus_ips[2]}", "${var.fidus_ips[3]}"]
+    cidr_blocks = ["${var.bastion_server_ip}/32"]
   }
 }
 

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -102,6 +102,3 @@ variable "prometheus_ip_ireland" {
 variable "prometheus_security_group_id" {
   type = string
 }
-
-variable "fidus_ips" {
-}

--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "grafana_ec2_in" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["${var.bastion_ip}/32", "${var.fidus_ips[0]}", "${var.fidus_ips[1]}", "${var.fidus_ips[2]}", "${var.fidus_ips[3]}"]
+    cidr_blocks = ["${var.bastion_ip}/32"]
   }
 }
 

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -79,7 +79,3 @@ variable "critical_notifications_arn" {
 
 variable "aws_account_id" {
 }
-
-variable "fidus_ips" {
-}
-

--- a/govwifi/alpaca/dublin.tf
+++ b/govwifi/alpaca/dublin.tf
@@ -241,8 +241,6 @@ module "dublin_frontend" {
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
 
-  fidus_ips = var.fidus_ips
-
 }
 
 module "dublin_api" {
@@ -329,7 +327,6 @@ module "dublin_prometheus" {
   dublin_radius_ip_addresses = module.dublin_frontend.eip_public_ips
 
   grafana_ip = module.london_grafana.eip_public_ip
-
 }
 
 module "dublin_route53_notifications" {

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -144,9 +144,6 @@ module "london_frontend" {
   prometheus_security_group_id = module.london_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-
-  fidus_ips = var.fidus_ips
-
 }
 
 module "london_admin" {
@@ -338,7 +335,6 @@ module "london_prometheus" {
   dublin_radius_ip_addresses = module.dublin_frontend.eip_public_ips
 
   grafana_ip = module.london_grafana.eip_public_ip
-
 }
 
 module "london_grafana" {
@@ -370,9 +366,6 @@ module "london_grafana" {
     module.london_prometheus.eip_public_ip,
     module.dublin_prometheus.eip_public_ip
   ]
-
-  fidus_ips = var.fidus_ips
-
 
 }
 

--- a/govwifi/alpaca/variables.tf
+++ b/govwifi/alpaca/variables.tf
@@ -36,6 +36,3 @@ variable "smoketest_subnet_public_a" {
 
 variable "smoketest_subnet_public_b" {
 }
-
-variable "fidus_ips" {
-}

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -240,7 +240,6 @@ module "dublin_frontend" {
   prometheus_security_group_id = module.dublin_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-  fidus_ips = var.fidus_ips
 
 }
 

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -144,7 +144,6 @@ module "london_frontend" {
   prometheus_security_group_id = module.london_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-  fidus_ips = var.fidus_ips
 }
 
 module "london_admin" {
@@ -368,7 +367,6 @@ module "london_grafana" {
     module.dublin_prometheus.eip_public_ip
   ]
   aws_account_id = local.aws_account_id
-  fidus_ips = var.fidus_ips
 
 }
 

--- a/govwifi/staging/variables.tf
+++ b/govwifi/staging/variables.tf
@@ -36,6 +36,3 @@ variable "smoketest_subnet_public_a" {
 
 variable "smoketest_subnet_public_b" {
 }
-
-variable "fidus_ips" {
-}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -212,9 +212,6 @@ module "frontend" {
   prometheus_security_group_id = module.govwifi_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-
-  fidus_ips = var.fidus_ips
-
 }
 
 module "govwifi_admin" {
@@ -442,7 +439,6 @@ module "govwifi_prometheus" {
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
   grafana_ip = var.grafana_ip
-
 }
 
 module "govwifi_grafana" {
@@ -477,8 +473,6 @@ module "govwifi_grafana" {
     var.prometheus_ip_london,
     var.prometheus_ip_ireland
   ]
-
-  fidus_ips = var.fidus_ips
 
 }
 

--- a/govwifi/wifi-london/variables.tf
+++ b/govwifi/wifi-london/variables.tf
@@ -105,6 +105,3 @@ variable "smoketest_subnet_public_a" {
 
 variable "smoketest_subnet_public_b" {
 }
-
-variable "fidus_ips" {
-}

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -251,8 +251,6 @@ module "frontend" {
   prometheus_security_group_id = module.govwifi_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-
-  fidus_ips = var.fidus_ips
 }
 
 module "api" {
@@ -389,7 +387,6 @@ module "govwifi_prometheus" {
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
   grafana_ip = var.grafana_ip
-
 }
 
 # Cross region VPC peering

--- a/govwifi/wifi/variables.tf
+++ b/govwifi/wifi/variables.tf
@@ -82,6 +82,3 @@ variable "prometheus_ip_ireland" {
 
 variable "grafana_ip" {
 }
-
-variable "fidus_ips" {
-}


### PR DESCRIPTION
Reverts alphagov/govwifi-terraform#801

FIDUS have now finished the IT Healthcheck. We can revoke their access.