### PR TITLE
bug: [GW-278] put correct BE VPC CDIR into local Variable for Dublin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: govwifi-terraform-linting
 on: [push, pull_request]
 jobs:
   lint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout source code
 
       - uses: Homebrew/actions/setup-homebrew@master
@@ -15,7 +15,7 @@ jobs:
           tfenv install $(cat .terraform-version)
           tfenv use $(cat .terraform-version)
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -4,6 +4,9 @@ locals {
   env           = "production"
 
   product_name = "GovWifi"
+  dublin_backend_vpc_cidr_block  = "10.42.0.0/16"
+  dublin_frontend_vpc_cidr_block = "10.43.0.0/16"
+  london_backend_vpc_cidr_block = "10.84.0.0/16"
 }
 
 locals {

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -3,10 +3,10 @@ locals {
   env_subdomain = "wifi" # Environment specific subdomain to use under the service domain
   env           = "production"
 
-  product_name = "GovWifi"
+  product_name                   = "GovWifi"
   dublin_backend_vpc_cidr_block  = "10.42.0.0/16"
   dublin_frontend_vpc_cidr_block = "10.43.0.0/16"
-  london_backend_vpc_cidr_block = "10.84.0.0/16"
+  london_backend_vpc_cidr_block  = "10.84.0.0/16"
 }
 
 locals {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -110,7 +110,7 @@ module "backend" {
   aws_region      = var.aws_region
   aws_region_name = var.aws_region_name
   route53_zone_id = data.aws_route53_zone.main.zone_id
-  vpc_cidr_block  = "10.42.0.0/16"
+  vpc_cidr_block  = local.dublin_backend_vpc_cidr_block
 
   administrator_cidrs = var.administrator_cidrs
   frontend_radius_ips = local.frontend_radius_ips
@@ -204,8 +204,8 @@ module "frontend" {
   aws_region              = var.aws_region
   aws_region_name         = var.aws_region_name
   route53_zone_id         = data.aws_route53_zone.main.zone_id
-  vpc_cidr_block          = "10.43.0.0/16"
-  london_backend_vpc_cidr = "10.42.0.0/16"
+  vpc_cidr_block          = local.dublin_frontend_vpc_cidr_block
+  london_backend_vpc_cidr = local.london_backend_vpc_cidr_block
   rack_env                = "production"
   sentry_current_env      = "production"
 


### PR DESCRIPTION
### What
Correct VPC ID and store them in locals so they are in only 1 place.

### Why
Bug with previous deployment where wrong VPC id was used.


### Link to JIRA card (if applicable): 
[GW-278](https://technologyprogramme.atlassian.net/browse/GW-278)

[GW-278]: https://technologyprogramme.atlassian.net/browse/GW-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ