### PR TITLE
DO NOT MERGE: admin site changes for cert access

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -90,6 +90,9 @@ resource "aws_ecs_task_definition" "admin_task" {
           "name": "S3_TRUSTED_CERTS_PATH_KEY",
           "value": "trusted_certificates"
         },{
+          "name": "S3_ROOT_CERTS_PATH_KEY",
+          "value": "root_certificates"
+        },{
           "name": "S3_EMAIL_DOMAINS_OBJECT_KEY",
           "value": "domains.yml"
         },{

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -84,6 +84,12 @@ resource "aws_ecs_task_definition" "admin_task" {
           "name": "S3_ORGANISATION_NAMES_OBJECT_KEY",
           "value": "organisations.yml"
         },{
+          "name": "S3_TRUSTED_CERTS_BUCKET",
+          "value": "${var.frontend_certs_s3_bucket_name}"
+        },{
+          "name": "S3_TRUSTED_CERTS_PATH_KEY",
+          "value": "trusted_certificates"
+        },{
           "name": "S3_EMAIL_DOMAINS_OBJECT_KEY",
           "value": "domains.yml"
         },{

--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -85,7 +85,7 @@ resource "aws_ecs_task_definition" "admin_task" {
           "value": "organisations.yml"
         },{
           "name": "S3_TRUSTED_CERTS_BUCKET",
-          "value": "${var.frontend_certs_s3_bucket_name}"
+          "value": "${var.frontend_cert_s3_bucket_name}"
         },{
           "name": "S3_TRUSTED_CERTS_PATH_KEY",
           "value": "trusted_certificates"

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -94,7 +94,7 @@ resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
         "s3:GetObjectAcl",
         "s3:DeleteObject"
       ],
-      "Resource": ["${var.frontend_cert_s3_bucket_arn}/trusted_certificates/*"]
+      "Resource": ["${var.frontend_cert_s3_bucket_arn}/trusted_certificates/*", "${var.frontend_cert_s3_bucket_arn}/root_certificates/*"]
     }
   ]
 }

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
   name       = "${var.aws_region_name}-ecs-admin-instance-policy-${var.env_name}"
   role       = aws_iam_role.ecs_admin_instance_role.id
-  depends_on = [aws_s3_bucket.admin_bucket, var.frontend_certs_s3_bucket_name]
+  depends_on = [aws_s3_bucket.admin_bucket, var.frontend_cert_s3_bucket_name]
 
   policy = <<EOF
 {
@@ -94,7 +94,7 @@ resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
         "s3:GetObjectAcl",
         "s3:DeleteObject"
       ],
-      "Resource": ["${var.frontend_certs_s3_bucket_name.arn}/trusted_certificates/*"]
+      "Resource": ["${var.frontend_cert_s3_bucket_arn}/trusted_certificates/*"]
     }
   ]
 }

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
   name       = "${var.aws_region_name}-ecs-admin-instance-policy-${var.env_name}"
   role       = aws_iam_role.ecs_admin_instance_role.id
-  depends_on = [aws_s3_bucket.admin_bucket]
+  depends_on = [aws_s3_bucket.admin_bucket, var.frontend_certs_s3_bucket_name]
 
   policy = <<EOF
 {
@@ -84,6 +84,17 @@ resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
         "s3:PutObjectVersionAcl"
       ],
       "Resource": ["${aws_s3_bucket.product_page_data_bucket.arn}/*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:GetObject",
+        "s3:GetObjectAcl",
+        "s3:DeleteObject"
+      ],
+      "Resource": ["${var.frontend_certs_s3_bucket_name.arn}/*"]
     }
   ]
 }

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -94,7 +94,7 @@ resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
         "s3:GetObjectAcl",
         "s3:DeleteObject"
       ],
-      "Resource": ["${var.frontend_certs_s3_bucket_name.arn}/*"]
+      "Resource": ["${var.frontend_certs_s3_bucket_name.arn}/trusted_certificates/*"]
     }
   ]
 }

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -132,5 +132,8 @@ variable "bastion_server_ip" {
 variable "elasticsearch_endpoint" {
 }
 
-variable "frontend_certs_s3_bucket_name" {
+variable "frontend_cert_s3_bucket_arn" {
+}
+
+variable "frontend_cert_s3_bucket_name"{
 }

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -131,3 +131,6 @@ variable "bastion_server_ip" {
 
 variable "elasticsearch_endpoint" {
 }
+
+variable "frontend_certs_s3_bucket_name" {
+}

--- a/govwifi-frontend/outputs.tf
+++ b/govwifi-frontend/outputs.tf
@@ -33,3 +33,8 @@ output "eip_public_ips" {
 output "load_balanced_frontend_service_security_group_id" {
   value = aws_security_group.load_balanced_frontend_service.id
 }
+
+output "frontend_cert_s3_bucket_name" {
+  description = "Name (id) for the admin bucket"
+  value       = aws_s3_bucket.frontend_cert_bucket.id
+}

--- a/govwifi-frontend/outputs.tf
+++ b/govwifi-frontend/outputs.tf
@@ -35,6 +35,11 @@ output "load_balanced_frontend_service_security_group_id" {
 }
 
 output "frontend_cert_s3_bucket_name" {
-  description = "Name (id) for the admin bucket"
+  description = "Name (id) for the frontend certs bucket"
   value       = aws_s3_bucket.frontend_cert_bucket.id
+}
+
+output "frontend_cert_s3_bucket_arn" {
+  description = "ARN for the frontend certs bucket"
+  value       = aws_s3_bucket.frontend_cert_bucket.arn
 }

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -212,7 +212,10 @@ module "london_admin" {
 
   elasticsearch_endpoint = module.london_elasticsearch.endpoint
 
-  frontend_certs_s3_bucket_name = module.london_frontend.frontend_cert_s3_bucket_name
+  frontend_cert_s3_bucket_name = module.london_frontend.frontend_cert_s3_bucket_name
+
+  frontend_cert_s3_bucket_arn = module.london_frontend.frontend_cert_s3_bucket_arn
+
 }
 
 module "london_api" {

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -211,6 +211,8 @@ module "london_admin" {
   notification_arn = module.london_notifications.topic_arn
 
   elasticsearch_endpoint = module.london_elasticsearch.endpoint
+
+  frontend_certs_s3_bucket_name = module.london_frontend.frontend_cert_s3_bucket_name
 }
 
 module "london_api" {

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -210,6 +210,8 @@ module "london_admin" {
   notification_arn = module.london_notifications.topic_arn
 
   elasticsearch_endpoint = module.london_elasticsearch.endpoint
+
+  frontend_certs_s3_bucket_name = module.london_frontend.frontend_cert_s3_bucket_name
 }
 
 module "london_api" {

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -211,7 +211,9 @@ module "london_admin" {
 
   elasticsearch_endpoint = module.london_elasticsearch.endpoint
 
-  frontend_certs_s3_bucket_name = module.london_frontend.frontend_cert_s3_bucket_name
+  frontend_cert_s3_bucket_name = module.london_frontend.frontend_cert_s3_bucket_name
+
+  frontend_cert_s3_bucket_arn = module.london_frontend.frontend_cert_s3_bucket_arn
 }
 
 module "london_api" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -273,6 +273,8 @@ module "govwifi_admin" {
   bastion_server_ip = var.bastion_server_ip
 
   elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
+
+  frontend_certs_s3_bucket_name = module.london_frontend.frontend_cert_s3_bucket_name  
 }
 
 module "api" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -274,7 +274,9 @@ module "govwifi_admin" {
 
   elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
 
-  frontend_certs_s3_bucket_name = module.frontend.frontend_cert_s3_bucket_name  
+  frontend_cert_s3_bucket_name = module.frontend.frontend_cert_s3_bucket_name
+
+  frontend_cert_s3_bucket_arn = module.frontend.frontend_cert_s3_bucket_arn
 }
 
 module "api" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -274,7 +274,7 @@ module "govwifi_admin" {
 
   elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
 
-  frontend_certs_s3_bucket_name = module.london_frontend.frontend_cert_s3_bucket_name  
+  frontend_certs_s3_bucket_name = module.frontend.frontend_cert_s3_bucket_name  
 }
 
 module "api" {


### PR DESCRIPTION
### What
Changes to admin site ecs task env vars and policy to enable access to trusted certificates used by frontend certificate sync.

### Why
Admin site now Creates and Moves (ie deletes) certificates from the frontend_certs bucket


### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-1462