### PR TITLE
feat: [GW-1125] add notify field var to smoke tests

### DIFF
--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -101,6 +101,11 @@ resource "aws_codebuild_project" "smoke_tests" {
       name  = "NOTIFY_SMOKETEST_API_KEY"
       value = data.aws_secretsmanager_secret_version.notify_smoketest_api_key.secret_string
     }
+
+    environment_variable {
+      name  = "NOTIFY_FIELD"
+      value = "${var.notify_field}"
+    }
   }
 
   source {

--- a/govwifi-smoke-tests/variables.tf
+++ b/govwifi-smoke-tests/variables.tf
@@ -30,3 +30,6 @@ variable "create_slack_alert" {
 
 variable "govwifi_phone_number" {
 }
+
+variable "notify_field" {    
+}

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -405,7 +405,7 @@ module "london_smoke_tests" {
   aws_region                 = local.london_aws_region
   create_slack_alert         = 0
   govwifi_phone_number       = "+447860003687"
-
+  notify_field               = "govwifidevelopment"
   depends_on = [
     module.london_frontend
   ]

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -406,6 +406,7 @@ module "london_smoke_tests" {
   aws_region                 = local.london_aws_region
   create_slack_alert         = 0
   govwifi_phone_number       = "+447537417039"
+  notify_field               = "govwifistaging"
 
   depends_on = [
     module.london_frontend

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -524,7 +524,7 @@ module "smoke_tests" {
   aws_region                 = var.aws_region
   create_slack_alert         = 1
   govwifi_phone_number       = "+447537417417"
-
+  notify_field               = "govwifi"
   depends_on = [
     module.frontend
   ]


### PR DESCRIPTION
What
Add a new env var to the smoke tests for each env to specify the notify field for email.

Why
To allow the smoke tests to run on each environment independently

Link to Trello card (if applicable):
GW-1125