### PR TITLE
fix: [GW-1954] add public read policy to export data bucket

### DIFF
--- a/govwifi-dashboard/s3.tf
+++ b/govwifi-dashboard/s3.tf
@@ -45,3 +45,23 @@ resource "aws_s3_bucket_public_access_block" "export_data_bucket" {
   block_public_acls       = false
   block_public_policy     = false
 }
+
+
+resource "aws_s3_bucket_policy" "export_data_bucket_policy" {
+  bucket = aws_s3_bucket.export_data_bucket.id
+
+  policy = <<POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "PublicAccess",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::${aws_s3_bucket.export_data_bucket.id}/*"
+        }
+    ]
+  }
+  POLICY
+}


### PR DESCRIPTION
### What
Add a bucket policy to allow public read access to the export data objects

### Why
because data.gov requires this to allow public access, and we've had an FOI request for this, it should have been working.


### Link to JIRA card (if applicable): 
[GW-1954](https://technologyprogramme.atlassian.net/browse/GW-1954)

[GW-1954]: https://technologyprogramme.atlassian.net/browse/GW-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ