### PR TITLE
DNS record correction

### DIFF
--- a/govwifi-docs/route_53.tf
+++ b/govwifi-docs/route_53.tf
@@ -14,36 +14,19 @@ resource "aws_route53_record" "wifi_apex" {
   records = ["185.199.108.153","185.199.109.153","185.199.110.153","185.199.111.153"]
 }
 
-
-resource "aws_route53_record" "www_tech_docs" {
-  zone_id = var.route53_zone_id
-  name    = "www.docs.wifi.service.gov.uk"
-  type    = "CNAME"
-  ttl     = "300"
-  records = ["alphagov.github.io."]
-}
-
-resource "aws_route53_record" "tech_docs_apex" {
+resource "aws_route53_record" "tech_docs" {
   zone_id = var.route53_zone_id
   name    = "docs.wifi.service.gov.uk"
-  type    = "A"
-  ttl     = "300"
-  records = ["185.199.108.153","185.199.109.153","185.199.110.153","185.199.111.153"]
-}
-
-resource "aws_route53_record" "www_dev_docs" {
-  zone_id = var.route53_zone_id
-  name    = "www.dev-docs.wifi.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
   records = ["alphagov.github.io."]
 }
 
-resource "aws_route53_record" "dev_docs_apex" {
+resource "aws_route53_record" "dev_docs" {
   zone_id = var.route53_zone_id
   name    = "dev-docs.wifi.service.gov.uk"
-  type    = "A"
+  type    = "CNAME"
   ttl     = "300"
-  records = ["185.199.108.153","185.199.109.153","185.199.110.153","185.199.111.153"]
+  records = ["alphagov.github.io."]
 }
 


### PR DESCRIPTION
### What
Remove www record for some documentation pages

### Why
We chatted with our TA about this, it was causing some needless complications in the DNS routing. So the www in record has been removed.


