### PR TITLE
remove legacy SES rulesets

### DIFF
--- a/govwifi-emails/emails.tf
+++ b/govwifi-emails/emails.tf
@@ -56,29 +56,6 @@ resource "aws_ses_receipt_rule" "all_mail_rule" {
   }
 }
 
-resource "aws_ses_receipt_rule" "newsite_mail_rule" {
-  name          = "${var.env_name}-newsite-mail-rule"
-  rule_set_name = aws_ses_receipt_rule_set.main.rule_set_name
-  enabled       = true
-  scan_enabled  = true
-  after         = aws_ses_receipt_rule.all_mail_rule.name
-
-  depends_on = [
-    aws_sns_topic.govwifi_email_notifications,
-    aws_s3_bucket.emailbucket,
-    aws_ses_receipt_rule.user_signup_rule,
-  ]
-
-  recipients = [
-    "newsite@${var.env_subdomain}.service.gov.uk",
-  ]
-
-  sns_action {
-    topic_arn = var.devops_notifications_arn
-    position  = 1
-  }
-}
-
 resource "aws_ses_receipt_rule" "admin_email_rule" {
   name          = "${var.env_name}-admin-email-rule"
   rule_set_name = aws_ses_receipt_rule_set.main.rule_set_name


### PR DESCRIPTION
### What
Remove legacy SES rulesets

### Why
Our code and infrastructure should match our service.
We introduce risk if we leave redundant assets in place.

### Testing
This has been successfully tested in STAGING, to replicate it would be necessary to add some test rulesets and then execute terraform to remove them.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251