### PR TITLE
Add Environment Name Variable For Smoketests

### DIFF
--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -130,7 +130,7 @@ resource "aws_codebuild_project" "smoke_tests" {
 
     environment_variable {
       name  = "ENVIRONMENT"
-      value = var.env
+      value = var.environment
     }
 
   }

--- a/govwifi-smoke-tests/variables.tf
+++ b/govwifi-smoke-tests/variables.tf
@@ -30,3 +30,6 @@ variable "vpc_id" {
 
 variable "default_security_group_id" {
 }
+
+variable "environment" {
+}

--- a/govwifi/alpaca/london.tf
+++ b/govwifi/alpaca/london.tf
@@ -459,6 +459,7 @@ module "london_smoke_tests" {
   aws_account_id             = local.aws_account_id
   env_subdomain              = local.env_subdomain
   env                        = local.env_name
+  environment                = local.env
   vpc_id                     = module.london_tests_vpc.vpc_id
   default_security_group_id  = module.london_tests_vpc.default_security_group_id
   smoketest_subnet_private_a = module.london_tests_vpc.subnet_private_a_id

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -455,6 +455,7 @@ module "london_smoke_tests" {
   aws_account_id             = local.aws_account_id
   env_subdomain              = local.env_subdomain
   env                        = local.env_name
+  environment                = local.env
   vpc_id                     = module.london_tests_vpc.vpc_id
   default_security_group_id  = module.london_tests_vpc.default_security_group_id
   smoketest_subnet_private_a = module.london_tests_vpc.subnet_private_a_id

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -541,6 +541,7 @@ module "smoke_tests" {
   aws_account_id             = local.aws_account_id
   env_subdomain              = local.env_subdomain
   env                        = local.env_name
+  environment                = local.env
   vpc_id                     = module.london_tests_vpc.vpc_id
   default_security_group_id  = module.london_tests_vpc.default_security_group_id
   smoketest_subnet_private_a = module.london_tests_vpc.subnet_private_a_id


### PR DESCRIPTION
### What
Add Environment Name Variable For Smoketests

### Why
We need to get the environment name (not wifi) this commit corrects the previous one

