### PR TITLE
Transfer to new org

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,15 @@ This repository contains instructions on how to build GovWifi end-to-end - the s
 
 ## Overview
 Our public-facing websites are:
-- A [product page](https://github.com/alphagov/govwifi-product-page) explaining the benefits of GovWifi
-- An [admin platform](https://github.com/alphagov/govwifi-admin) for organisations to self-serve changes to their GovWifi installation
-- [Technical documentation](https://github.com/alphagov/govwifi-tech-docs), explaining GovWifi in more detail
-- A [redirection service](https://github.com/alphagov/govwifi-redirect) to handle "www" requests to these sites
+- A [product page](https://github.com/GovWifi/govwifi-product-page) explaining the benefits of GovWifi
+- An [admin platform](https://github.com/GovWifi/govwifi-admin) for organisations to self-serve changes to their GovWifi installation
+- [Technical documentation](https://github.com/GovWifi/govwifi-tech-docs), explaining GovWifi in more detail to clients and organisations. Aimed at network administrators
 
 Our services include:
-- [Frontend servers](https://github.com/alphagov/govwifi-frontend), instances of FreeRADIUS that act as authentication servers and use [FreeRADIUS Prometheus Exporter](https://github.com/bvantagelimited/freeradius_exporter) to measure server stats
-- An [authentication API](https://github.com/alphagov/govwifi-authentication-api), which the frontend calls to help authenticate GovWifi requests
-- A [logging API](https://github.com/alphagov/govwifi-logging-api), which the frontend calls to record each GovWifi request
-- A [user signup API](https://github.com/alphagov/govwifi-user-signup-api), which handles incoming sign-up texts and e-mails (with a little help from AWS)
+- [Frontend servers](https://github.com/GovWifi/govwifi-frontend), instances of FreeRADIUS that act as authentication servers and use [FreeRADIUS Prometheus Exporter](https://github.com/bvantagelimited/freeradius_exporter) to measure server stats
+- An [authentication API](https://github.com/GovWifi/govwifi-authentication-api), which the frontend calls to help authenticate GovWifi requests
+- A [logging API](https://github.com/GovWifi/govwifi-logging-api), which the frontend calls to record each GovWifi request
+- A [user signup API](https://github.com/GovWifi/govwifi-user-signup-api), which handles incoming sign-up texts and e-mails (with a little help from AWS)
 - A Prometheus server to scrape metrics from the FreeRADIUS Prometheus Exporters which exposes FreeRADIUS server data
 
 We manage our infrastructure via:
@@ -181,16 +180,16 @@ for filename in ./govwifi/<NEW-ENV-NAME>/* ; do sed -i '' 's/staging/<NEW-ENV-NA
 ```
 
 #### Add The New Environment To The Makefile
-Add the new environment to the Makefile. [See here for an example commit](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52).
+Add the new environment to the Makefile. [See here for an example commit](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52).
 
-#### Update Application Environment Variables 
+#### Update Application Environment Variables
 
 The APP_ENV environment variable for any new GovWifi environment should be set to the name of your environment (e.g. `recovery`), unless this is a real disaster recovery of production (in which case set the APP_ENV to `production`).
 
 #### Update Govwifi-Build
 
 ##### Add A Directory For Your New Environment
-We keep sensitive (but non secret information) in a private repo called govwifi-build(https://github.com/alphagov/govwifi-build). This folder is only accessible to GovWifi team members.  If you create a new GovWifi environment you will need to add new directory of the same name [here](https://github.com/alphagov/govwifi-build/tree/master/non-encrypted/secrets-to-copy/govwifi). 
+We keep sensitive (but non secret information) in a private repo called govwifi-build(https://github.com/alphagov/govwifi-build). This folder is only accessible to GovWifi team members.  If you create a new GovWifi environment you will need to add new directory of the same name [here](https://github.com/alphagov/govwifi-build/tree/master/non-encrypted/secrets-to-copy/govwifi).
 Instructions
 - Make a copy of the staging directory and rename it to your environment name
 
@@ -223,19 +222,19 @@ Use an empty passphrase.
 
 - Add encrypted versions of the files to the govwifi-build/passwords/keys/ [using the instructions here](https://dev-docs.wifi.service.gov.uk/infrastructure/secrets.html#adding-editing-a-secret).
 - Update the terraform for your environment:
-  - With the name of the key in in the dublin-keys module in the dublin.tf file of your environment [See here for an example commit](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-9745914b44847dfa981046a838f8d8886ddf9454939ee465b8ea257950c5ca85R171).
-  - With the **public** key file in the dublin-keys module in the dublin.tf file of your environment [See here for an example commit](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-9745914b44847dfa981046a838f8d8886ddf9454939ee465b8ea257950c5ca85R172).
-  - Update name of key in dublin_backend module of dublin.tf, [see here for an example commit](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-9745914b44847dfa981046a838f8d8886ddf9454939ee465b8ea257950c5ca85R105).
-  - With the name of the key in in the london-keys module in the london.tf file. To see an example [open the london.tf file in the commit](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-adf1083457d3aaad1753c8b333a2dbae1f1aff6f202d4b2390a983cef0389f88), click on the `Load diff` and navigate to a **line 24**.
-  - With the **public** key file in the london-keys module in the london.tf file. To see an example [open the london.tf file in the commit](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-adf1083457d3aaad1753c8b333a2dbae1f1aff6f202d4b2390a983cef0389f88), click on the `Load diff` and navigate to a **line 25**.
-  - To see an example [open the london.tf file in the commit](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-adf1083457d3aaad1753c8b333a2dbae1f1aff6f202d4b2390a983cef0389f88), click on the `Load diff` and navigate to a **line 55**.
-  - Update the `ssh_key_name` variable in the variables.ft with the name of the ssh key [see here for an example commit](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-481c8f75e7c6c7ff9da71e734bc80ea24feff6f398f07b81ce8bd0439d9e8c8eR3)  
+  - With the name of the key in in the dublin-keys module in the dublin.tf file of your environment [See here for an example commit](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-9745914b44847dfa981046a838f8d8886ddf9454939ee465b8ea257950c5ca85R171).
+  - With the **public** key file in the dublin-keys module in the dublin.tf file of your environment [See here for an example commit](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-9745914b44847dfa981046a838f8d8886ddf9454939ee465b8ea257950c5ca85R172).
+  - Update name of key in dublin_backend module of dublin.tf, [see here for an example commit](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-9745914b44847dfa981046a838f8d8886ddf9454939ee465b8ea257950c5ca85R105).
+  - With the name of the key in in the london-keys module in the london.tf file. To see an example [open the london.tf file in the commit](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-adf1083457d3aaad1753c8b333a2dbae1f1aff6f202d4b2390a983cef0389f88), click on the `Load diff` and navigate to a **line 24**.
+  - With the **public** key file in the london-keys module in the london.tf file. To see an example [open the london.tf file in the commit](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-adf1083457d3aaad1753c8b333a2dbae1f1aff6f202d4b2390a983cef0389f88), click on the `Load diff` and navigate to a **line 25**.
+  - To see an example [open the london.tf file in the commit](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-adf1083457d3aaad1753c8b333a2dbae1f1aff6f202d4b2390a983cef0389f88), click on the `Load diff` and navigate to a **line 55**.
+  - Update the `ssh_key_name` variable in the variables.ft with the name of the ssh key [see here for an example commit](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-481c8f75e7c6c7ff9da71e734bc80ea24feff6f398f07b81ce8bd0439d9e8c8eR3)
 
 ### Prepare The AWS Environment
 If you are running terraform in a brand new AWS account, then you will need to ensure the following steps have been completed before terraform will execute without error.
 
 #### AWS Secret Manager
-Ensure all required secrets have been entered into AWS Secrets manager in region eu-west-2 of your of your new account ([replicate over any secrets needed by resources in eu-west-1](https://docs.aws.amazon.com/secretsmanager/latest/userguide/create-manage-multi-region-secrets.html)). The name of the credentials in Secrets Manager MUST match the names of the secrets that already exist in the code. 
+Ensure all required secrets have been entered into AWS Secrets manager in region eu-west-2 of your of your new account ([replicate over any secrets needed by resources in eu-west-1](https://docs.aws.amazon.com/secretsmanager/latest/userguide/create-manage-multi-region-secrets.html)). The name of the credentials in Secrets Manager MUST match the names of the secrets that already exist in the code.
 
 ##### Auto-generating the database secrets in a new AWS environment
 
@@ -244,7 +243,7 @@ The code will automatically generate RDS secrets for the admin, sessions and use
 - govwifi-backend/secrets-manager.tf
 
 #### Increase The Default AWS Quotas
-Terraform needs to create a larger number of resources than AWS allows out of the box. Luckily it is easy to get these limits increased. 
+Terraform needs to create a larger number of resources than AWS allows out of the box. Luckily it is easy to get these limits increased.
 - [Follow the instructions from AWS to request an increase](https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html).
 - Increase the quotas in your new account so they match the following
   - **22** Elastic IPs
@@ -264,7 +263,7 @@ Terraform needs to create a larger number of resources than AWS allows out of th
 - Copy the NS records for the newly created hosted zone.
 - Log into the GovWifi Production AWS account `gds-cli aws govwifi -l`
 - In the GovWifi Production account in the Route53 go to the `wifi.service.gov.uk` hosted zone.
-- Add the NS records for your new environment with the copied NS records. 
+- Add the NS records for your new environment with the copied NS records.
 - Validate DNS delegation is complete:
   - Verify DNS delegation is complete ` dig -t NS <ENV>.wifi.service.gov.uk`  The result should match the your new environments NS records.
 
@@ -293,7 +292,7 @@ gds-cli aws govwifi-<NEW-ENV-NAME> -- aws s3api list-buckets
 ### Setting Up Remote State
 We use remote state, but there is a chicken and egg problem of creating a state bucket in which to store the remote state. When you are first creating a new environment (or migrating an environment not using remote state to use remote state) you will need to run the following commands. Anywhere you see the `<ENV>` replace this with the name of your environment e.g. `staging`.
 
-#### Manually Create S3 State Bucket 
+#### Manually Create S3 State Bucket
 
 ```
 gds-cli aws <account-name> -- aws s3api create-bucket --bucket govwifi-<ENV>-tfstate-eu-west-2 --region eu-west-2 --create-bucket-configuration LocationConstraint=eu-west-2
@@ -331,7 +330,7 @@ replication_configuration{
 
 The first time terraform is run in a new environment the replication configuration lines need to be commented out because the replication bucket in eu-west-1 will not yet exist. Leaving these lines uncommented will cause an error.
 
-#### Plan and apply terraform 
+#### Plan and apply terraform
 
 **NOTE:** Before running the command below you may need to edit the `Makefile` file and remove the `delete-secret` parameter from the `terraform` command.
 
@@ -353,7 +352,7 @@ And then
 gds-cli aws <account-name> -- make <ENV> apply
 ```
 
-After you have finished terraforming follow the manual steps below to complete the setup. 
+After you have finished terraforming follow the manual steps below to complete the setup.
 
 **NOTE:** There is currently a bug within the AWS that means that terraform can get stuck on the "Creating" RDS instances step. While building the new Env in the Recovery account it took 30 minutes to create RDS instances. However, the User-DB's Read-Replica was not created during the first `terraform apply` run. Please run `terraform apply` once again. It may run for further 30 minutes. Validate the User-DB's Read-Replica status using the AWS Console.
 
@@ -364,7 +363,7 @@ Run the terraform `plan` and `apply` again. Ensure all components are create. In
 ### Manual Steps Needed to Set Up a New Environment
 
 #### Update AWS Secrets Manager entries for all RDS instances
-When all RDS instances are created you need to use the AWS console to check configuration details of newly deployed instances. You need to use this information to update AWS Secrets for all databases' secrets. Following values need to be updated: 
+When all RDS instances are created you need to use the AWS console to check configuration details of newly deployed instances. You need to use this information to update AWS Secrets for all databases' secrets. Following values need to be updated:
 - rds/database_name/credentials/host
 - rds/database_name/credentials/dbname
 - rds/database_name/credentials/dbInstanceIdentifier
@@ -373,7 +372,7 @@ When all RDS instances are created you need to use the AWS console to check conf
 Ensure you are in the eu-west-1 region (Ireland) and follow the instructions here(https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim-easy-setup-domain.html) to verify your new subdomain (e.g. staging.wifi.service.gov.uk)
 
 #### Activate SES Rulesets
-The SES ruleset must be manually activated. 
+The SES ruleset must be manually activated.
 1. Login to the AWS console and ensure you are in the eu-west-1 region (Ireland).
 1. Go to the SES section and select "Email receiving”.
 1. Select  “GovWifiRuleSet” from the list
@@ -410,16 +409,16 @@ To deploy the Codebuild and Code Pipeline the the new environment, replace "your
 
 ##### Updating Other Pipeline files:
 
-You will also need to do the following in the tools account: 
+You will also need to do the following in the tools account:
 
-- Add the new environment's account number to AWS Secrets Manager, and then add it to terraform, [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-d94ff418330c275e25ef2b45b9d7d2dd4a9ef3720db62dd38073bd72773562d4). 
-- Add your new AWS account ID as a local variable in the govwifi-deploy module, [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-80629d600c5574b9e7d4dc7ba991ce39068d32cabd1046130d5e8e4827460f77). 
-- An ECR repository for your new environment,  [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-62eed9657e3fa19b6a5801b47b549ab70711b54c5997c50fb90a395653cccf9d).
+- Add the new environment's account number to AWS Secrets Manager, and then add it to terraform, [see here for an example](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-d94ff418330c275e25ef2b45b9d7d2dd4a9ef3720db62dd38073bd72773562d4).
+- Add your new AWS account ID as a local variable in the govwifi-deploy module, [see here for an example](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-80629d600c5574b9e7d4dc7ba991ce39068d32cabd1046130d5e8e4827460f77).
+- An ECR repository for your new environment,  [see here for an example](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-62eed9657e3fa19b6a5801b47b549ab70711b54c5997c50fb90a395653cccf9d).
 - Give the GovWifi Tools account permission to deploy things in your new environment
-  - Add appropriate S3 access: [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-d94ff418330c275e25ef2b45b9d7d2dd4a9ef3720db62dd38073bd72773562d4).
-  - Add appropriate codepipeline permissions [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-02cf364873b2fce26391e6e2b6d9ed222ce8e8f23f7d745e5c8024b02a932389).
-  - Allow your new environment to access the KMS keys used by Codepipeline [see here for an example](https://github.com/alphagov/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-8a01e39d3fd4d4d2ee124f9f0c45495bb36677f5384040c59ff023b3f517032d).
-  
+  - Add appropriate S3 access: [see here for an example](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-d94ff418330c275e25ef2b45b9d7d2dd4a9ef3720db62dd38073bd72773562d4).
+  - Add appropriate codepipeline permissions [see here for an example](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-02cf364873b2fce26391e6e2b6d9ed222ce8e8f23f7d745e5c8024b02a932389).
+  - Allow your new environment to access the KMS keys used by Codepipeline [see here for an example](https://github.com/GovWifi/govwifi-terraform/pull/777/commits/5482ac674b74b946b66040e158101bd4aa703a44#diff-8a01e39d3fd4d4d2ee124f9f0c45495bb36677f5384040c59ff023b3f517032d).
+
 #### Restoring The Databases
 
 **NOTE:**
@@ -446,7 +445,7 @@ You will also need to do the following in the tools account:
 [Follow thees instructions to restore the databases](https://dev-docs.wifi.service.gov.uk/infrastructure/database-restore.html#restoring-databases).
 
 ---
-## Application deployment 
+## Application deployment
 
 ### Deploy terraform to the Tools account
 
@@ -476,24 +475,24 @@ Run the AWS CodeBuild's Build Projects created for the new environment (e.g. adm
 
 [Follow these deployment instructions](https://dev-docs.wifi.service.gov.uk/applications/deploying.html#core-services), refer to the document linked within the `Core services` section for detailed steps.
 
-## Updating task definitions 
+## Updating task definitions
 
-This affects the following apps: 
-- [admin](https://github.com/alphagov/govwifi-admin)
-- [authentication-api](https://github.com/alphagov/govwifi-authentication-api)
-- [user-api](https://github.com/alphagov/govwifi-user-signup-api)
-- [logging-api](https://github.com/alphagov/govwifi-logging-api)
+This affects the following apps:
+- [admin](https://github.com/GovWifi/govwifi-admin)
+- [authentication-api](https://github.com/GovWifi/govwifi-authentication-api)
+- [user-api](https://github.com/GovWifi/govwifi-user-signup-api)
+- [logging-api](https://github.com/GovWifi/govwifi-logging-api)
 
 Once the task definitions for the above apps have been created by terraform, they are then managed by Codepipeline.  When the pipelines run for the first time after their initial creation, they store a copy of the task definition for that application in memory. If you create a new version of a task definition, **Codepipeline will still use the previous one AND CONTINUE to deploy the old one**. To get Codepipeline to use new task definitions you need to recreate the  pipelines. This is a flaw on AWS's part. Instructions for a work around are below:
- 
+
 - First apply your task definition change.
-- Remove the "ignore_task" attribute for the service you are modifying. For example if you were changing the admin task [you would remove the task_definition element in this array](https://github.com/alphagov/govwifi-terraform/blob/5482ac674b74b946b66040e158101bd4aa703a44/govwifi-admin/cluster.tf#L207). For example change the line so it reads `ignore_changes = [tags_all, task_definition]`)  
-- Using terraform destroy pipeline for the particular application you are changing the task definition for. For example, if you were changing the task definition for the admin pipeline, [comment out this entire file](https://github.com/alphagov/govwifi-terraform/blob/5482ac674b74b946b66040e158101bd4aa703a44/govwifi-deploy/alpaca-codepipeline-admin.tf). 
+- Remove the "ignore_task" attribute for the service you are modifying. For example if you were changing the admin task [you would remove the task_definition element in this array](https://github.com/GovWifi/govwifi-terraform/blob/5482ac674b74b946b66040e158101bd4aa703a44/govwifi-admin/cluster.tf#L207). For example change the line so it reads `ignore_changes = [tags_all, task_definition]`)
+- Using terraform destroy pipeline for the particular application you are changing the task definition for. For example, if you were changing the task definition for the admin pipeline, [comment out this entire file](https://github.com/GovWifi/govwifi-terraform/blob/5482ac674b74b946b66040e158101bd4aa703a44/govwifi-deploy/alpaca-codepipeline-admin.tf).
   - Run terraform the govwifi tools account with `gds-cli aws govwifi-tools -- make govwifi-tools apply`
-- Recreate the pipeline  using terraform 
+- Recreate the pipeline  using terraform
   - Uncomment previously commented lines
 	- Run terraform in tools again
-	- Warning: The pipelines will run as soon as they are created. But will not deploy to production without manual approval. [See the pipeline documentation for more information](https://docs.google.com/document/d/1ORrF2HwrqUu3tPswSlB0Duvbi3YHzvESwOqEY9-w6IQ/edit#heading=h.j6kp1kgy7mfw). 
+	- Warning: The pipelines will run as soon as they are created. But will not deploy to production without manual approval. [See the pipeline documentation for more information](https://docs.google.com/document/d/1ORrF2HwrqUu3tPswSlB0Duvbi3YHzvESwOqEY9-w6IQ/edit#heading=h.j6kp1kgy7mfw).
   - The new task definition should now be picked up.
 
 ---

--- a/govwifi-deploy/alpaca-codebuild-build-source-apps.tf
+++ b/govwifi-deploy/alpaca-codebuild-build-source-apps.tf
@@ -67,14 +67,14 @@ resource "aws_codebuild_project" "govwifi_codebuild_get_source_apps_dev" {
 
   source {
     type            = "GITHUB"
-    location        = "https://github.com/alphagov/govwifi-${each.key}.git"
+    location        = "https://github.com/GovWifi/govwifi-${each.key}.git"
     git_clone_depth = 1
     buildspec       = file("${path.module}/buildspec_get_app_source.yml")
   }
 }
 
 resource "aws_codebuild_webhook" "govwifi_app_webhook_dev" {
-  for_each      = toset(var.deployed_app_names)
+  for_each     = toset(var.deployed_app_names)
   project_name = aws_codebuild_project.govwifi_codebuild_get_source_apps_dev[each.key].name
 
   build_type = "BUILD"

--- a/govwifi-docs/route_53.tf
+++ b/govwifi-docs/route_53.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "www_wifi" {
   name    = "www.wifi.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
-  records = ["alphagov.github.io."]
+  records = ["govwifi.github.io."]
 }
 
 resource "aws_cloudwatch_metric_alarm" "product_pages" {
@@ -51,7 +51,7 @@ resource "aws_route53_record" "tech_docs" {
   name    = "docs.wifi.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
-  records = ["alphagov.github.io."]
+  records = ["govwifi.github.io."]
 }
 
 resource "aws_route53_health_check" "tech_docs" {
@@ -91,7 +91,7 @@ resource "aws_route53_record" "dev_docs" {
   name    = "dev-docs.wifi.service.gov.uk"
   type    = "CNAME"
   ttl     = "300"
-  records = ["alphagov.github.io."]
+  records = ["govwifi.github.io."]
 }
 
 resource "aws_route53_health_check" "dev_docs" {
@@ -125,5 +125,3 @@ resource "aws_cloudwatch_metric_alarm" "dev_docs" {
     HealthCheckId = aws_route53_health_check.dev_docs.id
   }
 }
-
-


### PR DESCRIPTION
### What
Update README As Part Of Github Org Migration Work
Updating DNS records to match the name of our new github org.
Update development environment deployment pipeline

### Why
We need to migrate our Github repos to our own organisation. This has been
triggered by the DSIT/GDS split

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1841