### PR TITLE
Change URL In Smoketests for Github Migration

### DIFF
--- a/govwifi-smoke-tests/buildspec.yml
+++ b/govwifi-smoke-tests/buildspec.yml
@@ -1,11 +1,11 @@
 version: 0.2
 phases:
-    pre_build:
-        commands:
-              - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
-    build:
-        commands:
-            - echo "Smoke-tests running"
-            - git clone https://github.com/alphagov/govwifi-smoke-tests.git
-            - cd govwifi-smoke-tests
-            - make test
+  pre_build:
+    commands:
+      - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+  build:
+    commands:
+      - echo "Smoke-tests running"
+      - git clone https://github.com/GovWifi/govwifi-smoke-tests.git
+      - cd govwifi-smoke-tests
+      - make test


### PR DESCRIPTION
### What
Change URL In Smoketests for Github Migration

### Why
We are migrating to our own github organisation following the GDS split


### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1847