### PR TITLE
Bring Terraform Parameters Inline with MySQL 8 Upgrade / Part 2

### DIFF
--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -51,7 +51,6 @@ resource "aws_db_instance" "read_replica" {
   apply_immediately           = true
   instance_class              = var.rr_instance_type
   identifier                  = "${var.env_name}-db-rr"
-  password                    = local.session_db_password
   backup_retention_period     = 0
   multi_az                    = false
   storage_encrypted           = var.db_encrypt_at_rest


### PR DESCRIPTION
### What
Bring Terraform Parameters Inline with MySQL 8 Upgrade / Part 2

### Why
This is part of the changes related to upgrading the sessions database to mysql 8. Password field on the replica has been removed as it is the same the main.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-1133