### PR TITLE
GW-1526 change runner and bump versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: govwifi-terraform-linting
 on: [push, pull_request]
 jobs:
   lint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout source code
 
       - uses: Homebrew/actions/setup-homebrew@master
@@ -15,7 +15,7 @@ jobs:
           tfenv install $(cat .terraform-version)
           tfenv use $(cat .terraform-version)
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins


### PR DESCRIPTION
### What
Update os runner to Ubuntu and bump the action verisons.

### Why
The original MacOs runner kept failing on python libraries 2to3


### Link to JIRA card (if applicable): 
[GW-1526](https://technologyprogramme.atlassian.net/browse/GW-1526)

[GW-1526]: https://technologyprogramme.atlassian.net/browse/GW-1526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ