### PR TITLE
Remove legacy container insights setting from removed container

### DIFF
--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -2,11 +2,6 @@
 
 resource "aws_ecs_cluster" "frontend_fargate" {
   name = "frontend-fargate"
-
-  setting {
-    name  = "containerInsights"
-    value = "enabled"
-  }
 }
 
 resource "aws_ecs_cluster_capacity_providers" "frontend_fargate" {


### PR DESCRIPTION
### What
Remove the setting 'containerinsights' from legacy cluster 'frontend'

### Why
Left behind after migration to fargate-frontend
We should have clean lean infrastructure.

### Testing 
Check log group exists, execute terraform, confirm log group has vanished :-) If not, delete via the UI. Terraform will report 'no change' so a manual delete is likely required.

### Link to JIRA card (if applicable): 
(https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-1885)