### PR TITLE
Update Prometheus, Grafana & Bastion AMI

### DIFF
--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -32,9 +32,6 @@ variable "enable_bastion" {
   default = 1
 }
 
-variable "bastion_ami" {
-}
-
 variable "bastion_instance_type" {
 }
 

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -3,7 +3,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-20230324.1"]
+    values = ["ubuntu-pro-server/images/hvm-ssd/ubuntu-jammy-22.04-amd64-pro-server-20230726"]
   }
 
   filter {
@@ -49,6 +49,7 @@ resource "aws_instance" "grafana_instance" {
   }
 
   root_block_device {
+    volume_size = 30
     tags = {
       Name = "${title(var.env_name)} Grafana Root Volume"
     }
@@ -57,7 +58,7 @@ resource "aws_instance" "grafana_instance" {
   lifecycle {
     create_before_destroy = true
 
-    ignore_changes = [user_data, volume_tags]
+    ignore_changes = [volume_tags]
   }
 }
 

--- a/govwifi-grafana/user_data.sh
+++ b/govwifi-grafana/user_data.sh
@@ -26,6 +26,9 @@ function run-until-success() {
 run-until-success apt-get update  --yes
 run-until-success apt-get upgrade --yes
 
+# Turn on unattended upgrades
+dpkg-reconfigure -f noninteractive unattended-upgrades
+
 # We want to make sure that the journal does not write to syslog
 # This would fill up the disk, with logs we already have in the journal
 logger "Ensure journal does not write to syslog"
@@ -86,31 +89,10 @@ log_stream_name = {instance_id}/var/log/cloud-init-output.log
 EOF
 
 # Install awslogs
-# Steps required are install pre-reqs for python 3.5.n, install & build python 3.5 cos awslogs script only supports python < 3.5
-# Legacy - instance has this already - The install script requires the issue file to start with the string "Ubuntu"
-# Legacy - default - sudo echo "Ubuntu Linux 20.04 LTS - Authorized uses only. All activity may be monitored and reported. \d \t @ \n" > /etc/issue
-
-# Install python 3.5 prerequisites
-run-until-success sudo apt-get install --yes build-essential checkinstall
-run-until-success sudo apt-get install --yes libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
-
-# Install python 3.5.n source
-cd /usr/src
-run-until-success sudo wget https://www.python.org/ftp/python/3.5.9/Python-3.5.9.tgz
-sudo tar xzf Python-3.5.9.tgz
-
-# Build python
-cd Python-3.5.9/
-sudo ./configure --enable-optimizations
-sudo make altinstall
 
 # Retrieve and run awslogs install script
 cd /
 run-until-success sudo curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
-
-# Legacy possibly - Try to circumvent pip install error with waiting for 10 seconds.
-# sleep 10
-sudo python3.5 ./awslogs-agent-setup.py -n -r eu-west-2 -c ./initial-awslogs.conf
 
 # Install Docker and Send Logs to CloudWatch
 logger 'Installing and configuring docker'

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -3,7 +3,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-20230324.1"]
+    values = ["ubuntu-pro-server/images/hvm-ssd/ubuntu-jammy-22.04-amd64-pro-server-20230726"]
   }
 
   filter {
@@ -54,7 +54,7 @@ resource "aws_instance" "prometheus_instance" {
   }
 
   root_block_device {
-
+    volume_size = 30
     tags = {
       Name = "${title(var.env_name)} Prometheus Root Volume"
     }
@@ -63,7 +63,7 @@ resource "aws_instance" "prometheus_instance" {
   lifecycle {
     create_before_destroy = true
 
-    ignore_changes = [user_data, volume_tags]
+    ignore_changes = [volume_tags]
   }
 }
 

--- a/govwifi-prometheus/user_data.sh
+++ b/govwifi-prometheus/user_data.sh
@@ -50,6 +50,8 @@ chown -R nobody /srv/prometheus
 run-until-success apt-get update  --yes
 run-until-success apt-get upgrade --yes
 
+# Turn on unattended upgrades
+dpkg-reconfigure -f noninteractive unattended-upgrades
 
 # We want to make sure that the journal does not write to syslog
 # This would fill up the disk, with logs we already have in the journal
@@ -115,32 +117,10 @@ EOF
 sed -i s/\ trust-ad// /etc/resolv.conf
 
 # Install awslogs
-# Steps required are install pre-reqs for python 3.5.n, install & build python 3.5 cos awslogs script only supports python < 3.5
-# Legacy - instance has this already - The install script requires the issue file to start with the string "Ubuntu"
-# Legacy - default - sudo echo "Ubuntu Linux 20.04 LTS - Authorized uses only. All activity may be monitored and reported. \d \t @ \n" > /etc/issue
-
-# Install python 3.5 prerequisites
-run-until-success sudo apt-get install --yes build-essential checkinstall
-run-until-success sudo apt-get install --yes libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
-
-# Install python 3.5.n source
-cd /usr/src
-run-until-success sudo wget https://www.python.org/ftp/python/3.5.9/Python-3.5.9.tgz
-sudo tar xzf Python-3.5.9.tgz
-
-# Build python
-cd Python-3.5.9/
-sudo ./configure --enable-optimizations
-sudo make altinstall
 
 # Retrieve and run awslogs install script
 cd /
 run-until-success sudo curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
-
-# Legacy possibly - Try to circumvent pip install error with waiting for 10 seconds.
-# sleep 10
-sudo python3.5 ./awslogs-agent-setup.py -n -r eu-west-2 -c ./initial-awslogs.conf
-
 
 # Install Docker and Send Logs to cloudwatch
 logger 'Installing and configuring docker'

--- a/govwifi/alpaca/dublin.tf
+++ b/govwifi/alpaca/dublin.tf
@@ -98,7 +98,6 @@ module "dublin_backend" {
 
   # Instance-specific setup -------------------------------
   enable_bastion = 0
-  bastion_ami    = "ami-08bac620dc84221eb"
 
   bastion_instance_type     = "t2.micro"
   bastion_server_ip         = module.london_backend.bastion_public_ip

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -50,7 +50,6 @@ module "london_backend" {
   administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
 
-  bastion_ami               = "ami-096cb92bb3580c759"
   bastion_instance_type     = "t2.micro"
   bastion_ssh_key_name      = "govwifi-alpaca-bastion-20230120"
   enable_bastion_monitoring = false

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -98,7 +98,6 @@ module "dublin_backend" {
 
   # Instance-specific setup -------------------------------
   enable_bastion = 0
-  bastion_ami    = "ami-08bac620dc84221eb"
 
   bastion_instance_type     = "t2.micro"
   bastion_server_ip         = module.london_backend.bastion_public_ip

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -50,7 +50,6 @@ module "london_backend" {
   administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
 
-  bastion_ami               = "ami-096cb92bb3580c759"
   bastion_instance_type     = "t2.micro"
   bastion_ssh_key_name      = "staging-bastion-20200717"
   enable_bastion_monitoring = false

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -117,7 +117,6 @@ module "backend" {
   administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
 
-  bastion_ami                = "ami-096cb92bb3580c759"
   bastion_instance_type      = "t2.micro"
   bastion_ssh_key_name       = "govwifi-bastion-key-20210630"
   enable_bastion_monitoring  = true

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -119,7 +119,6 @@ module "backend" {
   # eu-west-1, CIS Ubuntu Linux 16.04 LTS Benchmark v1.0.0.4 - Level 1
   # bastion-ami = "ami-51d3e928"
   # eu-west-2 eu-west-2, CIS Ubuntu Linux 20.04 LTS
-  bastion_ami               = "ami-08bac620dc84221eb"
   bastion_instance_type     = "t2.micro"
   bastion_ssh_key_name      = "govwifi-bastion-key-20210630"
   enable_bastion_monitoring = true


### PR DESCRIPTION
### What & Why
Update Prometheus, Grafana & Bastion AMI to latest version of Ubuntu (22.04.2 LTS (Jammy Jellyfish)). Increase root volume size, on all instances (new version of Ubuntu needs more disk space).
    
Update userdata:
 - Remove section on installing python 3.5 as this is no longer needed (Python3 comes pre-installed on the latest version of Ubuntu)
  - Enable automatic updates for stable releases and security patches on all instances
    
Remove bastion_ami variable. The version of ubuntu used should be standard across all environments

### Why
This work was recommended as a result of the 2023 ITHC


Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1012