### PR TITLE
Revert Option Audit Group to 5.7 Temporarily

### DIFF
--- a/govwifi-backend/db-parameters.tf
+++ b/govwifi-backend/db-parameters.tf
@@ -138,7 +138,7 @@ resource "aws_db_option_group" "mariadb_audit" {
 
   option_group_description = "Mariadb audit configuration"
   engine_name              = "mysql"
-  major_engine_version     = "8.0"
+  major_engine_version     = "5.7"
 
   option {
     option_name = "MARIADB_AUDIT_PLUGIN"


### PR DESCRIPTION
### What
Revert Option Audit Group to 5.7 Temporarily

### Why
This audit option group will be updated once we delete the final snapshots of the old 5.7 db instances. AWS will not allow you to delete audit groups still associated with snapshots.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-1133