### PR TITLE
Run A Lighter Version Of Smoketests In Production

### DIFF
--- a/govwifi-smoke-tests/buildspec.yml
+++ b/govwifi-smoke-tests/buildspec.yml
@@ -3,9 +3,9 @@ phases:
   pre_build:
     commands:
     - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
-    - git clone -b $BRANCH https://github.com/GovWifi/govwifi-smoke-tests.git
+    - git clone -b $BRANCH https://github.com/GovWifi/$REPO_NAME.git
   build:
     commands:
     - echo "Smoke-tests running"
-    - cd govwifi-smoke-tests
+    - cd $REPO_NAME
     - make test

--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -22,6 +22,11 @@ resource "aws_codebuild_project" "smoke_tests" {
     }
 
     environment_variable {
+      name  = "REPO_NAME" 
+      value = var.smoke_tests_repo_name
+    }
+
+    environment_variable {
       name  = "DOCKER_HUB_AUTHTOKEN_ENV"
       value = data.aws_secretsmanager_secret_version.docker_hub_authtoken.secret_string
     }

--- a/govwifi-smoke-tests/variables.tf
+++ b/govwifi-smoke-tests/variables.tf
@@ -33,3 +33,6 @@ variable "govwifi_phone_number" {
 
 variable "notify_field" {
 }
+
+variable "smoke_tests_repo_name" {
+}

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -457,6 +457,9 @@ module "london_smoke_tests" {
   create_slack_alert         = 0
   govwifi_phone_number       = "+447860003687"
   notify_field               = "govwifidevelopment"
+  smoke_tests_repo_name      = "govwifi-smoke-tests"
+
+
   depends_on = [
     module.london_frontend
   ]

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -455,6 +455,8 @@ module "london_smoke_tests" {
   create_slack_alert         = 0
   govwifi_phone_number       = "+447537417039"
   notify_field               = "govwifistaging"
+  smoke_tests_repo_name      = "govwifi-smoke-tests"
+
 
   depends_on = [
     module.london_frontend

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -540,6 +540,9 @@ module "smoke_tests" {
   create_slack_alert         = 1
   govwifi_phone_number       = "+447537417417"
   notify_field               = "govwifi"
+  smoke_tests_repo_name      = "govwifi-smoke-tests-light"
+
+
   depends_on = [
     module.frontend
   ]


### PR DESCRIPTION
### What
Run A Lighter Version Of Smoketests In Production

### Why
The automated SMS journey routinely fails, due to issues with notify, this is not a reflection of system failing but an issue with the API call. This is giving false warnings about our production systems so this part of the test has been disabled in the production environment, but will still be used in staging and when we deploy new code.
https://github.com/GovWifi/govwifi-smoke-tests-light

