### PR TITLE
Add certificates to smoke tests to support EAP-TLS

### DIFF
--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -106,6 +106,17 @@ resource "aws_codebuild_project" "smoke_tests" {
       name  = "NOTIFY_FIELD"
       value = var.notify_field
     }
+
+    environment_variable {
+      name  = "EAP_TLS_CLIENT_CERT"
+      value = data.aws_secretsmanager_secret_version.eap_tls_client_cert.secret_string
+    }
+
+    environment_variable {
+      name  = "EAP_TLS_CLIENT_KEY"
+      value = data.aws_secretsmanager_secret_version.eap_tls_client_key.secret_string
+    }
+
   }
 
   source {

--- a/govwifi-smoke-tests/secrets-manager.tf
+++ b/govwifi-smoke-tests/secrets-manager.tf
@@ -80,6 +80,22 @@ data "aws_secretsmanager_secret" "notify_smoketest_api_key" {
   name = "smoketests/notify_smoketest_api_key"
 }
 
+data "aws_secretsmanager_secret_version" "eap_tls_client_cert" {
+  secret_id = data.aws_secretsmanager_secret.eap_tls_client_cert.id
+}
+
+data "aws_secretsmanager_secret" "eap_tls_client_cert" {
+  name = "smoke_tests/certificates/public"
+}
+
+data "aws_secretsmanager_secret_version" "eap_tls_client_key" {
+  secret_id = data.aws_secretsmanager_secret.eap_tls_client_key.id
+}
+
+data "aws_secretsmanager_secret" "eap_tls_client_key" {
+  name = "smoke_tests/certificates/private"
+}
+
 data "aws_secretsmanager_secret_version" "google_api_credentials" {
   secret_id = data.aws_secretsmanager_secret.google_api_credentials.id
 }


### PR DESCRIPTION
Make a certificate / private key available to the smoke tests so that they can test EAP-TLS

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1117