### PR TITLE
IAM disable inactive users

### DIFF
--- a/govwifi-account-policy/README.md
+++ b/govwifi-account-policy/README.md
@@ -1,0 +1,3 @@
+IAM User Management Module
+
+This module runs a codebuild job every 30 days that deactivates IAM user access keys that have not been used in 45 days.

--- a/govwifi-account-policy/buildspec.yml
+++ b/govwifi-account-policy/buildspec.yml
@@ -1,0 +1,12 @@
+version: 0.2
+phases:
+    pre_build:
+        commands:
+            - echo "Pulling script from github"
+            - git clone https://github.com/alphagov/govwifi-terraform.git
+            - cd govwifi-terraform
+
+    build:
+        commands:
+            - echo "Running script"
+            - ./govwifi-account-policy/disable-inactive-iam-keys.sh

--- a/govwifi-account-policy/codebuild.tf
+++ b/govwifi-account-policy/codebuild.tf
@@ -1,0 +1,55 @@
+resource "aws_codebuild_project" "iam_management" {
+  count         = (var.aws_region == "eu-west-2" ? 1 : 0)
+  name          = "govwifi-disable-inactive-IAM-keys"
+  description   = "This project disables IAM user keys that have not been used in over 45 days"
+  build_timeout = "5"
+  service_role  = aws_iam_role.iam_management[0].arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:6.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+  }
+
+  source {
+    type      = "NO_SOURCE"
+    buildspec = file("${path.module}/buildspec.yml")
+
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "govwifi-iam-user-managment-script-log"
+      stream_name = "govwifi-iam-user-managment-script-log"
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${aws_s3_bucket.iam_user_managment_logs.id}/govwifi-iam-user-managment-log"
+    }
+  }
+
+}
+
+# Trigger inactive users check to run every 30 days
+resource "aws_cloudwatch_event_target" "check_inactive_iam_users" {
+  count = (var.aws_region == "eu-west-2" ? 1 : 0)
+  rule  = aws_cloudwatch_event_rule.check_inactive_iam_users[0].name
+  arn   = aws_codebuild_project.iam_management[0].id
+
+  role_arn = aws_iam_role.iam_management[0].arn
+}
+
+# Runs on the 30th day of every month at 10:30
+resource "aws_cloudwatch_event_rule" "check_inactive_iam_users" {
+  count               = (var.aws_region == "eu-west-2" ? 1 : 0)
+  name                = "check-inactive-iam-users"
+  schedule_expression = "cron(30 10 28 * ? *)"
+}

--- a/govwifi-account-policy/disable-inactive-iam-keys.sh
+++ b/govwifi-account-policy/disable-inactive-iam-keys.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Get the current date in seconds since epoch
+current_date=$(date +%s)
+
+# List all IAM users
+users=$(aws iam list-users --query "Users[].UserName" --output text)
+
+# Days to wait before deactivating key
+deactivate_after_days=45
+
+# Loop through users
+for user in $users; do
+    
+    # Get access keys for the user
+    access_keys=$(aws iam list-access-keys --user-name "$user" --query "AccessKeyMetadata[?Status=='Active'].{AccessKeyId:AccessKeyId,CreateDate:CreateDate}" --output json)
+
+    # Loop through access keys
+    for key in $(echo "$access_keys" | jq -c '.[]'); do
+        access_key_id=$(echo "$key" | jq -r '.AccessKeyId')
+        create_date=$(echo "$key" | jq -r '.CreateDate')
+
+        # Get information about the last time the key was used
+        last_used_info=$(aws iam get-access-key-last-used --access-key-id "$access_key_id")
+
+        # # Extract the LastUsedDate field
+        last_used_date=$(echo "$last_used_info" | jq -r '.AccessKeyLastUsed.LastUsedDate')
+
+        # Calculate the difference in days
+        if [ "$last_used_date" != "null" ]; then
+            last_used_seconds=$(date --date="$last_used_date" +%s)
+            days_inactive=$(( (current_date - last_used_seconds) / 86400 ))
+            
+            if (( "$days_inactive" > $deactivate_after_days )); then
+                echo "Making Access Key inactive: User: $user, Access Key: $access_key_id. It has not been used for $days_inactive days"
+                aws iam update-access-key --user-name "$user" --access-key-id "$access_key_id" --status Inactive 
+            fi
+        else
+            # If the key has never been used calculate how long ago the key was created
+            create_date_seconds=$(date --date="$create_date" +%s)
+            days_inactive=$(( (current_date - create_date_seconds) / 86400 ))
+            
+            if (( "$days_inactive" > $deactivate_after_days )); then
+                echo "Deactivating keys that have never been used"
+                echo "Making Access Key inactive: User: $user, Access Key: $access_key_id. It was created $days_inactive days ago and not used"
+                aws iam update-access-key --user-name "$user" --access-key-id "$access_key_id" --status Inactive 
+            fi
+        fi
+    done
+done

--- a/govwifi-account-policy/iam.tf
+++ b/govwifi-account-policy/iam.tf
@@ -1,0 +1,65 @@
+resource "aws_iam_role" "iam_management" {
+  count = (var.aws_region == "eu-west-2" ? 1 : 0)
+  name  = "govwifi-iam-management-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+
+EOF
+
+}
+
+resource "aws_iam_policy" "iam_management" {
+  count = (var.aws_region == "eu-west-2" ? 1 : 0)
+  name  = "GovwifiIAMUserManagment"
+  path  = "/"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:ListUsers",
+        "iam:ListAccessKeys",
+        "iam:GetAccessKeyLastUsed",
+        "iam:UpdateAccessKey"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:*"
+      ]
+    }
+  ]
+}
+
+EOF
+
+}
+
+resource "aws_iam_role_policy_attachment" "iam_management" {
+  count      = (var.aws_region == "eu-west-2" ? 1 : 0)
+  role       = aws_iam_role.iam_management[0].name
+  policy_arn = aws_iam_policy.iam_management[0].arn
+}
+

--- a/govwifi-account-policy/s3.tf
+++ b/govwifi-account-policy/s3.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_bucket" "iam_user_managment_logs" {
+  bucket = "govwifi-iam-user-managment-logs-${var.env}-${lower(var.region_name)}"
+}
+
+resource "aws_s3_bucket_public_access_block" "iam_user_managment_logs" {
+  bucket = aws_s3_bucket.iam_user_managment_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/govwifi-account-policy/variables.tf
+++ b/govwifi-account-policy/variables.tf
@@ -1,0 +1,12 @@
+variable "aws_region" {
+}
+
+variable "env" {
+}
+
+variable "aws_account_id" {
+}
+
+variable "region_name" {
+}
+

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -431,4 +431,9 @@ module "london_account_policy" {
 
   source = "../../govwifi-account-policy"
 
+  aws_region     = local.london_aws_region
+  env            = local.env
+  aws_account_id = local.aws_account_id
+  region_name    = local.london_aws_region_name
+
 }

--- a/govwifi/alpaca/variables.tf
+++ b/govwifi/alpaca/variables.tf
@@ -4,7 +4,7 @@ variable "ssh_key_name" {
 }
 
 variable "ssh_key_name_pub" {
-  type = string
+  type    = string
   default = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC4q8NhyH2wtEj8CiqOn+4OFgrB6wZgdzB/qjEh1t7ATQwgkFii0vtsJIzTfOVyxLr0rF79TQCdy7RcVidnZJOoa6QYJRDUx61f2bSacDsiI04/6QSAzqYe0x12fDoRMZqU6GWN1tRY3HYGdLCSMo8QaYonpdiyuS2q+gzFl1V1pk2c3/VT0KhZMWPV1qh6y6uCV13CkiFEgRpqhWTxfagv38lCRFvgJVmNxXtwBME8lqAs7DRoxfD5WZ4oGWO+wCaw+3QgD6gGDMUxpLk1CtL0BVpZ73OGB1XW2atTf2Ugma1jLMvP5IIrEDhMfOEX4iFexRVZBTqIqmsFaHjTH6BRp0J5FJ4suDVIv9eMblgZEGomDmP/T3ZIUq+96Z5BcOLpW1dEdCswbXtzuw7F+hIceSbnYMefSJ/8mhjxTcvBrJK4pv/BKEx/1UBOYtcwu3PZ52oiQaFFxElJiFTa/SUTLAks50e90o7kIZo2z4eal2e5mvWLSNwjA5kCniATfTs= govwifi-developers@digital.cabinet-office.gov.uk"
 }
 

--- a/govwifi/staging/.terraform.lock.hcl
+++ b/govwifi/staging/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   version = "2.4.0"
   hashes = [
     "h1:EtN1lnoHoov3rASpgGmh6zZ/W6aRCTgKC7iMwvFY1yc=",
+    "h1:cJokkjeH1jfpG4QEHdRx0t2j8rr52H33A7C/oX73Ok4=",
     "zh:18e408596dd53048f7fc8229098d0e3ad940b92036a24287eff63e2caec72594",
     "zh:392d4216ecd1a1fd933d23f4486b642a8480f934c13e2cae3c13b6b6a7e34a7b",
     "zh:655dd1fa5ca753a4ace21d0de3792d96fff429445717f2ce31c125d19c38f3ff",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "5.12.0"
   hashes = [
     "h1:3Gchmc4oyFvWh3B4tEOQN5UOCd0bfp0P4fEgdpatmlo=",
+    "h1:i28TUsgqoKs891cyDU0V9fFAwEz/RqbwF8sQShLfNq0=",
     "zh:0953565eb67ece49556dc9046c77322dc6c76e0ae6fa0c9fd6710b6afa2588c9",
     "zh:43676f3592c127a971719cc37b9199967376fb05d445b356f1545609e2b84bf8",
     "zh:46422ab8044b35e90f422ffabc17fa043ec8e4a33e3df2f8b305d63a950c0edb",
@@ -45,6 +47,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -432,4 +432,10 @@ module "london_account_policy" {
 
   source = "../../govwifi-account-policy"
 
+  aws_region     = local.london_aws_region
+  env            = local.env
+  aws_account_id = local.aws_account_id
+  region_name    = local.london_aws_region_name
+
 }
+

--- a/govwifi/tools/data.tf
+++ b/govwifi/tools/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/govwifi/tools/locals.tf
+++ b/govwifi/tools/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  aws_account_id = data.aws_caller_identity.current.account_id
+}

--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -48,4 +48,9 @@ module "govwifi_account_policy" {
 
   source = "../../govwifi-account-policy"
 
+  aws_region     = var.aws_region
+  env            = "tools"
+  aws_account_id = local.aws_account_id
+  region_name    = "London"
+
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -565,4 +565,9 @@ module "govwifi_account_policy" {
 
   source = "../../govwifi-account-policy"
 
+  aws_region     = "eu-west-2"
+  env            = local.env
+  aws_account_id = local.aws_account_id
+  region_name    = "London"
+
 }


### PR DESCRIPTION

### What
Deactivate the access keys of any IAM users that have not been used in 45 days. This commit adds a codebuild job and a shell script to achieve this.

### Why
This was a recommendation of the 2023 IT Healthcheck

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1021
