### PR TITLE
Update DNS Records For Documentation Pages

### DIFF
--- a/govwifi-docs/route_53.tf
+++ b/govwifi-docs/route_53.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_record" "www" {
+resource "aws_route53_record" "www_wifi" {
   zone_id = var.route53_zone_id
   name    = "www.wifi.service.gov.uk"
   type    = "CNAME"
@@ -6,19 +6,44 @@ resource "aws_route53_record" "www" {
   records = ["alphagov.github.io."]
 }
 
-resource "aws_route53_record" "tech_docs" {
+resource "aws_route53_record" "wifi_apex" {
   zone_id = var.route53_zone_id
-  name    = "docs.wifi.service.gov.uk"
+  name    = "wifi.service.gov.uk"
+  type    = "A"
+  ttl     = "300"
+  records = ["185.199.108.153","185.199.109.153","185.199.110.153","185.199.111.153"]
+}
+
+
+resource "aws_route53_record" "www_tech_docs" {
+  zone_id = var.route53_zone_id
+  name    = "www.docs.wifi.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
   records = ["alphagov.github.io."]
 }
 
-resource "aws_route53_record" "dev_docs" {
+resource "aws_route53_record" "tech_docs_apex" {
   zone_id = var.route53_zone_id
-  name    = "dev-docs.wifi.service.gov.uk"
+  name    = "docs.wifi.service.gov.uk"
+  type    = "A"
+  ttl     = "300"
+  records = ["185.199.108.153","185.199.109.153","185.199.110.153","185.199.111.153"]
+}
+
+resource "aws_route53_record" "www_dev_docs" {
+  zone_id = var.route53_zone_id
+  name    = "www.dev-docs.wifi.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
   records = ["alphagov.github.io."]
+}
+
+resource "aws_route53_record" "dev_docs_apex" {
+  zone_id = var.route53_zone_id
+  name    = "dev-docs.wifi.service.gov.uk"
+  type    = "A"
+  ttl     = "300"
+  records = ["185.199.108.153","185.199.109.153","185.199.110.153","185.199.111.153"]
 }
 


### PR DESCRIPTION
### What
Update DNS Records For Documentation Pages

### Why
Remove connection to PaaS

Add www counterpart records so our domain names will work with Github pages. See here for more information:
https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages

