### PR TITLE
reduce the retention period of authentication-api-docker-log-group to save taxpayer costs

### DIFF
--- a/govwifi-api/authentication-api-cluster.tf
+++ b/govwifi-api/authentication-api-cluster.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_group" "authentication_api_log_group" {
   name = "${var.env_name}-authentication-api-docker-log-group"
 
-  retention_in_days = 90
+  retention_in_days = 30
 }
 
 resource "aws_ecs_task_definition" "authentication_api_task" {


### PR DESCRIPTION
### What
Reduce the retention period from 90 days to 30 days

### Why
This log group is very large > 34Gb and we only require 30 days of history, so let's save the taxpayer some costs.

### Testing
Fully tested in Staging.
Terraform the branch and check either the UI or CLI for changed retention period. Zero impact.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-1884