### PR TITLE
Upgrade grafana

### DIFF
--- a/govwifi-backend/db-parameters.tf
+++ b/govwifi-backend/db-parameters.tf
@@ -138,7 +138,7 @@ resource "aws_db_option_group" "mariadb_audit" {
 
   option_group_description = "Mariadb audit configuration"
   engine_name              = "mysql"
-  major_engine_version     = "8.0"
+  major_engine_version     = "5.7"
 
   option {
     option_name = "MARIADB_AUDIT_PLUGIN"

--- a/govwifi-backend/db-parameters.tf
+++ b/govwifi-backend/db-parameters.tf
@@ -11,7 +11,7 @@ resource "aws_db_subnet_group" "db_subnets" {
 resource "aws_db_parameter_group" "db_parameters" {
   count       = var.db_instance_count
   name        = "${var.env_name}-db-parameter-group"
-  family      = "mysql5.7"
+  family      = "mysql8.0"
   description = "DB parameter configuration"
 
   parameter {
@@ -73,7 +73,7 @@ resource "aws_db_parameter_group" "user_db_parameters" {
 resource "aws_db_parameter_group" "rr_parameters" {
   name = "${var.env_name}-rr-parameter-group"
 
-  family      = "mysql5.7"
+  family      = "mysql8.0"
   description = "DB read replica parameter configuration"
 
   parameter {
@@ -138,7 +138,7 @@ resource "aws_db_option_group" "mariadb_audit" {
 
   option_group_description = "Mariadb audit configuration"
   engine_name              = "mysql"
-  major_engine_version     = "5.7"
+  major_engine_version     = "8.0"
 
   option {
     option_name = "MARIADB_AUDIT_PLUGIN"

--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -3,7 +3,7 @@ resource "aws_db_instance" "db" {
   allocated_storage           = var.session_db_storage_gb
   storage_type                = "gp2"
   engine                      = "mysql"
-  engine_version              = "5.7"
+  engine_version              = "8.0"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   apply_immediately           = true

--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -51,7 +51,6 @@ resource "aws_db_instance" "read_replica" {
   apply_immediately           = true
   instance_class              = var.rr_instance_type
   identifier                  = "${var.env_name}-db-rr"
-  password                    = local.session_db_password
   backup_retention_period     = 0
   multi_az                    = false
   storage_encrypted           = var.db_encrypt_at_rest

--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -27,7 +27,7 @@ resource "aws_db_instance" "db" {
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
   option_group_name               = "default:mysql-8-0"
-  parameter_group_name            = aws_db_parameter_group.db_parameters[0].name
+  parameter_group_name            = "default.mysql8.0"
 
   tags = {
     Name = "${title(var.env_name)} DB"

--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -26,7 +26,7 @@ resource "aws_db_instance" "db" {
   deletion_protection         = true
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
-  option_group_name               = aws_db_option_group.mariadb_audit.name
+  option_group_name               = "default:mysql-8-0"
   parameter_group_name            = aws_db_parameter_group.db_parameters[0].name
 
   tags = {
@@ -62,7 +62,7 @@ resource "aws_db_instance" "read_replica" {
   maintenance_window          = var.db_maintenance_window
   backup_window               = var.db_backup_window
   skip_final_snapshot         = true
-  option_group_name           = aws_db_option_group.mariadb_audit.name
+  option_group_name           = "default:mysql-8-0"
   parameter_group_name        = aws_db_parameter_group.rr_parameters.name
   deletion_protection         = true
 

--- a/govwifi-backend/variables.tf
+++ b/govwifi-backend/variables.tf
@@ -92,7 +92,7 @@ variable "rr_storage_gb" {
 }
 
 variable "user_rr_instance_type" {
-  default = "db.t2.medium"
+  default = "db.t3.medium"
 }
 
 variable "critical_notifications_arn" {

--- a/govwifi-frontend/load-balancer.tf
+++ b/govwifi-frontend/load-balancer.tf
@@ -46,22 +46,3 @@ resource "aws_lb_target_group" "main" {
     type = "source_ip"
   }
 }
-
-/*
-# TODO These EIPs are being used to test the network load balancer,
-# and can be replaced by the radius_eips once the network load
-# balancer is used behind these eips
-resource "aws_eip" "test_radius_eips" {
-  count = var.radius_instance_count
-  vpc   = true
-
-  lifecycle {
-    prevent_destroy = true
-  }
-
-  tags = {
-    Name   = "${title(var.env_name)} Frontend Radius-${var.dns_numbering_base + count.index + 1}"
-    Region = title(var.aws_region_name)
-  }
-}
-*/

--- a/govwifi-frontend/load-balancer.tf
+++ b/govwifi-frontend/load-balancer.tf
@@ -47,6 +47,7 @@ resource "aws_lb_target_group" "main" {
   }
 }
 
+/*
 # TODO These EIPs are being used to test the network load balancer,
 # and can be replaced by the radius_eips once the network load
 # balancer is used behind these eips
@@ -63,3 +64,4 @@ resource "aws_eip" "test_radius_eips" {
     Region = title(var.aws_region_name)
   }
 }
+*/

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -48,11 +48,11 @@ resource "aws_instance" "grafana_instance" {
     Name = "${title(var.env_name)} Grafana-Server"
   }
 
-  metadata_options {
-    http_endpoint               = "disabled"
-    http_tokens                 = "required"
-    http_put_response_hop_limit = 1
-  }
+  # metadata_options {
+  #   http_endpoint               = "disabled"
+  #   http_tokens                 = "required"
+  #   http_put_response_hop_limit = 1
+  # }
 
   root_block_device {
     volume_size = 30

--- a/govwifi-grafana/instances.tf
+++ b/govwifi-grafana/instances.tf
@@ -48,11 +48,11 @@ resource "aws_instance" "grafana_instance" {
     Name = "${title(var.env_name)} Grafana-Server"
   }
 
-  # metadata_options {
-  #   http_endpoint               = "disabled"
-  #   http_tokens                 = "required"
-  #   http_put_response_hop_limit = 1
-  # }
+  metadata_options {
+    http_endpoint               = "disabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
 
   root_block_device {
     volume_size = 30

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -72,7 +72,7 @@ variable "grafana_device_name" {
 variable "grafana_docker_version" {
   description = "Grafana Docker Version Number"
   type        = string
-  default     = "7.5.2"
+  default     = "10.2.2"
 }
 
 variable "critical_notifications_arn" {

--- a/govwifi/alpaca/dublin.tf
+++ b/govwifi/alpaca/dublin.tf
@@ -124,7 +124,7 @@ module "dublin_backend" {
 
   user_db_replica_count  = 1
   user_replica_source_db = "arn:aws:rds:eu-west-2:${local.aws_account_id}:db:wifi-alpaca-user-db"
-  user_rr_instance_type  = "db.t2.small"
+  user_rr_instance_type  = "db.t3.small"
 
   # TODO This should happen inside the module
   user_rr_hostname           = "users-rr.${lower(local.dublin_aws_region_name)}.${local.env_subdomain}.service.gov.uk"

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -60,14 +60,14 @@ module "london_backend" {
   enable_bastion_monitoring = false
   aws_account_id            = local.aws_account_id
   db_instance_count         = 1
-  session_db_instance_type  = "db.t2.small"
+  session_db_instance_type  = "db.t3.small"
   session_db_storage_gb     = 30
   db_backup_retention_days  = 1
   db_encrypt_at_rest        = true
   db_maintenance_window     = "sat:01:42-sat:02:12"
   db_backup_window          = "04:42-05:42"
   db_replica_count          = 0
-  rr_instance_type          = "db.t2.large"
+  rr_instance_type          = "db.t3.large"
   rr_storage_gb             = 200
   # TODO This should happen inside the module
   user_rr_hostname           = "users-rr.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
@@ -80,7 +80,7 @@ module "london_backend" {
   # Passed to application
   # TODO This should happen inside the module
   user_db_hostname      = "users-db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
-  user_db_instance_type = "db.t2.small"
+  user_db_instance_type = "db.t3.small"
   user_db_storage_gb    = 20
 
   prometheus_ip_london  = module.london_prometheus.eip_public_ip

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -124,7 +124,7 @@ module "dublin_backend" {
 
   user_db_replica_count  = 1
   user_replica_source_db = "arn:aws:rds:eu-west-2:${local.aws_account_id}:db:wifi-staging-user-db"
-  user_rr_instance_type  = "db.t2.small"
+  user_rr_instance_type  = "db.t3.small"
 
   # TODO This should happen inside the module
   user_rr_hostname           = "users-rr.${lower(local.dublin_aws_region_name)}.${local.env_subdomain}.service.gov.uk"

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -59,14 +59,14 @@ module "london_backend" {
   enable_bastion_monitoring = false
   aws_account_id            = local.aws_account_id
   db_instance_count         = 1
-  session_db_instance_type  = "db.t2.small"
+  session_db_instance_type  = "db.t3.small"
   session_db_storage_gb     = 20
   db_backup_retention_days  = 1
   db_encrypt_at_rest        = true
   db_maintenance_window     = "sat:01:42-sat:02:12"
   db_backup_window          = "04:42-05:42"
   db_replica_count          = 0
-  rr_instance_type          = "db.t2.large"
+  rr_instance_type          = "db.t3.large"
   rr_storage_gb             = 200
   # TODO This should happen inside the module
   user_rr_hostname           = "users-rr.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
@@ -79,7 +79,7 @@ module "london_backend" {
   # Passed to application
   # TODO This should happen inside the module
   user_db_hostname      = "users-db.${lower(local.london_aws_region_name)}.${local.env_subdomain}.service.gov.uk"
-  user_db_instance_type = "db.t2.small"
+  user_db_instance_type = "db.t3.small"
   user_db_storage_gb    = 20
 
   prometheus_ip_london  = module.london_prometheus.eip_public_ip

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -122,14 +122,14 @@ module "backend" {
   enable_bastion_monitoring  = true
   aws_account_id             = local.aws_account_id
   db_instance_count          = 1
-  session_db_instance_type   = "db.m4.xlarge"
+  session_db_instance_type   = "db.m5.xlarge"
   session_db_storage_gb      = 1000
   db_backup_retention_days   = 7
   db_encrypt_at_rest         = true
   db_maintenance_window      = "wed:01:42-wed:02:12"
   db_backup_window           = "03:05-04:05"
   db_replica_count           = 1
-  rr_instance_type           = "db.m4.xlarge"
+  rr_instance_type           = "db.m5.xlarge"
   rr_storage_gb              = 1000
   critical_notifications_arn = module.critical_notifications.topic_arn
   capacity_notifications_arn = module.capacity_notifications.topic_arn
@@ -141,7 +141,7 @@ module "backend" {
   # Passed to application
   user_db_hostname      = var.user_db_hostname
   user_rr_hostname      = var.user_rr_hostname
-  user_db_instance_type = "db.t2.medium"
+  user_db_instance_type = "db.t3.medium"
   user_db_storage_gb    = 1000
   user_db_replica_count = 1
 

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -125,7 +125,7 @@ module "backend" {
   aws_account_id            = local.aws_account_id
 
   db_instance_count        = 0
-  session_db_instance_type = "db.m4.xlarge"
+  session_db_instance_type = "db.m5.xlarge"
   session_db_storage_gb    = 1000
   db_backup_retention_days = 7
   db_encrypt_at_rest       = true
@@ -134,7 +134,7 @@ module "backend" {
 
   db_replica_count      = 0
   user_db_replica_count = 1
-  rr_instance_type      = "db.m3.medium"
+  rr_instance_type      = "db.m5.medium"
   rr_storage_gb         = 1000
 
   critical_notifications_arn = module.critical_notifications.topic_arn
@@ -145,7 +145,7 @@ module "backend" {
   db_monitoring_interval = 60
 
   # Passed to application
-  user_db_instance_type = "db.t2.medium"
+  user_db_instance_type = "db.t3.medium"
   user_db_hostname      = var.user_db_hostname
   user_db_storage_gb    = 20
   user_rr_hostname      = var.user_rr_hostname


### PR DESCRIPTION
### What
Upgrade the grafana version to 10.2.2
Remove the metadata code block

### Why
Grafana is very old at v7
The metadata block was preventing user-data from executing

### Link to JIRA card (if applicable): 
(https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?label=GovWifi-SRE&selectedIssue=GW-1325)

### Testing
terraform plan against e.g. our Dev or Staging environment. This has been done so there will be no significant changes. However if a plan is executed using master branch and then this is executed, the differences will be noticed but importantly Grafana will display it's new version.