### PR TITLE
fix prometheus ec2 instances not creating logs

### DIFF
--- a/govwifi-prometheus/user_data.sh
+++ b/govwifi-prometheus/user_data.sh
@@ -88,7 +88,6 @@ sudo cat <<'EOF' > /opt/aws/amazon-cloudwatch-agent/bin/config.json
 {
 	"agent": {
 		"metrics_collection_interval": 60,
-    "region": "eu-west-2",
 		"run_as_user": "root"
 	},
 	"logs": {
@@ -152,7 +151,7 @@ run-until-success apt-get install --yes docker.io
 cat <<EOF > /etc/systemd/system/docker.service.d/override.conf
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd --log-driver awslogs --log-opt awslogs-region=eu-west-2 --log-opt awslogs-group=${prometheus-log-group} --dns 10.0.0.2
+ExecStart=/usr/bin/dockerd --log-driver awslogs --log-opt --log-opt awslogs-group=${prometheus-log-group} --dns 10.0.0.2
 EOF
 
 # Reload systemctl daemon to pick up new override files

--- a/govwifi/alpaca/.terraform.lock.hcl
+++ b/govwifi/alpaca/.terraform.lock.hcl
@@ -48,6 +48,7 @@ provider "registry.terraform.io/hashicorp/awscc" {
   version = "0.74.0"
   hashes = [
     "h1:Brd9I23vJ6VQkarQ/Z9Yj1Vi3V1pvMawOxbgXhx1Esw=",
+    "h1:Ul1832evjT1Gu2DOH9sw4WxBbPOf7NHLJ3UfG/SAnqU=",
     "zh:033b1bf5b8b0fa412aa7e09610d03f603b83b91ba78dfc26548c450b16bdaa6a",
     "zh:1069cf96afe3e3b14f4934706523afeb07938f53a1e78567d2dcb4b336886ff2",
     "zh:25561adfb2ea86c21db300ec16f2b34f80babe0b8290efb28074c56e64f889e5",
@@ -91,6 +92,7 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = "~> 0.11.1"
   hashes = [
     "h1:IkDriv5C9G+kQQ+mP+8QGIahwKgbQcw1/mzh9U6q+ZI=",
+    "h1:pQGSL9mdgw4qsLndFYsEF93mbsIxyxNoAyIbBqhS3Xo=",
     "zh:19a393db736ec4fd024d098d55aefaef07056c37a448ece3b55b3f5f4c2c7e4a",
     "zh:227fa1e221de2907f37be78d40c06ca6a6f7b243a1ec33ade014dfaf6d92cd9c",
     "zh:29970fecbf4a3ca23bacbb05d6b90cdd33dd379f90059fe39e08289951502d9f",


### PR DESCRIPTION
### What
resolve Prometheus logging issues to Cloudwatch, by using the recommended AWS cloudwatch agent install and configuration. I've also removed the troublesome region which was causing some logs to be sent to another region.

### Why
Logging has never worked properly for these instances due to a number of changing factors. We must have proper logging and this tiny change completes a series of changes to insert a proper long term solution.

### Testing
This change has been fully tested in Dev & Staging. It has also been deployed to Production today, successfully. To test:

- migrate an environment back to a previous level of Master branch
- Delete the Prometheus EC2 & Cloudwatch infrastructure, retaining the external volume
- Apply this change
- Check for correct logging.

### Link to JIRA card (if applicable): 
[[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)](https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-1885)