### PR TITLE
GW-399 Remove old Test EIPs

### DIFF
--- a/govwifi-frontend/load-balancer.tf
+++ b/govwifi-frontend/load-balancer.tf
@@ -46,22 +46,3 @@ resource "aws_lb_target_group" "main" {
     type = "source_ip"
   }
 }
-
-/*
-# TODO These EIPs are being used to test the network load balancer,
-# and can be replaced by the radius_eips once the network load
-# balancer is used behind these eips
-resource "aws_eip" "test_radius_eips" {
-  count = var.radius_instance_count
-  vpc   = true
-
-  lifecycle {
-    prevent_destroy = true
-  }
-
-  tags = {
-    Name   = "${title(var.env_name)} Frontend Radius-${var.dns_numbering_base + count.index + 1}"
-    Region = title(var.aws_region_name)
-  }
-}
-*/

--- a/govwifi-frontend/load-balancer.tf
+++ b/govwifi-frontend/load-balancer.tf
@@ -47,6 +47,7 @@ resource "aws_lb_target_group" "main" {
   }
 }
 
+/*
 # TODO These EIPs are being used to test the network load balancer,
 # and can be replaced by the radius_eips once the network load
 # balancer is used behind these eips
@@ -63,3 +64,4 @@ resource "aws_eip" "test_radius_eips" {
     Region = title(var.aws_region_name)
   }
 }
+*/


### PR DESCRIPTION
### What
Remove 6 x EIP's that are no longer allocated, these where using in testing the move from ALB to NLB's and can now be removed.

### Why
These are redundant and will save a few $'s as there are 18 to remove (6 from each environment) and complete the NLB migration and cleanup.

Currently deployed to Dev and Staging (smoke tests passing on Staging).

### Link to JIRA card (if applicable): 
[GW-399](https://technologyprogramme.atlassian.net/browse/GW-399)

[GW-399]: https://technologyprogramme.atlassian.net/browse/GW-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ