### PR TITLE
Modify name of notify template backup bucket

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -81,7 +81,7 @@ resource "aws_cloudwatch_event_rule" "retrieve_notifications_event" {
 
 resource "aws_cloudwatch_event_rule" "backup_notify_templates_event" {
   count               = var.event_rule_count
-  name                = "${var.env_name}-backup-notify-templates"
+  name                = "${var.env}-backup-notify-templates"
   description         = "Triggers daily 06:00 UTC"
   schedule_expression = "cron(0 6 * * ? *)"
   state               = "ENABLED"

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -66,8 +66,8 @@ resource "aws_iam_role_policy" "user_signup_api_task_policy" {
         "s3:HeadBucket"
       ],
       "Resource": [
-        "arn:aws:s3:::govwifi-${var.env_name}-notification-templates",
-        "arn:aws:s3:::govwifi-${var.env_name}-notification-templates/*"
+        "arn:aws:s3:::govwifi-${var.env}-notification-templates",
+        "arn:aws:s3:::govwifi-${var.env}-notification-templates/*"
       ]
     }
   ]


### PR DESCRIPTION
### What
Modify name of notify template backup bucket

### Why
Fix error in production, by making names consistent
