### PR TITLE
Remove legacy reference to secondary

### DIFF
--- a/govwifi/alpaca/dublin.tf
+++ b/govwifi/alpaca/dublin.tf
@@ -196,7 +196,7 @@ module "dublin_frontend" {
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = local.dublin_frontend_vpc_cidr_block
   rack_env           = "alpaca"
-  sentry_current_env = "secondary-alpaca"
+  sentry_current_env = "alpaca"
 
   backend_vpc_id = module.dublin_backend.backend_vpc_id
 
@@ -286,7 +286,7 @@ module "dublin_api" {
 
   rack_env                = "alpaca"
   app_env                 = "staging"
-  sentry_current_env      = "secondary-alpaca"
+  sentry_current_env      = "alpaca"
   radius_server_ips       = local.frontend_radius_ips
   subnet_ids              = module.dublin_backend.backend_subnet_ids
   private_subnet_ids      = module.dublin_backend.backend_private_subnet_ids

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -107,7 +107,7 @@ module "london_frontend" {
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.102.0.0/16"
   rack_env           = "alpaca"
-  sentry_current_env = "secondary-alpaca"
+  sentry_current_env = "alpaca"
 
   backend_vpc_id = module.london_backend.backend_vpc_id
 

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -196,7 +196,7 @@ module "dublin_frontend" {
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = local.dublin_frontend_vpc_cidr_block
   rack_env           = "staging"
-  sentry_current_env = "secondary-staging"
+  sentry_current_env = "staging"
 
   backend_vpc_id = module.dublin_backend.backend_vpc_id
 
@@ -286,7 +286,7 @@ module "dublin_api" {
 
   rack_env                = "staging"
   app_env                 = "staging"
-  sentry_current_env      = "secondary-staging"
+  sentry_current_env      = "staging"
   radius_server_ips       = local.frontend_radius_ips
   subnet_ids              = module.dublin_backend.backend_subnet_ids
   private_subnet_ids      = module.dublin_backend.backend_private_subnet_ids

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -107,7 +107,7 @@ module "london_frontend" {
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.102.0.0/16"
   rack_env           = "staging"
-  sentry_current_env = "secondary-staging"
+  sentry_current_env = "staging"
 
   backend_vpc_id = module.london_backend.backend_vpc_id
 
@@ -169,7 +169,7 @@ module "london_admin" {
   admin_docker_image   = format("%s/admin:staging", local.docker_image_path)
   rails_env            = "staging"
   app_env              = "staging"
-  sentry_current_env   = "secondary-staging"
+  sentry_current_env   = "staging"
   ecr_repository_count = 1
 
   subnet_ids = module.london_backend.backend_subnet_ids
@@ -249,7 +249,7 @@ module "london_api" {
 
   rack_env                  = "staging"
   app_env                   = "staging"
-  sentry_current_env        = "secondary-staging"
+  sentry_current_env        = "staging"
   radius_server_ips         = local.frontend_radius_ips
   subnet_ids                = module.london_backend.backend_subnet_ids
   private_subnet_ids        = module.london_backend.backend_private_subnet_ids


### PR DESCRIPTION
### What
Remove references to 'secondary' from staging and child environments, e.g. alpaca.

### Why
We stopped using this reference some time ago and missed these remnants.
We need to keep our environments up to date.

### Link to Trello card (if applicable): 
n/a

### Testing
Staging has been reset to master branch.
To test, git checkout remove-secondary-remnants
Terraform plan against staging which should show zero related changes.