### PR TITLE
Correction to database engine version

### DIFF
--- a/govwifi-admin/db.tf
+++ b/govwifi-admin/db.tf
@@ -82,7 +82,7 @@ resource "aws_db_instance" "admin_db" {
   allocated_storage           = var.db_storage_gb
   storage_type                = "gp2"
   engine                      = "mysql"
-  engine_version              = "8.3"
+  engine_version              = "8.0"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true


### PR DESCRIPTION
### What
Correction to database engine version

### Why
Database engine version needs to be set to 8.0

