### PR TITLE
Update command

### DIFF
--- a/govwifi-admin/scheduled-tasks.tf
+++ b/govwifi-admin/scheduled-tasks.tf
@@ -175,7 +175,7 @@ resource "aws_cloudwatch_event_target" "daily_median_metrics" {
    "containerOverrides": [
      {
        "name": "admin",
-       "command": ["bundle", "exec", "rake", "elasticsearch:publish_metrics"]
+       "command": ["bundle", "exec", "rake", "opensearch:publish_metrics"]
      }
    ]
  }


### PR DESCRIPTION
### What
 Update the command in the scheduled task to call opensearch:publish_metrics instead of elasticsearch:publish_metrics

### Why
We renamed elasticsearch to opensearch in the admin app and didnt update the command in the scheduled task to call opensearch:publish_metrics instead of elasticsearch:publish_metrics


### Link to JIRA card (if applicable): 
[[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)](https://technologyprogramme.atlassian.net/browse/GW-2266)