### PR TITLE
Add Healthchecks For Documentation & Product Pages

### DIFF
--- a/govwifi-docs/main.tf
+++ b/govwifi-docs/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source                = "hashicorp/aws"
+      source = "hashicorp/aws"
     }
   }
 }

--- a/govwifi-docs/main.tf
+++ b/govwifi-docs/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source                = "hashicorp/aws"
     }
   }
 }

--- a/govwifi-docs/route_53.tf
+++ b/govwifi-docs/route_53.tf
@@ -1,3 +1,11 @@
+resource "aws_route53_record" "wifi_apex" {
+  zone_id = var.route53_zone_id
+  name    = "wifi.service.gov.uk"
+  type    = "A"
+  ttl     = "300"
+  records = ["185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153"]
+}
+
 resource "aws_route53_record" "www_wifi" {
   zone_id = var.route53_zone_id
   name    = "www.wifi.service.gov.uk"
@@ -6,12 +14,36 @@ resource "aws_route53_record" "www_wifi" {
   records = ["alphagov.github.io."]
 }
 
-resource "aws_route53_record" "wifi_apex" {
-  zone_id = var.route53_zone_id
-  name    = "wifi.service.gov.uk"
-  type    = "A"
-  ttl     = "300"
-  records = ["185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153"]
+resource "aws_cloudwatch_metric_alarm" "product_pages" {
+  alarm_name          = "product-pages-health-check-alarm"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "1"
+  alarm_description   = "Alarm for Product Pages Route 53 health check failure"
+  actions_enabled     = true
+  alarm_actions       = [var.critical_notifications_arn]
+  treat_missing_data = "missing"
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.product_pages.id
+  }
+}
+
+resource "aws_route53_health_check" "product_pages" {
+  fqdn                  = "www.wifi.service.gov.uk"
+  port                  = 443
+  type                  = "HTTPS"
+  resource_path         = "/"
+  failure_threshold     = "3"
+  request_interval      = "30"
+
+  tags = {
+    Name = "Product pages healthcheck"
+  }
 }
 
 resource "aws_route53_record" "tech_docs" {
@@ -22,6 +54,38 @@ resource "aws_route53_record" "tech_docs" {
   records = ["alphagov.github.io."]
 }
 
+resource "aws_route53_health_check" "tech_docs" {
+  fqdn                  = "docs.wifi.service.gov.uk"
+  port                  = 443
+  type                  = "HTTPS"
+  resource_path         = "/"
+  failure_threshold     = "3"
+  request_interval      = "30"
+
+  tags = {
+    Name = "Tech docs - offering GovWifi- healthcheck"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "tech_docs" {
+  alarm_name          = "tech-docs-health-check-alarm"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "1"
+  alarm_description   = "Alarm for Product Pages Route 53 health check failure"
+  actions_enabled     = true
+  alarm_actions       = [var.critical_notifications_arn]
+  treat_missing_data = "missing"
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.tech_docs.id
+  }
+}
+
 resource "aws_route53_record" "dev_docs" {
   zone_id = var.route53_zone_id
   name    = "dev-docs.wifi.service.gov.uk"
@@ -29,4 +93,37 @@ resource "aws_route53_record" "dev_docs" {
   ttl     = "300"
   records = ["alphagov.github.io."]
 }
+
+resource "aws_route53_health_check" "dev_docs" {
+  fqdn                  = "dev-docs.wifi.service.gov.uk"
+  port                  = 443
+  type                  = "HTTPS"
+  resource_path         = "/"
+  failure_threshold     = "3"
+  request_interval      = "30"
+
+  tags = {
+    Name = "Dev docs healthcheck"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "dev_docs" {
+  alarm_name          = "dev-docs-health-check-alarm"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "1"
+  alarm_description   = "Alarm for Product Pages Route 53 health check failure"
+  actions_enabled     = true
+  alarm_actions       = [var.critical_notifications_arn]
+  treat_missing_data = "missing"
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.dev_docs.id
+  }
+}
+
 

--- a/govwifi-docs/route_53.tf
+++ b/govwifi-docs/route_53.tf
@@ -26,7 +26,7 @@ resource "aws_cloudwatch_metric_alarm" "product_pages" {
   alarm_description   = "Alarm for Product Pages Route 53 health check failure"
   actions_enabled     = true
   alarm_actions       = [var.critical_notifications_arn]
-  treat_missing_data = "missing"
+  treat_missing_data  = "missing"
 
   dimensions = {
     HealthCheckId = aws_route53_health_check.product_pages.id
@@ -34,12 +34,12 @@ resource "aws_cloudwatch_metric_alarm" "product_pages" {
 }
 
 resource "aws_route53_health_check" "product_pages" {
-  fqdn                  = "www.wifi.service.gov.uk"
-  port                  = 443
-  type                  = "HTTPS"
-  resource_path         = "/"
-  failure_threshold     = "3"
-  request_interval      = "30"
+  fqdn              = "www.wifi.service.gov.uk"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/"
+  failure_threshold = "3"
+  request_interval  = "30"
 
   tags = {
     Name = "Product pages healthcheck"
@@ -55,12 +55,12 @@ resource "aws_route53_record" "tech_docs" {
 }
 
 resource "aws_route53_health_check" "tech_docs" {
-  fqdn                  = "docs.wifi.service.gov.uk"
-  port                  = 443
-  type                  = "HTTPS"
-  resource_path         = "/"
-  failure_threshold     = "3"
-  request_interval      = "30"
+  fqdn              = "docs.wifi.service.gov.uk"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/"
+  failure_threshold = "3"
+  request_interval  = "30"
 
   tags = {
     Name = "Tech docs - offering GovWifi- healthcheck"
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_metric_alarm" "tech_docs" {
   alarm_description   = "Alarm for Product Pages Route 53 health check failure"
   actions_enabled     = true
   alarm_actions       = [var.critical_notifications_arn]
-  treat_missing_data = "missing"
+  treat_missing_data  = "missing"
 
   dimensions = {
     HealthCheckId = aws_route53_health_check.tech_docs.id
@@ -95,12 +95,12 @@ resource "aws_route53_record" "dev_docs" {
 }
 
 resource "aws_route53_health_check" "dev_docs" {
-  fqdn                  = "dev-docs.wifi.service.gov.uk"
-  port                  = 443
-  type                  = "HTTPS"
-  resource_path         = "/"
-  failure_threshold     = "3"
-  request_interval      = "30"
+  fqdn              = "dev-docs.wifi.service.gov.uk"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/"
+  failure_threshold = "3"
+  request_interval  = "30"
 
   tags = {
     Name = "Dev docs healthcheck"
@@ -119,7 +119,7 @@ resource "aws_cloudwatch_metric_alarm" "dev_docs" {
   alarm_description   = "Alarm for Product Pages Route 53 health check failure"
   actions_enabled     = true
   alarm_actions       = [var.critical_notifications_arn]
-  treat_missing_data = "missing"
+  treat_missing_data  = "missing"
 
   dimensions = {
     HealthCheckId = aws_route53_health_check.dev_docs.id

--- a/govwifi-docs/variables.tf
+++ b/govwifi-docs/variables.tf
@@ -1,7 +1,7 @@
-variable "aws_region" {
+variable "route53_zone_id" {
 }
 
-variable "route53_zone_id" {
+variable "critical_notifications_arn" {
 }
 
 

--- a/govwifi/staging/.terraform.lock.hcl
+++ b/govwifi/staging/.terraform.lock.hcl
@@ -48,6 +48,7 @@ provider "registry.terraform.io/hashicorp/awscc" {
   version = "0.74.0"
   hashes = [
     "h1:Brd9I23vJ6VQkarQ/Z9Yj1Vi3V1pvMawOxbgXhx1Esw=",
+    "h1:Ul1832evjT1Gu2DOH9sw4WxBbPOf7NHLJ3UfG/SAnqU=",
     "zh:033b1bf5b8b0fa412aa7e09610d03f603b83b91ba78dfc26548c450b16bdaa6a",
     "zh:1069cf96afe3e3b14f4934706523afeb07938f53a1e78567d2dcb4b336886ff2",
     "zh:25561adfb2ea86c21db300ec16f2b34f80babe0b8290efb28074c56e64f889e5",

--- a/govwifi/wifi-london/.terraform.lock.hcl
+++ b/govwifi/wifi-london/.terraform.lock.hcl
@@ -48,6 +48,7 @@ provider "registry.terraform.io/hashicorp/awscc" {
   version = "0.74.0"
   hashes = [
     "h1:Brd9I23vJ6VQkarQ/Z9Yj1Vi3V1pvMawOxbgXhx1Esw=",
+    "h1:Ul1832evjT1Gu2DOH9sw4WxBbPOf7NHLJ3UfG/SAnqU=",
     "zh:033b1bf5b8b0fa412aa7e09610d03f603b83b91ba78dfc26548c450b16bdaa6a",
     "zh:1069cf96afe3e3b14f4934706523afeb07938f53a1e78567d2dcb4b336886ff2",
     "zh:25561adfb2ea86c21db300ec16f2b34f80babe0b8290efb28074c56e64f889e5",

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -286,7 +286,7 @@ module "govwifi_admin" {
 
   elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
 
-  frontend_cert_bucket = module.frontend.frontend_certs_bucket_name
+  frontend_cert_bucket     = module.frontend.frontend_certs_bucket_name
   trusted_certificates_key = module.frontend.trusted_certificates_key
 }
 
@@ -501,10 +501,10 @@ module "govwifi_slack_alerts" {
 
   source = "../../govwifi-slack-alerts"
 
-  london_critical_notifications_topic_arn         = module.london_critical_notifications.topic_arn
-  london_capacity_notifications_topic_arn         = module.london_capacity_notifications.topic_arn
-  dublin_critical_notifications_topic_arn         = data.terraform_remote_state.dublin.outputs.dublin_critical_notifications_arn
-  dublin_capacity_notifications_topic_arn         = data.terraform_remote_state.dublin.outputs.dublin_capacity_notifications_arn
+  london_critical_notifications_topic_arn = module.london_critical_notifications.topic_arn
+  london_capacity_notifications_topic_arn = module.london_capacity_notifications.topic_arn
+  dublin_critical_notifications_topic_arn = data.terraform_remote_state.dublin.outputs.dublin_critical_notifications_arn
+  dublin_capacity_notifications_topic_arn = data.terraform_remote_state.dublin.outputs.dublin_capacity_notifications_arn
 
   route53_critical_notifications_topic_arn = module.route53_critical_notifications.topic_arn
   create_slack_alert                       = 1 # set to 1 to create config for slack chat bot.
@@ -598,14 +598,27 @@ module "govwifi_account_policy" {
 
 }
 
+provider "aws" {
+  alias  = "useast"
+  region  = "us-east-1"
+
+  default_tags {
+    tags = {
+      Environment = "Production"
+    }
+  }
+}
+
 module "govwifi_docs" {
   providers = {
-    aws = aws.main
+    aws = aws.useast
   }
 
   source = "../../govwifi-docs"
 
-  aws_region      = "eu-west-2"
-  route53_zone_id = data.aws_route53_zone.main.zone_id
+  route53_zone_id            = data.aws_route53_zone.main.zone_id
+  critical_notifications_arn = module.route53_critical_notifications.topic_arn
+
+
 
 }

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -600,7 +600,7 @@ module "govwifi_account_policy" {
 
 provider "aws" {
   alias  = "useast"
-  region  = "us-east-1"
+  region = "us-east-1"
 
   default_tags {
     tags = {


### PR DESCRIPTION
### What

Add Healthchecks For Documentation & Product Pages

### Why

We need to be alerted whenever the following sites are down:
- https://www.wifi.service.gov.uk/
- https://dev-docs.wifi.service.gov.uk/
- https://docs.wifi.service.gov.uk/

This PR adds a route53 healthcheck, which is linked to a cloudwatch alarm. The cloudwatch alarm is in turn linked to our critical alerts sns topic. We will be notified by both slack and email if these sites go down. Outside of office hours these alerts are sent to pager duty.

Due to AWS legacy oddities we are forced to create the cloudwatch alarm in us-east-1 instead of eu-west-2 where we would prefer it. [See this link to AWS's documentation for more information](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/monitoring-health-checks.html#view-health-checks-metrics-cw).

[Jira Card](https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1744)