### PR TITLE
Add permission for the user signup api to access secret

### DIFF
--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -41,7 +41,8 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.safe_restarter_sentry_dsn.arn,
       data.aws_secretsmanager_secret.authentication_api_sentry_dsn.arn,
       data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.arn,
-      data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn
+      data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn,
+      data.aws_secretsmanager_secret.notify_do_not_reply.arn
     ]
   }
 }


### PR DESCRIPTION
The user signup api requires access to the 'notify_do_not_reply' secret
