### PR TITLE
fix: [GW-1898] import and update bastion CW log groups

### DIFF
--- a/govwifi-backend/management.tf
+++ b/govwifi-backend/management.tf
@@ -155,6 +155,20 @@ DATA
   }
 }
 
+locals {
+  log_group_names     = ["syslog","authlog","dmesg","unattended-upgrades/unattended-upgrades.log","cloud-init-output.log"]
+}
+
+resource "aws_cloudwatch_log_group" "bastion_logs" {
+  for_each = toset([
+    for v in local.log_group_names : v
+    if var.aws_region == "eu-west-2" && var.enable_bastion == 1
+  ])
+  name              = "${var.env_name}-bastion/var/log/${each.key}"
+  retention_in_days = 90
+}
+
+
 resource "aws_iam_role" "bastion_instance_role" {
   count = var.enable_bastion
   name  = "${var.aws_region_name}-${var.env_name}-backend-bastion-instance-role"


### PR DESCRIPTION
### What
Add the bastion CloudWatch groups to terraform and update their retention periods.

### Why
These groups were not part of Terraform, thus were not being managed correctly, plus having no retention period meant logs were never expiring which is costly.
Note that, although Bastion is created in both regions, logs are sent to eu-west-2, thus a condition is set to only create the groups in that region and only if Bastion is enabled.

### Deployment
First the Orphaned Log Groups need to be imported into Terraform

```
gds aws govwifi  -- make wifi-london terraform terraform_cmd='import module.backend.aws_cloudwatch_log_group.bastion_logs[\"syslog\"] wifi-bastion/var/log/syslog'
``` 
Repeat for all the logs
then run an Apply for the retention period to be applied.

### Link to JIRA card (if applicable): 
[GW-1898](https://technologyprogramme.atlassian.net/browse/GW-1898)


[GW-1898]: https://technologyprogramme.atlassian.net/browse/GW-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ