### PR TITLE
Ensure that EC2 Metadata Service only allows IMDSv2

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -32,6 +32,11 @@ resource "aws_instance" "management" {
 
   depends_on = [aws_iam_instance_profile.bastion_instance_profile]
 
+  metadata_options {
+    http_endpoint               = "disabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
 
   root_block_device {
     volume_size = 30

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -48,6 +48,12 @@ resource "aws_instance" "grafana_instance" {
     Name = "${title(var.env_name)} Grafana-Server"
   }
 
+  metadata_options {
+    http_endpoint               = "disabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
   root_block_device {
     volume_size = 30
     encrypted = true

--- a/govwifi-prometheus/instances.tf
+++ b/govwifi-prometheus/instances.tf
@@ -53,6 +53,12 @@ resource "aws_instance" "prometheus_instance" {
     Name = "${title(var.env_name)} Prometheus-Server"
   }
 
+  metadata_options {
+    http_endpoint               = "disabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
   root_block_device {
     volume_size = 30
     encrypted = true


### PR DESCRIPTION
### What
Ensure that EC2 Metadata Service is only enabled if necessary, and only allows IMDSv2

### Why
Recommended by the ITHC

Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1070
