### PR TITLE
Upgrade Audit Group To MySQL 8

### DIFF
--- a/govwifi-backend/db-parameters.tf
+++ b/govwifi-backend/db-parameters.tf
@@ -138,7 +138,7 @@ resource "aws_db_option_group" "mariadb_audit" {
 
   option_group_description = "Mariadb audit configuration"
   engine_name              = "mysql"
-  major_engine_version     = "5.7"
+  major_engine_version     = "8.0"
 
   option {
     option_name = "MARIADB_AUDIT_PLUGIN"


### PR DESCRIPTION
### What
Upgrade Audit Group To MySQL 8

### Why
This is cleanup work from the sessions database upgrade. More information available in this card

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1357
