### PR TITLE
fix: GW-1444 restrict Grafana egress 443 to be VPC

### DIFF
--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -155,19 +155,4 @@ resource "aws_security_group" "vpc_endpoints" {
   tags = {
     Name = "${title(var.env_name)} Backend VPC Endpoints"
   }
-
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
 }

--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "grafana_alb_in" {
   }
 
   ingress {
-    description = ""
+    description = "grafana_alb_in_443"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
@@ -31,6 +31,7 @@ resource "aws_security_group" "grafana_alb_out" {
 }
 
 resource "aws_security_group_rule" "grafana_alb_out_egress" {
+  description              = "grafana_alb_out_3000"
   type                     = "egress"
   from_port                = 3000
   to_port                  = 3000
@@ -50,7 +51,7 @@ resource "aws_security_group" "grafana_ec2_in" {
   }
 
   ingress {
-    description     = ""
+    description     = "grafana_ec2_in_3000"
     from_port       = 3000
     to_port         = 3000
     protocol        = "tcp"
@@ -58,7 +59,7 @@ resource "aws_security_group" "grafana_ec2_in" {
   }
 
   ingress {
-    description = ""
+    description = "grafana_ec2_in_22"
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
@@ -76,7 +77,7 @@ resource "aws_security_group" "grafana_ec2_out" {
   }
 
   egress {
-    description = ""
+    description = "grafana_ec2_out_22"
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
@@ -84,7 +85,7 @@ resource "aws_security_group" "grafana_ec2_out" {
   }
 
   egress {
-    description = ""
+    description = "grafana_ec2_out_9090"
     from_port   = 9090
     to_port     = 9090
     protocol    = "tcp"
@@ -92,7 +93,7 @@ resource "aws_security_group" "grafana_ec2_out" {
   }
 
   egress {
-    description = ""
+    description = "grafana_ec2_out_80"
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
@@ -101,10 +102,10 @@ resource "aws_security_group" "grafana_ec2_out" {
 
 # Cloudwatch Agent requires outbound to AWS
   egress {
-    description = ""
+    description = "grafana_ec2_out_443"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.vpc_be_cidr_block]
   }
 }

--- a/govwifi-grafana/variables.tf
+++ b/govwifi-grafana/variables.tf
@@ -82,3 +82,6 @@ variable "critical_notifications_arn" {
 
 variable "aws_account_id" {
 }
+
+variable "vpc_be_cidr_block" {
+}

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -2,6 +2,7 @@ locals {
   london_aws_region      = "eu-west-2"
   london_aws_region_name = "London"
   london_frontend_vpc_cidr_block = "10.102.0.0/16"
+  london_backend_vpc_cidr_block  = "10.106.0.0/16"
 }
 
 provider "aws" {
@@ -50,7 +51,7 @@ module "london_backend" {
   aws_region      = local.london_aws_region
   route53_zone_id = data.aws_route53_zone.main.zone_id
   aws_region_name = local.london_aws_region_name
-  vpc_cidr_block  = "10.106.0.0/16"
+  vpc_cidr_block  = local.london_backend_vpc_cidr_block
 
   administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
@@ -372,7 +373,8 @@ module "london_grafana" {
     module.london_prometheus.eip_public_ip,
     module.dublin_prometheus.eip_public_ip
   ]
-
+  
+  vpc_be_cidr_block  = local.london_backend_vpc_cidr_block
 }
 
 module "london_elasticsearch" {

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -1,6 +1,7 @@
 locals {
   london_aws_region      = "eu-west-2"
   london_aws_region_name = "London"
+  london_backend_vpc_cidr_block  = "10.106.0.0/16"
 }
 
 provider "aws" {
@@ -49,7 +50,7 @@ module "london_backend" {
   aws_region      = local.london_aws_region
   route53_zone_id = data.aws_route53_zone.main.zone_id
   aws_region_name = local.london_aws_region_name
-  vpc_cidr_block  = "10.106.0.0/16"
+  vpc_cidr_block  = local.london_backend_vpc_cidr_block
 
   administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
@@ -372,7 +373,7 @@ module "london_grafana" {
     module.dublin_prometheus.eip_public_ip
   ]
   aws_account_id = local.aws_account_id
-
+  vpc_be_cidr_block  = local.london_backend_vpc_cidr_block
 }
 
 module "london_elasticsearch" {

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -6,6 +6,7 @@ locals {
   product_name = "GovWifi"
 
   backup_mysql_rds = true
+  london_backend_vpc_cidr_block = "10.84.0.0/16"
 }
 
 locals {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -112,7 +112,7 @@ module "backend" {
   aws_region      = var.aws_region
   aws_region_name = var.aws_region_name
   route53_zone_id = data.aws_route53_zone.main.zone_id
-  vpc_cidr_block  = "10.84.0.0/16"
+  vpc_cidr_block  = local.london_backend_vpc_cidr_block
 
   administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
@@ -474,7 +474,7 @@ module "govwifi_grafana" {
     var.prometheus_ip_london,
     var.prometheus_ip_ireland
   ]
-
+  vpc_be_cidr_block  = local.london_backend_vpc_cidr_block
 }
 
 module "govwifi_slack_alerts" {


### PR DESCRIPTION
### What
Remove the 'catch all' from the Back End VPC egress and ingress 0.0.0.0/0 and add specific rule for Grafana to talk to the VPC on 443 and add descriptions to the rules so we know what they're doing.

### Why
This was causing conflicts with other rules and bad practice to have such an open rule.


### Link to JIRA card (if applicable): 
[GW-1444](https://technologyprogramme.atlassian.net/browse/GW-1444)

[GW-1444]: https://technologyprogramme.atlassian.net/browse/GW-1444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ