### PR TITLE
Update Product Page DNS Record to Point to Github Pages

### DIFF
--- a/govwifi-admin/route53.tf
+++ b/govwifi-admin/route53.tf
@@ -15,5 +15,5 @@ resource "aws_route53_record" "www" {
   name    = "www.${var.env_subdomain}.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
-  records = ["d2j0ojhs7n2cwa.cloudfront.net"]
+  records = ["alphagov.github.io."]
 }


### PR DESCRIPTION
### What
Update Product Page DNS Record to Point to Github Pages

### Why
We have migrated the product pages from PaaS to Github pages. Updating DNS to match change of host.

Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/browse/GW-1162 
