### PR TITLE
Refactor Admin app code: decouple application running state and environment

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -38,7 +38,7 @@ resource "aws_ecs_task_definition" "admin_task" {
           "value": "${aws_db_instance.admin_db.address}"
         },{
           "name": "RAILS_ENV",
-          "value": "${var.app_env}"
+          "value": "${var.rails_env}"
         },{
           "name": "SENTRY_CURRENT_ENV",
           "value": "${var.sentry_current_env}"
@@ -114,6 +114,9 @@ resource "aws_ecs_task_definition" "admin_task" {
         },{
           "name": "S3_CERTIFICATES_OBJECT_KEY",
           "value": "${var.trusted_certificates_key}"
+        },{
+          "name": "FULLY_QUALIFIED_DOMAIN_NAME",
+          "value": "${aws_route53_record.admin.name}"
         }
       ],
       "secrets": [

--- a/govwifi-admin/iam-roles.tf
+++ b/govwifi-admin/iam-roles.tf
@@ -119,7 +119,7 @@ data "aws_iam_policy_document" "allow_ssm" {
 }
 
 resource "aws_iam_role" "ecs_task_execution_role" {
-  name               = "admin-ecsTaskExecutionRole-${var.rails_env}-${var.aws_region_name}"
+  name               = "admin-ecsTaskExecutionRole-${var.app_env}-${var.aws_region_name}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 

--- a/govwifi-admin/s3.tf
+++ b/govwifi-admin/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "admin_bucket" {
-  bucket        = "govwifi-${var.rails_env}-admin"
+  bucket        = "govwifi-${var.app_env}-admin"
   force_destroy = true
 
   tags = {
@@ -26,11 +26,11 @@ resource "aws_s3_bucket_public_access_block" "admin_bucket" {
 }
 
 resource "aws_s3_bucket" "product_page_data_bucket" {
-  bucket        = "govwifi-${var.rails_env}-product-page-data"
+  bucket        = "govwifi-${var.app_env}-product-page-data"
   force_destroy = true
 
   tags = {
-    Name   = "${title(var.rails_env)} Product page data"
+    Name   = "${title(var.app_env)} Product page data"
     Region = title(var.aws_region_name)
   }
 }
@@ -49,7 +49,7 @@ resource "aws_s3_bucket_versioning" "product_page_data_bucket" {
 }
 
 resource "aws_s3_bucket" "admin_mou_bucket" {
-  bucket        = "govwifi-${var.rails_env}-admin-mou"
+  bucket        = "govwifi-${var.app_env}-admin-mou"
   force_destroy = true
 
   tags = {

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -29,7 +29,7 @@ variable "ecr_repository_count" {
 }
 
 variable "rails_env" {
-  description = "the Ruby environment, E.g. alpaca, staging"
+  description = "the Ruby environment, E.g. production, development, test"
 }
 
 

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -175,7 +175,7 @@ module "london_admin" {
   route53_zone_id = data.aws_route53_zone.main.zone_id
 
   admin_docker_image   = format("%s/admin:alpaca", local.docker_image_path)
-  rails_env            = "alpaca"
+  rails_env            = "production"
   app_env              = "alpaca" ## used for db name.
   sentry_current_env   = "alpaca"
   ecr_repository_count = 1

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -174,7 +174,7 @@ module "london_admin" {
   route53_zone_id = data.aws_route53_zone.main.zone_id
 
   admin_docker_image   = format("%s/admin:staging", local.docker_image_path)
-  rails_env            = "staging"
+  rails_env            = "production"
   app_env              = "staging"
   sentry_current_env   = "staging"
   ecr_repository_count = 1


### PR DESCRIPTION
### What
As part of splitting up the Rails environment and the Deployment
environment, an environment variable containing the Fully
Qualified Domain Name needs to be added to the admin poral.

The RAILS_ENV variable will now be the environment the portal runs
in (production, development, test) and the APP_ENV is the deployment
environment of AWS (production, staging, alpaca, recovery)

See: https://github.com/alphagov/govwifi-admin/pull/2069

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1739