### PR TITLE
Fix s3 lifecycle

### DIFF
--- a/govwifi-account-policy/aws-iam-account-password-policy.tf
+++ b/govwifi-account-policy/aws-iam-account-password-policy.tf
@@ -5,4 +5,5 @@ resource "aws_iam_account_password_policy" "strict" {
   require_uppercase_characters   = true
   require_symbols                = true
   allow_users_to_change_password = true
+  password_reuse_prevention      = 1
 }

--- a/govwifi-account-policy/aws-iam-account-password-policy.tf
+++ b/govwifi-account-policy/aws-iam-account-password-policy.tf
@@ -1,0 +1,8 @@
+resource "aws_iam_account_password_policy" "strict" {
+  minimum_password_length        = 14
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_uppercase_characters   = true
+  require_symbols                = true
+  allow_users_to_change_password = true
+}

--- a/govwifi-account-policy/main.tf
+++ b/govwifi-account-policy/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/govwifi-backend/s3.tf
+++ b/govwifi-backend/s3.tf
@@ -43,18 +43,18 @@ resource "aws_s3_bucket_lifecycle_configuration" "rds_mysql_backup_bucket" {
   rule {
     id = "expiration"
 
-    noncurrent_version_transition {
-      noncurrent_days = 30
+    transition {
+      days = 30
       storage_class   = "STANDARD_IA"
     }
 
-    noncurrent_version_transition {
-      noncurrent_days = 60
+    transition {
+      days = 60
       storage_class   = "GLACIER"
     }
 
-    noncurrent_version_expiration {
-      noncurrent_days = 180
+    expiration {
+      days = 180
     }
 
     status = "Enabled"

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -421,3 +421,12 @@ module "london_sync_certs" {
   aws_region     = local.london_aws_region
   region_name    = local.london_aws_region_name
 }
+
+module "london_account_policy" {
+  providers = {
+    aws = aws.london
+  }
+
+  source = "../../govwifi-account-policy"
+  
+}

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -422,3 +422,12 @@ module "london_sync_certs" {
   aws_region     = local.london_aws_region
   region_name    = local.london_aws_region_name
 }
+
+module "london_account_policy" {
+  providers = {
+    aws = aws.london
+  }
+
+  source = "../../govwifi-account-policy"
+  
+}

--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -40,3 +40,12 @@ module "govwifi_deploy" {
   built_app_names        = ["frontend", "safe-restarter", "database-backup"]
   frontend_docker_images = ["raddb", "frontend"]
 }
+
+module "govwifi_account_policy" {
+  providers = {
+    aws = aws.main
+  }
+
+  source = "../../govwifi-account-policy"
+  
+}

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -555,3 +555,12 @@ module "govwifi_sync_certs" {
   region_name    = var.aws_region_name
 
 }
+
+module "govwifi_account_policy" {
+  providers = {
+    aws = aws.main
+  }
+
+  source = "../../govwifi-account-policy"
+  
+}


### PR DESCRIPTION
### What
Fix the broken lifecycle for S3 DB backup bucket

### Why
We don't need 1695 backup objects


### Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/issues/GW-1004?jql=project%20%3D%20%22GW%22%20AND%20text%20~%20%22lifecycle%22%20ORDER%20BY%20created%20DESC


### Testing
Pull the branch and execute terraform plan against our Production environment. Wait 24 hours and observe changes in S3 objects which will be moved to Glacier.