### PR TITLE
Ensure IAM password policy requires minimum length of 14 or greater

### DIFF
--- a/govwifi-account-policy/aws-iam-account-password-policy.tf
+++ b/govwifi-account-policy/aws-iam-account-password-policy.tf
@@ -1,0 +1,8 @@
+resource "aws_iam_account_password_policy" "strict" {
+  minimum_password_length        = 14
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_uppercase_characters   = true
+  require_symbols                = true
+  allow_users_to_change_password = true
+}

--- a/govwifi-account-policy/main.tf
+++ b/govwifi-account-policy/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -421,3 +421,12 @@ module "london_sync_certs" {
   aws_region     = local.london_aws_region
   region_name    = local.london_aws_region_name
 }
+
+module "london_account_policy" {
+  providers = {
+    aws = aws.london
+  }
+
+  source = "../../govwifi-account-policy"
+  
+}

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -422,3 +422,12 @@ module "london_sync_certs" {
   aws_region     = local.london_aws_region
   region_name    = local.london_aws_region_name
 }
+
+module "london_account_policy" {
+  providers = {
+    aws = aws.london
+  }
+
+  source = "../../govwifi-account-policy"
+  
+}

--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -40,3 +40,12 @@ module "govwifi_deploy" {
   built_app_names        = ["frontend", "safe-restarter", "database-backup"]
   frontend_docker_images = ["raddb", "frontend"]
 }
+
+module "govwifi_account_policy" {
+  providers = {
+    aws = aws.main
+  }
+
+  source = "../../govwifi-account-policy"
+  
+}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -555,3 +555,12 @@ module "govwifi_sync_certs" {
   region_name    = var.aws_region_name
 
 }
+
+module "govwifi_account_policy" {
+  providers = {
+    aws = aws.main
+  }
+
+  source = "../../govwifi-account-policy"
+  
+}


### PR DESCRIPTION
### What
Ensure IAM password policy requires minimum length of 14 or greater

### Why
This was recommended by our annual IT Health Check

Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1019
