### PR TITLE
Remove Redundant IAM Users

### DIFF
--- a/govwifi-account/iam-users.tf
+++ b/govwifi-account/iam-users.tf
@@ -1,29 +1,5 @@
-resource "aws_iam_user" "govwifi_pipeline_deploy_prod" {
-  name          = "govwifi-pipeline-deploy-prod"
-  path          = "/"
-  force_destroy = false
-}
-
-resource "aws_iam_user" "govwifi_pipeline_deploy_smoketest" {
-  name          = "govwifi-pipeline-deploy-smoketest"
-  path          = "/"
-  force_destroy = false
-}
-
 resource "aws_iam_user" "monitoring_stats_user" {
   name          = "monitoring-stats-user"
   path          = "/"
   force_destroy = false
-}
-
-# User policy attachments
-
-resource "aws_iam_user_policy_attachment" "deploy_smoketest_container_service_events_role" {
-  user       = aws_iam_user.govwifi_pipeline_deploy_smoketest.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole"
-}
-
-resource "aws_iam_user_policy_attachment" "deploy_smoketest_ec2_container_registry_power_user" {
-  user       = aws_iam_user.govwifi_pipeline_deploy_smoketest.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
 }


### PR DESCRIPTION
### What
These IAM users are not needed.
- govwifi-pipeline-deploy-prod
- govwifi-pipeline-deploy-smoketest Removing them and related policies as part of best practice.

### Why
The IAM user _govwifi-pipeline-deploy-smoketest_ has not been accessed for 204 days 
The IAM user _govwifi-pipeline-deploy-prod_ has never been accessed.

These users appear to be left over from when GovWifi was using Concourse for it's deployment and are no longer needed (the new codepipeline deployment uses the assume role facility to gain permissions, rather than accessing resources through an IAM user, so these old users are therefore redundant).

