### PR TITLE
fix: [GW-1684]Add SG for Port 80 to allow package installs

### DIFF
--- a/govwifi-grafana/security_groups.tf
+++ b/govwifi-grafana/security_groups.tf
@@ -92,6 +92,15 @@ resource "aws_security_group" "grafana_ec2_out" {
     cidr_blocks = [for ip in var.prometheus_ips : "${ip}/32"]
   }
 
+  # outbound 80 rule to allow package installs.
+  egress {
+    description = "grafana_ec2_out_80"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   # Cloudwatch Agent requires outbound to AWS
   egress {
     description = "grafana_ec2_out_443"


### PR DESCRIPTION
### What
Added a security group for port 80 on Grafana, that was previously removed. 

### Why
To allow the EC2 access to port 80 to download packages, this is only an Egress outbound rule.


### Link to JIRA card (if applicable): 
[GW-1684](https://technologyprogramme.atlassian.net/browse/GW-1684)

[GW-1684]: https://technologyprogramme.atlassian.net/browse/GW-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ