### PR TITLE
GW-1125 smoke tests fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,9 +411,9 @@ You will also need to do the following in the tools account:
 - If you are attempting to recover the production environment change the RDS instance type for the `session` database to the `m4.xlarge` and allocate `400GB` of `gp3` storage which gives you `12000IOPS` and `500mbps`. You may need to consider disabling the Multi-AZ setup while restoring data.
 
 - For an environment other than the Production ensure RDS database names are:
-  - For the Users Database is set as `govwifi_staging_users`
+  - For the Users Database is set as `govwifi_<ENV>_users`
   - For the Session Database is set as `govwifi_<ENV>`
-  - For the Admin Database is set as `govwifi_staging_users`
+  - For the Admin Database is set as `govwifi_admin_staging`
 
 - If you are setting up a new environment and the `app_env` variable has been set to `staging` then copy the databases from the pre-existing staging environment and leave any references to `staging` in the database names unchanged. For example the user database name would be left as `govwifi_staging_users`. The `app_env` value in terraform MUST match the database environment reference otherwise the GovWifi applications will fail to start.
 

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -29,8 +29,9 @@ variable "ecr_repository_count" {
 }
 
 variable "rails_env" {
-  description = "E.g. staging"
+  description = "the Ruby environment, E.g. alpaca, staging"
 }
+
 
 variable "sentry_current_env" {
   description = "The environment that Sentry will log errors to: e.g. staging"

--- a/govwifi-smoke-tests/locals.tf
+++ b/govwifi-smoke-tests/locals.tf
@@ -1,4 +1,5 @@
+## Relates to the Smoke Test Notify Account!
 locals {
-  notify_go_template_id  = "8304abb4-e829-442d-a06e-2ae485f5dd5a"
-  smoketest_phone_number = "+447860003687"
+  notify_go_template_id  = "ab004ebd-c74f-43e3-95bc-60c9bd325a83"
+  smoketest_phone_number = "+447860003343"
 }

--- a/govwifi-smoke-tests/locals.tf
+++ b/govwifi-smoke-tests/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  notify_go_template_id  = "ab004ebd-c74f-43e3-95bc-60c9bd325a83"
-  smoketest_phone_number = "+447860003343"
+  notify_go_template_id  = "8304abb4-e829-442d-a06e-2ae485f5dd5a"
+  smoketest_phone_number = "+447860003687"
 }

--- a/govwifi/alpaca/dublin.tf
+++ b/govwifi/alpaca/dublin.tf
@@ -284,7 +284,7 @@ module "dublin_api" {
   user_rr_hostname = "users-rr.${lower(local.dublin_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
 
   rack_env                = "alpaca"
-  app_env                 = "staging"
+  app_env                 = "alpaca"
   sentry_current_env      = "alpaca"
   radius_server_ips       = local.frontend_radius_ips
   subnet_ids              = module.dublin_backend.backend_subnet_ids

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -166,8 +166,8 @@ module "london_admin" {
   route53_zone_id = data.aws_route53_zone.main.zone_id
 
   admin_docker_image   = format("%s/admin:alpaca", local.docker_image_path)
-  rails_env            = "alpaca"
-  app_env              = "alpaca"
+  rails_env            = "alpaca" 
+  app_env              = "alpaca" ## used for db name.
   sentry_current_env   = "alpaca"
   ecr_repository_count = 1
 

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -166,7 +166,7 @@ module "london_admin" {
   route53_zone_id = data.aws_route53_zone.main.zone_id
 
   admin_docker_image   = format("%s/admin:alpaca", local.docker_image_path)
-  rails_env            = "alpaca"
+  rails_env            = "development"
   app_env              = "staging"
   sentry_current_env   = "alpaca"
   ecr_repository_count = 1

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -166,7 +166,7 @@ module "london_admin" {
   route53_zone_id = data.aws_route53_zone.main.zone_id
 
   admin_docker_image   = format("%s/admin:alpaca", local.docker_image_path)
-  rails_env            = "development"
+  rails_env            = "alpaca"
   app_env              = "staging"
   sentry_current_env   = "alpaca"
   ecr_repository_count = 1

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -185,7 +185,7 @@ module "london_admin" {
   rr_db_name = "govwifi_alpaca"
 
   user_db_host = "users-db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
-  user_db_name = "govwifi_staging_users"
+  user_db_name = "govwifi_alpaca_users"
 
   critical_notifications_arn = module.london_notifications.topic_arn
   capacity_notifications_arn = module.london_notifications.topic_arn

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -167,7 +167,7 @@ module "london_admin" {
 
   admin_docker_image   = format("%s/admin:alpaca", local.docker_image_path)
   rails_env            = "alpaca"
-  app_env              = "staging"
+  app_env              = "alpaca"
   sentry_current_env   = "alpaca"
   ecr_repository_count = 1
 


### PR DESCRIPTION
Admin App needs merging first.
### What
Change app env to alpaca to pick up the correct database and Ruby config.

### Why
To allow the smoke tests to run on each environment independently 


Link to Trello card (if applicable): 
GW-1125