### PR TITLE
 Bring Terraform Parameters Inline with MySQL 8 Upgrade

### DIFF
--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -27,7 +27,7 @@ resource "aws_db_instance" "db" {
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
   option_group_name               = "default:mysql-8-0"
-  parameter_group_name            = aws_db_parameter_group.db_parameters[0].name
+  parameter_group_name            = "default.mysql8.0"
 
   tags = {
     Name = "${title(var.env_name)} DB"

--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -26,7 +26,7 @@ resource "aws_db_instance" "db" {
   deletion_protection         = true
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
-  option_group_name               = aws_db_option_group.mariadb_audit.name
+  option_group_name               = "default:mysql-8-0"
   parameter_group_name            = aws_db_parameter_group.db_parameters[0].name
 
   tags = {
@@ -62,7 +62,7 @@ resource "aws_db_instance" "read_replica" {
   maintenance_window          = var.db_maintenance_window
   backup_window               = var.db_backup_window
   skip_final_snapshot         = true
-  option_group_name           = aws_db_option_group.mariadb_audit.name
+  option_group_name           = "default:mysql-8-0"
   parameter_group_name        = aws_db_parameter_group.rr_parameters.name
   deletion_protection         = true
 


### PR DESCRIPTION
### What
Bring Terraform Parameters Inline with MySQL 8 Upgrade

### Why    
This is part of the changes related to upgrading the sessions database to mysql 8. Password field on the replica has been removed as it is the same the main.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-1133