### PR TITLE
Change AMI To Data Reference

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -1,7 +1,22 @@
-# Using custom ubuntu AMI id, as the micro size is only supported for paravirtual images.
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu-pro-server/images/hvm-ssd/ubuntu-jammy-22.04-amd64-pro-server-20230726"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
 resource "aws_instance" "management" {
   count         = var.enable_bastion
-  ami           = "ami-04287c76136434aaf"
+  ami           = data.aws_ami.ubuntu.id
   instance_type = var.bastion_instance_type
   key_name      = var.bastion_ssh_key_name
   subnet_id     = aws_subnet.wifi_backend_subnet[data.aws_availability_zones.zones.names[0]].id


### PR DESCRIPTION
### What
Change AMI To Data Reference

### Why
AMI id's are regional, but the AMI names are global. Changing this to a data reference and using an AMI name, avoids terraform errors when we deploy our code to the eu-west-1 region

Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1012
