### PR TITLE
Increase time that prometheus Radius logs are kept

### DIFF
--- a/govwifi-prometheus/prometheus-govwifi
+++ b/govwifi-prometheus/prometheus-govwifi
@@ -7,7 +7,7 @@ Restart=always
 User=prometheus
 ExecStart=/usr/bin/prometheus \
   --storage.tsdb.path=/srv/prometheus/metrics2 \
-  --storage.tsdb.retention.time=90d
+  --storage.tsdb.retention.time=365d
 TimeoutStopSec=30s
 
 [Install]

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -456,7 +456,7 @@ module "govwifi_prometheus" {
   dublin_radius_ip_addresses = var.dublin_radius_ip_addresses
 
   grafana_ip    = var.grafana_ip
-  log_retention = local.log_retention
+  log_retention = 30
 }
 
 module "govwifi_grafana" {

--- a/govwifi/wifi/main.tf
+++ b/govwifi/wifi/main.tf
@@ -376,7 +376,7 @@ module "govwifi_prometheus" {
   aws_region      = var.aws_region
   aws_region_name = var.aws_region_name
   aws_account_id  = local.aws_account_id
-  log_retention   = local.log_retention
+  log_retention   = 30
 
   ssh_key_name = var.ssh_key_name
 


### PR DESCRIPTION
### What
Increase time that prometheus Radius logs are kept

### Why
Request from our TA following incident investigation. Increase time radius prometheus logs are available Radius logs now available for 1 year.
However prometheus instance logs (which refer to what's happening on Prometheus itself, can be 30 days)


