### PR TITLE
add the dublin provider in order to update the bucket

### DIFF
--- a/govwifi-deploy/s3.tf
+++ b/govwifi-deploy/s3.tf
@@ -86,6 +86,7 @@ resource "aws_s3_bucket_acl" "codepipeline_bucket_acl_ireland" {
 resource "aws_s3_bucket_public_access_block" "codepipeline_bucket_ireland" {
   bucket = aws_s3_bucket.codepipeline_bucket_ireland.id
 
+  provider = aws.dublin
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true


### PR DESCRIPTION
### What
We need to add the Dublin provider in order to update this bucket.

### Why
terraform failing to execute changes to the bucket when assuming provider London

Link to Trello card (if applicable): 
No trello card.

### Testing
Terraform AWS Tools account using this branch. (Already tested and applied)