### PR TITLE
Increase Route53 alarm time to 5 minutes

### DIFF
--- a/govwifi-docs/route_53.tf
+++ b/govwifi-docs/route_53.tf
@@ -38,7 +38,7 @@ resource "aws_route53_health_check" "product_pages" {
   port              = 443
   type              = "HTTPS"
   resource_path     = "/"
-  failure_threshold = "3"
+  failure_threshold = "10"
   request_interval  = "30"
 
   tags = {
@@ -59,7 +59,7 @@ resource "aws_route53_health_check" "tech_docs" {
   port              = 443
   type              = "HTTPS"
   resource_path     = "/"
-  failure_threshold = "3"
+  failure_threshold = "10"
   request_interval  = "30"
 
   tags = {
@@ -99,7 +99,7 @@ resource "aws_route53_health_check" "dev_docs" {
   port              = 443
   type              = "HTTPS"
   resource_path     = "/"
-  failure_threshold = "3"
+  failure_threshold = "10"
   request_interval  = "30"
 
   tags = {


### PR DESCRIPTION
### What
Increase Route53 alarm time to 5 minutes

### Why
Everytime we update any of our github pages they go offline for a period of minutes whilst they redeploy. To prevent these alarms giving us false flags increase time to wait before alarming to 5 minutes.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-2148