### PR TITLE
Sync Production Smoketests With Other Envs

### DIFF
--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -549,7 +549,7 @@ module "smoke_tests" {
   create_slack_alert         = 1
   govwifi_phone_number       = "+447537417417"
   notify_field               = "govwifi"
-  smoke_tests_repo_name      = "govwifi-smoke-tests-light"
+  smoke_tests_repo_name      = "govwifi-smoke-tests"
 
 
   depends_on = [


### PR DESCRIPTION
### What
Sync Production Smoketests With Other Envs

### Why
We have updated the https://github.com/GovWifi/govwifi-smoke-tests repo so that it now only runs SMS tests in the staging and development environments (not every 15 minutes in production). This means that the smoke-tests for all environments can be fetched from the same repo