### PR TITLE
increase storage from 20 to 30Gb because we cant decrease easily

### DIFF
--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -60,7 +60,7 @@ module "london_backend" {
   aws_account_id            = local.aws_account_id
   db_instance_count         = 1
   session_db_instance_type  = "db.t2.small"
-  session_db_storage_gb     = 20
+  session_db_storage_gb     = 30
   db_backup_retention_days  = 1
   db_encrypt_at_rest        = true
   db_maintenance_window     = "sat:01:42-sat:02:12"


### PR DESCRIPTION
### What
Increase Dev sessions DB storage to 30Gb

### Why
During restore testing, the storage filled, so we are operating close to the limit. After temporarily increasing the size to enable testing to complete, it's now possible to downsize (AWS constraint) without the pain of replicating and migrating. So let's leave it at 30Gb and prevent this piece of work popping up again in a short time.


### Link to JIRA card (if applicable): 
[None](https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?label=GovWifi-SRE&selectedIssue=GW-975)