### PR TITLE
Correction to randomly generated password length

### DIFF
--- a/govwifi-admin/secrets-manager.tf
+++ b/govwifi-admin/secrets-manager.tf
@@ -69,7 +69,7 @@ data "aws_secretsmanager_secret" "tools_account" {
 
 #Generate new database credentials if new environment, otherwise ignore
 resource "random_password" "admin_password" {
-  length  = 33
+  length  = 32
   special = false
 }
 

--- a/govwifi-backend/secrets-manager.tf
+++ b/govwifi-backend/secrets-manager.tf
@@ -81,7 +81,7 @@ data "aws_secretsmanager_secret" "users_db_credentials" {
 
 
 resource "random_password" "sessions_db_password" {
-  length  = 33
+  length  = 32
   special = false
 }
 


### PR DESCRIPTION
### What
Correction to randomly generated password length

### Why
The MySQL password limit is 32 characters. Reference: https://dev.mysql.com/doc/refman/8.0/en/assigning-passwords.html


