### PR TITLE
GW-278 add network ACL rules

### DIFF
--- a/govwifi-frontend/network-acl.tf
+++ b/govwifi-frontend/network-acl.tf
@@ -1,9 +1,9 @@
 
 resource "aws_default_network_acl" "frontend_london" {
-  count =var.aws_region == "eu-west-2" ? 1 : 0
+  count                  = var.aws_region == "eu-west-2" ? 1 : 0
   default_network_acl_id = aws_vpc.wifi_frontend.default_network_acl_id
-  subnet_ids = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
- 
+  subnet_ids             = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+
   tags = {
     Name = "ACL GovWifi Frontend - ${var.env_name}"
   }
@@ -40,7 +40,7 @@ resource "aws_default_network_acl" "frontend_london" {
     protocol        = "-1"
     rule_no         = 99
     to_port         = 0
-  }  
+  }
   ingress {
     action          = "deny"
     cidr_block      = "172.16.0.0/12"
@@ -66,7 +66,7 @@ resource "aws_default_network_acl" "frontend_london" {
 
   ingress {
     action          = "allow"
-    cidr_block      =  var.vpc_cidr_block
+    cidr_block      = var.vpc_cidr_block
     from_port       = 0
     icmp_code       = 0
     icmp_type       = 0
@@ -89,10 +89,10 @@ resource "aws_default_network_acl" "frontend_london" {
 }
 
 resource "aws_default_network_acl" "frontend_dublin" {
-  count =var.aws_region == "eu-west-1" ? 1 : 0
+  count                  = var.aws_region == "eu-west-1" ? 1 : 0
   default_network_acl_id = aws_vpc.wifi_frontend.default_network_acl_id
-  subnet_ids = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
- 
+  subnet_ids             = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+
   tags = {
     Name = "ACL GovWifi Frontend - ${var.env_name}"
   }
@@ -129,7 +129,7 @@ resource "aws_default_network_acl" "frontend_dublin" {
     protocol        = "-1"
     rule_no         = 99
     to_port         = 0
-  }  
+  }
   ingress {
     action          = "deny"
     cidr_block      = "172.16.0.0/12"
@@ -155,7 +155,7 @@ resource "aws_default_network_acl" "frontend_dublin" {
 
   ingress {
     action          = "allow"
-    cidr_block      =  var.vpc_cidr_block
+    cidr_block      = var.vpc_cidr_block
     from_port       = 0
     icmp_code       = 0
     icmp_type       = 0

--- a/govwifi-frontend/network-acl.tf
+++ b/govwifi-frontend/network-acl.tf
@@ -1,5 +1,6 @@
 
-resource "aws_default_network_acl" "frontend" {
+resource "aws_default_network_acl" "frontend_london" {
+  count =var.aws_region == "eu-west-2" ? 1 : 0
   default_network_acl_id = aws_vpc.wifi_frontend.default_network_acl_id
   subnet_ids = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
  
@@ -86,3 +87,104 @@ resource "aws_default_network_acl" "frontend" {
     to_port         = 0
   }
 }
+
+resource "aws_default_network_acl" "frontend_dublin" {
+  count =var.aws_region == "eu-west-1" ? 1 : 0
+  default_network_acl_id = aws_vpc.wifi_frontend.default_network_acl_id
+  subnet_ids = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+ 
+  tags = {
+    Name = "ACL GovWifi Frontend - ${var.env_name}"
+  }
+
+  egress {
+    action          = "allow"
+    cidr_block      = "0.0.0.0/0"
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 100
+    to_port         = 0
+  }
+  ingress {
+    action          = "allow"
+    cidr_block      = "0.0.0.0/0"
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 100
+    to_port         = 0
+  }
+  ingress {
+    action          = "deny"
+    cidr_block      = "192.168.0.0/16"
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 99
+    to_port         = 0
+  }  
+  ingress {
+    action          = "deny"
+    cidr_block      = "172.16.0.0/12"
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 98
+    to_port         = 0
+  }
+  ingress {
+    action          = "deny"
+    cidr_block      = "10.0.0.0/8"
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 97
+    to_port         = 0
+  }
+
+  ingress {
+    action          = "allow"
+    cidr_block      =  var.vpc_cidr_block
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 96
+    to_port         = 0
+  }
+  ingress {
+    action          = "allow"
+    cidr_block      = one(data.aws_vpc.backend.cidr_block_associations).cidr_block
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 95
+    to_port         = 0
+  }
+  ingress {
+    action          = "allow"
+    cidr_block      = var.london_backend_vpc_cidr
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 94
+    to_port         = 0
+  }
+}
+

--- a/govwifi-frontend/network-acl.tf
+++ b/govwifi-frontend/network-acl.tf
@@ -1,0 +1,88 @@
+
+resource "aws_default_network_acl" "frontend" {
+  default_network_acl_id = aws_vpc.wifi_frontend.default_network_acl_id
+  subnet_ids = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]
+ 
+  tags = {
+    Name = "ACL GovWifi Frontend - ${var.env_name}"
+  }
+
+  egress {
+    action          = "allow"
+    cidr_block      = "0.0.0.0/0"
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 100
+    to_port         = 0
+  }
+  ingress {
+    action          = "allow"
+    cidr_block      = "0.0.0.0/0"
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 100
+    to_port         = 0
+  }
+  ingress {
+    action          = "deny"
+    cidr_block      = "192.168.0.0/16"
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 99
+    to_port         = 0
+  }  
+  ingress {
+    action          = "deny"
+    cidr_block      = "172.16.0.0/12"
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 98
+    to_port         = 0
+  }
+  ingress {
+    action          = "deny"
+    cidr_block      = "10.0.0.0/8"
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 97
+    to_port         = 0
+  }
+
+  ingress {
+    action          = "allow"
+    cidr_block      =  var.vpc_cidr_block
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 96
+    to_port         = 0
+  }
+  ingress {
+    action          = "allow"
+    cidr_block      = one(data.aws_vpc.backend.cidr_block_associations).cidr_block
+    from_port       = 0
+    icmp_code       = 0
+    icmp_type       = 0
+    ipv6_cidr_block = null
+    protocol        = "-1"
+    rule_no         = 95
+    to_port         = 0
+  }
+}

--- a/govwifi-frontend/variables.tf
+++ b/govwifi-frontend/variables.tf
@@ -102,3 +102,6 @@ variable "prometheus_ip_ireland" {
 variable "prometheus_security_group_id" {
   type = string
 }
+
+variable "london_backend_vpc_cidr" {
+}

--- a/govwifi/alpaca/dublin.tf
+++ b/govwifi/alpaca/dublin.tf
@@ -1,7 +1,7 @@
 locals {
-  dublin_aws_region      = "eu-west-1"
-  dublin_aws_region_name = "Dublin"
-  dublin_backend_vpc_cidr_block = "10.104.0.0/16"
+  dublin_aws_region              = "eu-west-1"
+  dublin_aws_region_name         = "Dublin"
+  dublin_backend_vpc_cidr_block  = "10.104.0.0/16"
   dublin_frontend_vpc_cidr_block = "10.105.0.0/16"
 }
 
@@ -85,7 +85,7 @@ module "dublin_backend" {
   providers = {
     aws = aws.dublin
   }
-  
+
   source        = "../../govwifi-backend"
   env           = "alpaca"
   env_name      = local.env_name
@@ -243,7 +243,7 @@ module "dublin_frontend" {
   prometheus_security_group_id = module.dublin_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-  
+
   london_backend_vpc_cidr = module.london_backend.vpc_cidr_block
 }
 

--- a/govwifi/alpaca/dublin.tf
+++ b/govwifi/alpaca/dublin.tf
@@ -1,7 +1,7 @@
 locals {
   dublin_aws_region      = "eu-west-1"
   dublin_aws_region_name = "Dublin"
-
+  dublin_backend_vpc_cidr_block = "10.104.0.0/16"
   dublin_frontend_vpc_cidr_block = "10.105.0.0/16"
 }
 
@@ -85,7 +85,7 @@ module "dublin_backend" {
   providers = {
     aws = aws.dublin
   }
-
+  
   source        = "../../govwifi-backend"
   env           = "alpaca"
   env_name      = local.env_name
@@ -243,7 +243,8 @@ module "dublin_frontend" {
   prometheus_security_group_id = module.dublin_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-
+  
+  london_backend_vpc_cidr = module.london_backend.vpc_cidr_block
 }
 
 module "dublin_api" {

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -1,7 +1,7 @@
 locals {
-  london_aws_region      = "eu-west-2"
-  london_aws_region_name = "London"
-  london_backend_vpc_cidr_block = "10.106.0.0/16"
+  london_aws_region              = "eu-west-2"
+  london_aws_region_name         = "London"
+  london_backend_vpc_cidr_block  = "10.106.0.0/16"
   london_frontend_vpc_cidr_block = "10.102.0.0/16"
 }
 

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -1,6 +1,7 @@
 locals {
   london_aws_region      = "eu-west-2"
   london_aws_region_name = "London"
+  london_backend_vpc_cidr_block = "10.106.0.0/16"
   london_frontend_vpc_cidr_block = "10.102.0.0/16"
 }
 
@@ -50,7 +51,7 @@ module "london_backend" {
   aws_region      = local.london_aws_region
   route53_zone_id = data.aws_route53_zone.main.zone_id
   aws_region_name = local.london_aws_region_name
-  vpc_cidr_block  = "10.106.0.0/16"
+  vpc_cidr_block  = local.london_backend_vpc_cidr_block
 
   administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
@@ -148,6 +149,8 @@ module "london_frontend" {
   prometheus_security_group_id = module.london_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
+
+  london_backend_vpc_cidr = module.london_backend.vpc_cidr_block
 }
 
 module "london_admin" {

--- a/govwifi/staging/dublin.tf
+++ b/govwifi/staging/dublin.tf
@@ -244,6 +244,7 @@ module "dublin_frontend" {
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
 
+  london_backend_vpc_cidr = module.london_backend.vpc_cidr_block
 }
 
 module "dublin_api" {

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -147,6 +147,8 @@ module "london_frontend" {
   prometheus_security_group_id = module.london_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
+
+  london_backend_vpc_cidr = module.london_backend.vpc_cidr_block
 }
 
 module "london_admin" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -211,6 +211,8 @@ module "frontend" {
   prometheus_security_group_id = module.govwifi_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
+
+  london_backend_vpc_cidr = module.london_backend.vpc_cidr_block
 }
 
 module "govwifi_admin" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -173,6 +173,7 @@ module "frontend" {
   aws_region_name    = var.aws_region_name
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.85.0.0/16"
+  london_backend_vpc_cidr = module.backend.vpc_cidr_block
   rack_env           = "production"
   sentry_current_env = "production"
 
@@ -209,10 +210,8 @@ module "frontend" {
   prometheus_ip_ireland = var.prometheus_ip_ireland
 
   prometheus_security_group_id = module.govwifi_prometheus.prometheus_security_group_id
-
+  
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-
-  london_backend_vpc_cidr = module.london_backend.vpc_cidr_block
 }
 
 module "govwifi_admin" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -250,6 +250,8 @@ module "frontend" {
   prometheus_security_group_id = module.govwifi_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
+
+  london_backend_vpc_cidr = module.london_backend.vpc_cidr_block
 }
 
 module "api" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -205,6 +205,7 @@ module "frontend" {
   aws_region_name    = var.aws_region_name
   route53_zone_id    = data.aws_route53_zone.main.zone_id
   vpc_cidr_block     = "10.43.0.0/16"
+  london_backend_vpc_cidr = "10.42.0.0/16"
   rack_env           = "production"
   sentry_current_env = "production"
 
@@ -250,8 +251,6 @@ module "frontend" {
   prometheus_security_group_id = module.govwifi_prometheus.prometheus_security_group_id
 
   radius_cidr_blocks = [for ip in local.frontend_radius_ips : "${ip}/32"]
-
-  london_backend_vpc_cidr = module.london_backend.vpc_cidr_block
 }
 
 module "api" {


### PR DESCRIPTION
### What
Add a Network ACL module to capture the ACL's that have been manually deployed to prod.

### Why
To ensure the consistency of the environments by removing manually applied configurations.


### Link to JIRA card (if applicable): 
[GW-278](https://technologyprogramme.atlassian.net/browse/GW-278)