### PR TITLE
feature: [GW-1971] Add shield to Admin endpoints

### DIFF
--- a/govwifi-admin/loadbalancer.tf
+++ b/govwifi-admin/loadbalancer.tf
@@ -20,6 +20,12 @@ resource "aws_lb" "admin_alb" {
   }
 }
 
+# Shield advanced protection
+resource "aws_shield_protection" "admin_alb" {
+  name     = "admin-alb-${var.env_name}"
+  resource_arn = aws_lb.admin_alb.arn
+}
+
 resource "aws_s3_bucket" "access_logs" {
   bucket_prefix = "govwifi-admin-access-logs-"
 

--- a/govwifi-admin/route53.tf
+++ b/govwifi-admin/route53.tf
@@ -9,3 +9,8 @@ resource "aws_route53_record" "admin" {
     evaluate_target_health = true
   }
 }
+# Shield advanced protection
+resource "aws_shield_protection" "admin_route53" {
+  name    = "admin.${var.env_subdomain}.service.gov.uk"
+  resource_arn = var.route53_zone_arn
+}

--- a/govwifi-admin/variables.tf
+++ b/govwifi-admin/variables.tf
@@ -48,6 +48,11 @@ variable "route53_zone_id" {
   description = "Route53 zone to use for the domain name"
 }
 
+variable "route53_zone_arn" {
+  description = "Route53 zone arn to use with shield"
+}
+
+
 variable "instance_count" {
   description = "Number of EC2 hosts and ECS containers to be running"
 }

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -173,6 +173,7 @@ module "london_admin" {
   vpc_endpoints_security_group_id = module.london_backend.vpc_endpoints_security_group_id
 
   route53_zone_id = data.aws_route53_zone.main.zone_id
+  route53_zone_arn = data.aws_route53_zone.main.arn
 
   admin_docker_image   = format("%s/admin:alpaca", local.docker_image_path)
   rails_env            = "production"

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -172,7 +172,8 @@ module "london_admin" {
   vpc_endpoints_security_group_id = module.london_backend.vpc_endpoints_security_group_id
 
   route53_zone_id = data.aws_route53_zone.main.zone_id
-
+  route53_zone_arn = data.aws_route53_zone.main.arn
+  
   admin_docker_image   = format("%s/admin:staging", local.docker_image_path)
   rails_env            = "production"
   app_env              = "staging"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -244,7 +244,8 @@ module "govwifi_admin" {
   vpc_endpoints_security_group_id = module.backend.vpc_endpoints_security_group_id
 
   route53_zone_id = data.aws_route53_zone.main.zone_id
-
+  route53_zone_arn = data.aws_route53_zone.main.arn
+  
   admin_docker_image   = format("%s/admin:production", local.docker_image_path)
   rails_env            = "production"
   app_env              = "production"


### PR DESCRIPTION
### What
Add shield protection to the Admin Endpoints

### Why
To protect the admin portal against DDoS attacks.

### Deployed
Currently deployed to Alpaca (DEV)

### Link to JIRA card (if applicable): 
[GW-1971](https://technologyprogramme.atlassian.net/browse/GW-1971)

[GW-1971]: https://technologyprogramme.atlassian.net/browse/GW-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ