### PR TITLE
Fix: Edit Grafana Outbound Security Groups

### DIFF
--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -92,20 +92,12 @@ resource "aws_security_group" "grafana_ec2_out" {
     cidr_blocks = [for ip in var.prometheus_ips : "${ip}/32"]
   }
 
-  egress {
-    description = "grafana_ec2_out_80"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   # Cloudwatch Agent requires outbound to AWS
   egress {
     description = "grafana_ec2_out_443"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = [var.vpc_be_cidr_block]
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }


### PR DESCRIPTION
### What
Edit Grafana Outbound Security Groups

### Why
Users were unable to log in to Grafana using Google SSO, we have opened up the outbound group on port 443, and removed access on port 80.

