### PR TITLE
Remove Unused ECR Repos

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -8,11 +8,6 @@ resource "aws_cloudwatch_log_group" "admin_log_group" {
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "govwifi_admin_ecr" {
-  count = var.ecr_repository_count
-  name  = "govwifi/admin"
-}
-
 resource "aws_ecs_task_definition" "admin_task" {
   family                   = "admin-task-${var.env_name}"
   requires_compatibilities = ["FARGATE"]

--- a/govwifi-api/authentication-api-cluster.tf
+++ b/govwifi-api/authentication-api-cluster.tf
@@ -4,16 +4,6 @@ resource "aws_cloudwatch_log_group" "authentication_api_log_group" {
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "authentication_api_ecr" {
-  count = var.ecr_repository_count
-  name  = "govwifi/authentication-api"
-}
-
-resource "aws_ecr_repository" "authorisation_api_ecr" {
-  count = var.ecr_repository_count
-  name  = "govwifi/authorisation-api"
-}
-
 resource "aws_ecs_task_definition" "authentication_api_task" {
   family                   = "authentication-api-task-${var.env_name}"
   requires_compatibilities = ["FARGATE"]

--- a/govwifi-api/database-backup-task.tf
+++ b/govwifi-api/database-backup-task.tf
@@ -13,11 +13,6 @@ resource "aws_cloudwatch_log_group" "backup_rds_to_s3_log_group" {
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "database_backup_ecr" {
-  count = var.ecr_repository_count
-  name  = "govwifi/database-backup"
-}
-
 resource "aws_ecs_task_definition" "backup_rds_to_s3_task_definition" {
   count                    = var.backup_mysql_rds ? 1 : 0
   family                   = "backup-rds-to-s3-task-${var.env_name}"

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -5,11 +5,6 @@ resource "aws_cloudwatch_log_group" "logging_api_log_group" {
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "logging_api_ecr" {
-  count = var.ecr_repository_count
-  name  = "govwifi/logging-api"
-}
-
 resource "aws_ecs_task_definition" "logging_api_task" {
   count                    = var.logging_enabled
   family                   = "logging-api-task-${var.env_name}"

--- a/govwifi-api/safe-restart-scheduled-task.tf
+++ b/govwifi-api/safe-restart-scheduled-task.tf
@@ -13,11 +13,6 @@ resource "aws_cloudwatch_log_group" "safe_restart_log_group" {
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "safe_restarter_ecr" {
-  count = var.ecr_repository_count
-  name  = "govwifi/safe-restarter"
-}
-
 resource "aws_ecs_task_definition" "safe_restart_task_definition" {
   count                    = var.safe_restart_enabled
   family                   = "safe-restart-task-${var.env_name}"

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -5,11 +5,6 @@ resource "aws_cloudwatch_log_group" "user_signup_api_log_group" {
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "user_signup_api_ecr" {
-  count = var.ecr_repository_count
-  name  = "govwifi/user-signup-api"
-}
-
 resource "aws_iam_role" "user_signup_api_task_role" {
   count = var.user_signup_enabled
   name  = "${var.env_name}-user-signup-api-task-role"

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -27,21 +27,6 @@ resource "aws_cloudwatch_log_group" "frontend" {
   retention_in_days = 90
 }
 
-resource "aws_ecr_repository" "govwifi_frontend_ecr" {
-  count = var.create_ecr
-  name  = "govwifi/frontend"
-}
-
-resource "aws_ecr_repository" "govwifi_frontend_base_ecr" {
-  count = var.create_ecr
-  name  = "govwifi/frontend-base"
-}
-
-resource "aws_ecr_repository" "govwifi_raddb_ecr" {
-  count = var.create_ecr
-  name  = "govwifi/raddb"
-}
-
 data "aws_caller_identity" "current" {}
 
 resource "aws_ecr_replication_configuration" "main" {

--- a/govwifi/staging/.terraform.lock.hcl
+++ b/govwifi/staging/.terraform.lock.hcl
@@ -69,6 +69,7 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = "~> 0.11.1"
   hashes = [
     "h1:bC4b7n4g30ciIn5w6b66mXSTIo2CH6XQbp+gBdDvlYs=",
+    "h1:qg3O4PmHnlPcvuZ2LvzOYEAPGOKtccgD5kPdQPZw094=",
     "zh:02588b5b8ba5d31e86d93edc93b306bcbf47c789f576769245968cc157a9e8c5",
     "zh:088a30c23796133678d1d6614da5cf5544430570408a17062288b58c0bd67ac8",
     "zh:0df5faa072d67616154d38021934d8a8a316533429a3f582df3b4b48c836cf89",

--- a/govwifi/wifi-london/.terraform.lock.hcl
+++ b/govwifi/wifi-london/.terraform.lock.hcl
@@ -69,6 +69,7 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = "~> 0.11.1"
   hashes = [
     "h1:bC4b7n4g30ciIn5w6b66mXSTIo2CH6XQbp+gBdDvlYs=",
+    "h1:qg3O4PmHnlPcvuZ2LvzOYEAPGOKtccgD5kPdQPZw094=",
     "zh:02588b5b8ba5d31e86d93edc93b306bcbf47c789f576769245968cc157a9e8c5",
     "zh:088a30c23796133678d1d6614da5cf5544430570408a17062288b58c0bd67ac8",
     "zh:0df5faa072d67616154d38021934d8a8a316533429a3f582df3b4b48c836cf89",


### PR DESCRIPTION
### What

Remove Unused ECR Repos

### Why

The ECS tasks were updated to reference  the ECR images in our tools account (where the GovWifi pipelines live) in late 2022, during the migration from Concourse and the introduction of AWS Codepipeline.

Prior to this, the ECR images were stored in their respective AWS environments (e.g. development, staging, production). These were not removed when Concourse was retired and Codepipeline went live as we wanted to be absolutely sure nothing was using them. Now that enough time has elapsed on the new system the ECR images in Development/Staging/Production should be deleted to reduce confusion and costs.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-1177