### PR TITLE
feature: [GW-1865] adding SSM to Bastion

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -176,6 +176,12 @@ resource "aws_iam_role" "bastion_instance_role" {
 EOF
 }
 
+resource aws_iam_role_policy_attachment "bastion_instance_ssm" {
+    count      = var.enable_bastion
+    policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    role = aws_iam_role.bastion_instance_role[0].id
+}
+
 resource "aws_iam_role_policy" "bastion_instance_policy" {
   count      = var.enable_bastion
   name       = "${var.aws_region_name}-${var.env_name}-backend-bastion-instance-policy"


### PR DESCRIPTION
### What
Adding SSM access for Bastion, this just adds the policy attachment, a rebuild of the EC2 isn't required.

### Why
In preparation of moving from traditional SSH on port 22 to SSM 


### Link to JIRA card (if applicable): 
[GW-1865](https://technologyprogramme.atlassian.net/browse/GW-1865)

[GW-1865]: https://technologyprogramme.atlassian.net/browse/GW-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ