### PR TITLE
Upgrade Sessions Database

### DIFF
--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -3,7 +3,7 @@ resource "aws_db_instance" "db" {
   allocated_storage           = var.session_db_storage_gb
   storage_type                = "gp2"
   engine                      = "mysql"
-  engine_version              = "5.7"
+  engine_version              = "8.0"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -92,7 +92,7 @@ variable "rr_storage_gb" {
 }
 
 variable "user_rr_instance_type" {
-  default = "db.t2.medium"
+  default = "db.t3.medium"
 }
 
 variable "critical_notifications_arn" {

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -124,7 +124,7 @@ module "dublin_backend" {
 
   user_db_replica_count  = 1
   user_replica_source_db = "arn:aws:rds:eu-west-2:${local.aws_account_id}:db:wifi-staging-user-db"
-  user_rr_instance_type  = "db.t2.small"
+  user_rr_instance_type  = "db.t3.small"
 
   # TODO This should happen inside the module
   user_rr_hostname           = "users-rr.${lower(local.dublin_aws_region_name)}.${local.env_subdomain}.service.gov.uk"

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -59,14 +59,14 @@ module "london_backend" {
   enable_bastion_monitoring = false
   aws_account_id            = local.aws_account_id
   db_instance_count         = 1
-  session_db_instance_type  = "db.t2.small"
+  session_db_instance_type  = "db.t3.small"
   session_db_storage_gb     = 20
   db_backup_retention_days  = 1
   db_encrypt_at_rest        = true
   db_maintenance_window     = "sat:01:42-sat:02:12"
   db_backup_window          = "04:42-05:42"
   db_replica_count          = 0
-  rr_instance_type          = "db.t2.large"
+  rr_instance_type          = "db.t3.large"
   rr_storage_gb             = 200
   # TODO This should happen inside the module
   user_rr_hostname           = "users-rr.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
@@ -79,7 +79,7 @@ module "london_backend" {
   # Passed to application
   # TODO This should happen inside the module
   user_db_hostname      = "users-db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
-  user_db_instance_type = "db.t2.small"
+  user_db_instance_type = "db.t3.small"
   user_db_storage_gb    = 20
 
   prometheus_ip_london  = module.london_prometheus.eip_public_ip

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -122,14 +122,14 @@ module "backend" {
   enable_bastion_monitoring  = true
   aws_account_id             = local.aws_account_id
   db_instance_count          = 1
-  session_db_instance_type   = "db.m4.xlarge"
+  session_db_instance_type   = "db.m5.xlarge"
   session_db_storage_gb      = 1000
   db_backup_retention_days   = 7
   db_encrypt_at_rest         = true
   db_maintenance_window      = "wed:01:42-wed:02:12"
   db_backup_window           = "03:05-04:05"
   db_replica_count           = 1
-  rr_instance_type           = "db.m4.xlarge"
+  rr_instance_type           = "db.m5.xlarge"
   rr_storage_gb              = 1000
   critical_notifications_arn = module.critical_notifications.topic_arn
   capacity_notifications_arn = module.capacity_notifications.topic_arn
@@ -141,7 +141,7 @@ module "backend" {
   # Passed to application
   user_db_hostname      = var.user_db_hostname
   user_rr_hostname      = var.user_rr_hostname
-  user_db_instance_type = "db.t2.medium"
+  user_db_instance_type = "db.t3.medium"
   user_db_storage_gb    = 1000
   user_db_replica_count = 1
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -125,7 +125,7 @@ module "backend" {
   aws_account_id            = local.aws_account_id
 
   db_instance_count        = 0
-  session_db_instance_type = "db.m4.xlarge"
+  session_db_instance_type = "db.m5.xlarge"
   session_db_storage_gb    = 1000
   db_backup_retention_days = 7
   db_encrypt_at_rest       = true
@@ -134,7 +134,7 @@ module "backend" {
 
   db_replica_count      = 0
   user_db_replica_count = 1
-  rr_instance_type      = "db.m3.medium"
+  rr_instance_type      = "db.m5.medium"
   rr_storage_gb         = 1000
 
   critical_notifications_arn = module.critical_notifications.topic_arn
@@ -145,7 +145,7 @@ module "backend" {
   db_monitoring_interval = 60
 
   # Passed to application
-  user_db_instance_type = "db.t2.medium"
+  user_db_instance_type = "db.t3.medium"
   user_db_hostname      = var.user_db_hostname
   user_db_storage_gb    = 20
   user_rr_hostname      = var.user_rr_hostname


### PR DESCRIPTION
### What
Update MySQL to version 8 on sessions databases in Staging and Production. Upgrade sessions and user database instance type.

### Why
AWS is retiring their RDS M4 and T2 Instance types and recommends upgrading them to M5 and T3 types respectively. According to AWS these provide improved performance due to increased computing capacity . The M5 instances are powered by the AWS Nitro System. More details can be found here: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1133
