### PR TITLE
Add event to send inactive user follow up emails

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -87,6 +87,15 @@ resource "aws_cloudwatch_event_rule" "active_users_signup_survey_event" {
   is_enabled          = true
 }
 
+resource "aws_cloudwatch_event_rule" "inactive_user_followup_event" {
+  count               = var.event_rule_count
+  name                = "${var.env_name}-inactive-user-followup"
+  description         = "Triggers daily at 6:00PM UTC"
+  schedule_expression = "cron(0 18 * * ? *)"
+  is_enabled          = true
+}
+
+
 resource "aws_cloudwatch_event_rule" "sync_s3_to_elasticsearch_event" {
   count               = var.event_rule_count
   name                = "${var.env_name}-sync-s3-to-elasticsearch"

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -42,7 +42,8 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.authentication_api_sentry_dsn.arn,
       data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.arn,
       data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn,
-      data.aws_secretsmanager_secret.notify_do_not_reply.arn
+      data.aws_secretsmanager_secret.notify_do_not_reply.arn,
+      data.aws_secretsmanager_secret.notify_support_reply.arn
     ]
   }
 }

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -30,6 +30,14 @@ data "aws_secretsmanager_secret" "notify_do_not_reply" {
   name = "user-signup-api/notify-do-not-reply"
 }
 
+data "aws_secretsmanager_secret_version" "notify_support_reply" {
+  secret_id = data.aws_secretsmanager_secret.notify_support_reply.id
+}
+
+data "aws_secretsmanager_secret" "notify_support_reply" {
+  name = "user-signup-api/notify-support-reply"
+}
+
 data "aws_secretsmanager_secret_version" "notify_bearer_token" {
   secret_id = data.aws_secretsmanager_secret.notify_bearer_token.id
 }

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -149,6 +149,9 @@ resource "aws_ecs_task_definition" "user_signup_api_task" {
           "name": "NOTIFY_DO_NOT_REPLY",
           "valueFrom": "${data.aws_secretsmanager_secret.notify_do_not_reply.arn}"
         },{
+          "name": "NOTIFY_SUPPORT_REPLY",
+          "valueFrom": "${data.aws_secretsmanager_secret.notify_support_reply.arn}"
+        },{
           "name": "GOVNOTIFY_BEARER_TOKEN",
           "valueFrom": "${data.aws_secretsmanager_secret_version.notify_bearer_token.arn}:token::"
         },{

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -243,6 +243,9 @@ resource "aws_ecs_task_definition" "user_signup_api_scheduled_task" {
           "name": "NOTIFY_DO_NOT_REPLY",
           "valueFrom": "${data.aws_secretsmanager_secret.notify_do_not_reply.arn}"
         },{
+          "name": "NOTIFY_SUPPORT_REPLY",
+          "valueFrom": "${data.aws_secretsmanager_secret.notify_support_reply.arn}"
+        },{
           "name": "GOVNOTIFY_BEARER_TOKEN",
           "valueFrom": "${data.aws_secretsmanager_secret_version.notify_bearer_token.arn}:token::"
         },{
@@ -330,7 +333,6 @@ resource "aws_cloudwatch_event_target" "inactive_user_followup" {
       subnets = var.subnet_ids
 
       security_groups = concat(
-        var.backend_sg_list,
         [aws_security_group.api_in.id],
         [aws_security_group.api_out.id]
       )
@@ -343,7 +345,7 @@ resource "aws_cloudwatch_event_target" "inactive_user_followup" {
 {
   "containerOverrides": [
     {
-      "name": "user-signup-api",
+      "name": "inactive-user-followup",
       "command": ["bundle", "exec", "rake", "inactive_user_followup"]
     }
   ]


### PR DESCRIPTION
### What
We want to send emails to users that asked for credentials but did not manage to sign up after two days, offering help

### Why
So we can help users get connected or get a better understanding of potential issues users face when trying to connect

### Link to JIRA card (if applicable): 
[[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)](https://technologyprogramme.atlassian.net/browse/GW-1689)