### PR TITLE
remove legacy log group wifi-frontend-docker-log-group

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -15,12 +15,6 @@ resource "aws_ecs_cluster_capacity_providers" "frontend_fargate" {
   capacity_providers = ["FARGATE"]
 }
 
-resource "aws_cloudwatch_log_group" "frontend_log_group" {
-  name = "${var.env_name}-frontend-docker-log-group"
-
-  retention_in_days = 90
-}
-
 resource "aws_cloudwatch_log_group" "frontend" {
   name = "frontend"
 
@@ -143,7 +137,7 @@ resource "aws_ecs_task_definition" "radius_task" {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "${aws_cloudwatch_log_group.frontend_log_group.name}",
+        "awslogs-group": "${aws_cloudwatch_log_group.frontend.name}",
         "awslogs-region": "${var.aws_region}",
         "awslogs-stream-prefix": "${var.env_name}-docker-logs"
       }
@@ -179,7 +173,7 @@ resource "aws_ecs_task_definition" "radius_task" {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "${aws_cloudwatch_log_group.frontend_log_group.name}",
+        "awslogs-group": "${aws_cloudwatch_log_group.frontend.name}",
         "awslogs-region": "${var.aws_region}",
         "awslogs-stream-prefix": "${var.env_name}-docker-logs"
       }


### PR DESCRIPTION
### What
Remove legacy log group staging-frontend-docker-log-group

### Why
It is no longer required or used
We should maintain our infrastructure to be as clean and lean as possible.

### Testing
Check log group exists, execute terraform, confirm log group has vanished :-)

### Link to JIRA card (if applicable): 
[[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)](https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-1885)