### PR TITLE
Add Sync Certs Module To Development Environment

### DIFF
--- a/govwifi/alpaca/.terraform.lock.hcl
+++ b/govwifi/alpaca/.terraform.lock.hcl
@@ -42,3 +42,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fc93015058e9592810aa4b3e7834df1717ba8d6aec4679997d16c030c885d6fc",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/govwifi/alpaca/dublin.tf
+++ b/govwifi/alpaca/dublin.tf
@@ -349,3 +349,17 @@ module "dublin_notifications" {
   topic_name = "govwifi-alpaca"
   emails     = [var.notification_email]
 }
+
+module "dublin_sync_certs" {
+  providers = {
+    aws = aws.dublin
+  }
+
+  source = "../../govwifi-sync-certs"
+
+  env            = local.env
+  aws_account_id = local.aws_account_id
+  aws_region     = local.dublin_aws_region
+  region_name    = local.dublin_aws_region_name
+
+}

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -408,3 +408,16 @@ module "london_smoke_tests" {
     module.london_frontend
   ]
 }
+
+module "london_sync_certs" {
+  providers = {
+    aws = aws.london
+  }
+
+  source = "../../govwifi-sync-certs"
+
+  env            = local.env
+  aws_account_id = local.aws_account_id
+  aws_region     = local.london_aws_region
+  region_name    = local.london_aws_region_name
+}


### PR DESCRIPTION
### What
Add Sync Certs Module To Development Environment the change

### Why
Since the development environment/alpaca was created the sync cert module was added to other environments. Updating the Dev environment to keep things synced.

Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-872
