### PR TITLE
Add GovWifi Docs DNS Records To Terraform

### DIFF
--- a/govwifi-admin/route53.tf
+++ b/govwifi-admin/route53.tf
@@ -9,11 +9,3 @@ resource "aws_route53_record" "admin" {
     evaluate_target_health = true
   }
 }
-
-resource "aws_route53_record" "www" {
-  zone_id = var.route53_zone_id
-  name    = "www.${var.env_subdomain}.service.gov.uk"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["alphagov.github.io."]
-}

--- a/govwifi-docs/README.md
+++ b/govwifi-docs/README.md
@@ -1,0 +1,5 @@
+This module manages the DNS for the GovWifi Docs which are hosted on Github pages.
+
+- [Team Manual/Developer Docs](https://dev-docs.wifi.service.gov.uk/)
+- [Technical Documentation - for network administrators](https://docs.wifi.service.gov.uk/)
+- [Product Pages](https://www.wifi.service.gov.uk/)

--- a/govwifi-docs/main.tf
+++ b/govwifi-docs/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/govwifi-docs/route_53.tf
+++ b/govwifi-docs/route_53.tf
@@ -1,0 +1,24 @@
+resource "aws_route53_record" "www" {
+  zone_id = var.route53_zone_id
+  name    = "www.wifi.service.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["alphagov.github.io."]
+}
+
+resource "aws_route53_record" "tech_docs" {
+  zone_id = var.route53_zone_id
+  name    = "docs.wifi.service.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["alphagov.github.io."]
+}
+
+resource "aws_route53_record" "dev_docs" {
+  zone_id = var.route53_zone_id
+  name    = "dev-docs.wifi.service.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["alphagov.github.io."]
+}
+

--- a/govwifi-docs/variables.tf
+++ b/govwifi-docs/variables.tf
@@ -1,0 +1,7 @@
+variable "aws_region" {
+}
+
+variable "route53_zone_id" {
+}
+
+

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -571,3 +571,15 @@ module "govwifi_account_policy" {
   region_name    = "London"
 
 }
+
+module "govwifi_docs" {
+  providers = {
+    aws = aws.main
+  }
+
+  source = "../../govwifi-docs"
+
+  aws_region      = "eu-west-2"
+  route53_zone_id = data.aws_route53_zone.main.zone_id
+
+}


### PR DESCRIPTION
### What

These two DNS Records exist in our production AWS account: https://dev-docs.wifi.service.gov.uk/
https://docs.wifi.service.gov.uk/
However were are not in our terraform. Now added in new module.

DNS record for the product page docs have been added to the new module, and moved from the admin module as this is more logical.

### Why

All our DNS records should be in terraform, so we can recreate our infrastructure 

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1263