### PR TITLE
Add database parameter group for mysql 8 admin database

### DIFF
--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -82,7 +82,7 @@ resource "aws_db_instance" "admin_db" {
   allocated_storage           = var.db_storage_gb
   storage_type                = "gp2"
   engine                      = "mysql"
-  engine_version              = "5.7"
+  engine_version              = "8.3"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true
@@ -104,8 +104,8 @@ resource "aws_db_instance" "admin_db" {
   deletion_protection         = true
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
-  option_group_name               = aws_db_option_group.mariadb_audit.name
-  parameter_group_name            = aws_db_parameter_group.db_parameters.name
+  option_group_name               = "default:mysql-8-0"
+  parameter_group_name            = aws_db_parameter_group.db_parameters_v8.name
 
   tags = {
     Name = "${title(var.env_name)} DB for govwifi-admin"

--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -28,6 +28,40 @@ resource "aws_db_parameter_group" "db_parameters" {
   }
 }
 
+
+
+resource "aws_db_parameter_group" "db_parameters_v8" {
+  name        = "${var.env_name}-mysql8-admin-db-parameter-group"
+  family      = "mysql8.0"
+  description = "DB parameter configuration for govwifi-admin"
+
+  parameter {
+    name  = "slow_query_log"
+    value = 1
+  }
+
+  parameter {
+    name  = "general_log"
+    value = 0
+  }
+
+  parameter {
+    name  = "log_queries_not_using_indexes"
+    value = 1
+  }
+
+  parameter {
+    name  = "log_output"
+    value = "FILE"
+  }
+
+  tags = {
+    Name = "${title(var.env_name)} mysql 8 DB parameter group for govwifi-admin"
+  }
+}
+
+
+
 resource "aws_db_option_group" "mariadb_audit" {
   name = "${var.env_name}-admin-db-audit"
 

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -173,7 +173,7 @@ module "london_admin" {
 
   subnet_ids = module.london_backend.backend_subnet_ids
 
-  db_instance_type         = "db.t2.medium"
+  db_instance_type         = "db.t3.medium"
   db_storage_gb            = 120
   db_backup_retention_days = 1
   db_encrypt_at_rest       = true

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -173,7 +173,7 @@ module "london_admin" {
 
   subnet_ids = module.london_backend.backend_subnet_ids
 
-  db_instance_type         = "db.t2.medium"
+  db_instance_type         = "db.t3.medium"
   db_storage_gb            = 120
   db_backup_retention_days = 1
   db_encrypt_at_rest       = true

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -241,7 +241,7 @@ module "govwifi_admin" {
 
   subnet_ids = module.backend.backend_subnet_ids
 
-  db_instance_type         = "db.t2.large"
+  db_instance_type         = "db.t3.large"
   db_storage_gb            = 120
   db_backup_retention_days = 1
   db_encrypt_at_rest       = true


### PR DESCRIPTION
### What
Add database parameter group for mysql 8 admin database

### Why
We are upgrading the admin database to Mysql 8. Making database parameter groups compatible. This will be merged during the maintenance window when the actual upgrade to production is performed.

Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1179
