### PR TITLE
Remove ACL on access logs replication S3 bucket

### DIFF
--- a/new-terraform-state/replication_accesslogs_bucket.tf
+++ b/new-terraform-state/replication_accesslogs_bucket.tf
@@ -16,11 +16,6 @@ resource "aws_s3_bucket_public_access_block" "replication_accesslogs_bucket" {
   restrict_public_buckets = true
 }
 
-resource "aws_s3_bucket_acl" "replication_accesslogs_bucket" {
-  bucket = aws_s3_bucket.replication_accesslogs_bucket.id
-  acl    = "log-delivery-write"
-}
-
 resource "aws_s3_bucket_versioning" "replication_accesslogs_bucket" {
   bucket = aws_s3_bucket.replication_accesslogs_bucket.id
 


### PR DESCRIPTION
### What
Remove S3 Bucket ACL

### Why
This is no longer necessary. We have blocked public access to the necessary buckets in this PR: https://github.com/alphagov/govwifi-terraform/pull/817. Due to a change by AWS creating ACLs now causes a terraform apply error: https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1063
