### PR TITLE
Increase the timeout of smoke-tests

### DIFF
--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -1,7 +1,7 @@
 resource "aws_codebuild_project" "smoke_tests" {
   name          = "govwifi-smoke-tests"
   description   = "This project runs the govwifi tests at regular intervals"
-  build_timeout = "10"
+  build_timeout = "15"
   service_role  = aws_iam_role.govwifi_codebuild.arn
 
   artifacts {


### PR DESCRIPTION
### What
Increase the timeout of smoke-tests

### Why
We experiencing quite a few false flags, because we are waiting for Notify to respond.

