### PR TITLE
reduce the retention period of wifi-logging-api-docker-log-group

### DIFF
--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -2,7 +2,7 @@ resource "aws_cloudwatch_log_group" "logging_api_log_group" {
   count = var.logging_enabled
   name  = "${var.env_name}-logging-api-docker-log-group"
 
-  retention_in_days = 90
+  retention_in_days = 30
 }
 
 resource "aws_ecs_task_definition" "logging_api_task" {


### PR DESCRIPTION
### What
Reduce the retention period of this large log set from 90 days to 30 days. Agreed by Jos.

### Why
The log set is ~ 60Gb and the taxpayer is paying for this. We don't need 90 days of logs so let's save the taxpayer some money. Part of a larger body of work to refine the logging requirements.

### Testing
This has been tested in Staging without issue. The retention period is updated in place.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-1884