### PR TITLE
Add Capacity Testing Module

### DIFF
--- a/govwifi-capacity-testing/cluster.tf
+++ b/govwifi-capacity-testing/cluster.tf
@@ -72,7 +72,7 @@ resource "aws_ecs_service" "capacity_testing" {
   name             = "govwifi-capacity-testing-svc-${var.env}"
   cluster          = aws_ecs_cluster.capacity.id
   task_definition  = aws_ecs_task_definition.capacity_testing.arn
-  desired_count    = 3
+  desired_count    = 0
   launch_type      = "FARGATE"
   platform_version = "LATEST"
 
@@ -85,6 +85,11 @@ resource "aws_ecs_service" "capacity_testing" {
   enable_execute_command = true
 
   tags = { Env = var.env }
+
+  lifecycle {
+    ignore_changes = [
+    desired_count]
+  }
 }
 
 

--- a/govwifi-capacity-testing/cluster.tf
+++ b/govwifi-capacity-testing/cluster.tf
@@ -1,0 +1,136 @@
+/*
+	ECS service for govwifi-capacity-testing.
+	- Fargate ECS cluster and service (desired_count = 1)
+	- Task definition uses the ECR repo created in ecr.tf
+	- CloudWatch Logs group
+	- Execution role with AmazonECSTaskExecutionRolePolicy and SSM messaging permissions for ECS Exec
+	- Service has `enable_execute_command = true` so you can use AWS SSM to exec into the container
+*/
+
+resource "aws_cloudwatch_log_group" "capacity_testing" {
+	name              = "/ecs/govwifi-capacity-testing-${var.env}"
+	retention_in_days = 30
+	tags = { Env = var.env }
+}
+
+resource "aws_ecs_cluster" "capacity" {
+	name = "govwifi-capacity-${var.env}"
+	setting {
+		name  = "containerInsights"
+		value = "disabled"
+	}
+	tags = { Env = var.env }
+}
+
+resource "aws_ecs_task_definition" "capacity_testing" {
+	family                   = "govwifi-capacity-testing-${var.env}"
+	requires_compatibilities = ["FARGATE"]
+	network_mode             = "awsvpc"
+	cpu                      = "8192"
+	memory                   = "61440"
+	execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+	task_role_arn            = aws_iam_role.ecs_task_role.arn
+
+	container_definitions = <<EOF
+[
+		{
+			"name": "capacity-testing",
+			"image": "${aws_ecr_repository.capacity_testing.repository_url}:latest",
+			"essential": true,
+			"secrets": [
+				{
+				"name": "RADIUS_SERVER_IP",
+				"valueFrom": "arn:aws:ssm:eu-west-2:${var.aws_account_id}:parameter/govwifi/capacity_testing/radius_server_ip"
+				},
+				{
+				"name": "RADIUS_SECRET",
+				"valueFrom": "arn:aws:ssm:eu-west-2:${var.aws_account_id}:parameter/govwifi/capacity_testing/radius_secret"
+				},
+				{
+				"name": "GW_USERNAME",
+				"valueFrom": "arn:aws:ssm:eu-west-2:${var.aws_account_id}:parameter/govwifi/capacity_testing/gw_username"
+				},
+				{
+				"name": "GW_PASSWORD",
+				"valueFrom": "arn:aws:ssm:eu-west-2:${var.aws_account_id}:parameter/govwifi/capacity_testing/gw_password"
+				}
+			],
+			"logConfiguration": {
+				"logDriver": "awslogs",
+				"options": {
+					"awslogs-group": "${aws_cloudwatch_log_group.capacity_testing.name}",
+					"awslogs-region": "${var.aws_region}",
+					"awslogs-stream-prefix": "capacity-testing"
+				}
+			}
+		}
+	]
+EOF
+}
+
+resource "aws_ecs_service" "capacity_testing" {
+	name            = "govwifi-capacity-testing-svc-${var.env}"
+	cluster         = aws_ecs_cluster.capacity.id
+	task_definition = aws_ecs_task_definition.capacity_testing.arn
+	desired_count   = 3
+	launch_type     = "FARGATE"
+	platform_version = "LATEST"
+
+	network_configuration {
+		subnets         = aws_subnet.capacity_private[*].id
+		security_groups = [aws_security_group.capacity_tasks_sg.id]
+		assign_public_ip = false
+	}
+
+	enable_execute_command = true
+
+	tags = { Env = var.env }
+}
+
+
+resource "aws_security_group" "capacity_tasks_sg" {
+	name        = "govwifi-capacity-tasks-sg-${var.env}"
+	description = "Security group for capacity testing ECS tasks"
+	vpc_id      = aws_vpc.capacity_public.id
+
+	tags = {
+		Name = "${title(var.env)} Capacity Testing"
+	}
+
+  ingress {
+    description = "RADIUS traffic"
+    from_port   = 1812
+    to_port     = 1812
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    cidr_blocks  	= ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Need for Jmeter workers. Allow traffic from self"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+  }
+
+  egress {
+    description = "Allow all traffic out"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+
+}
+
+
+
+

--- a/govwifi-capacity-testing/cluster.tf
+++ b/govwifi-capacity-testing/cluster.tf
@@ -8,30 +8,30 @@
 */
 
 resource "aws_cloudwatch_log_group" "capacity_testing" {
-	name              = "/ecs/govwifi-capacity-testing-${var.env}"
-	retention_in_days = 30
-	tags = { Env = var.env }
+  name              = "/ecs/govwifi-capacity-testing-${var.env}"
+  retention_in_days = 30
+  tags              = { Env = var.env }
 }
 
 resource "aws_ecs_cluster" "capacity" {
-	name = "govwifi-capacity-${var.env}"
-	setting {
-		name  = "containerInsights"
-		value = "disabled"
-	}
-	tags = { Env = var.env }
+  name = "govwifi-capacity-${var.env}"
+  setting {
+    name  = "containerInsights"
+    value = "disabled"
+  }
+  tags = { Env = var.env }
 }
 
 resource "aws_ecs_task_definition" "capacity_testing" {
-	family                   = "govwifi-capacity-testing-${var.env}"
-	requires_compatibilities = ["FARGATE"]
-	network_mode             = "awsvpc"
-	cpu                      = "8192"
-	memory                   = "61440"
-	execution_role_arn       = aws_iam_role.ecs_task_execution.arn
-	task_role_arn            = aws_iam_role.ecs_task_role.arn
+  family                   = "govwifi-capacity-testing-${var.env}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "8192"
+  memory                   = "61440"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
 
-	container_definitions = <<EOF
+  container_definitions = <<EOF
 [
 		{
 			"name": "capacity-testing",
@@ -69,33 +69,33 @@ EOF
 }
 
 resource "aws_ecs_service" "capacity_testing" {
-	name            = "govwifi-capacity-testing-svc-${var.env}"
-	cluster         = aws_ecs_cluster.capacity.id
-	task_definition = aws_ecs_task_definition.capacity_testing.arn
-	desired_count   = 3
-	launch_type     = "FARGATE"
-	platform_version = "LATEST"
+  name             = "govwifi-capacity-testing-svc-${var.env}"
+  cluster          = aws_ecs_cluster.capacity.id
+  task_definition  = aws_ecs_task_definition.capacity_testing.arn
+  desired_count    = 3
+  launch_type      = "FARGATE"
+  platform_version = "LATEST"
 
-	network_configuration {
-		subnets         = aws_subnet.capacity_private[*].id
-		security_groups = [aws_security_group.capacity_tasks_sg.id]
-		assign_public_ip = false
-	}
+  network_configuration {
+    subnets          = aws_subnet.capacity_private[*].id
+    security_groups  = [aws_security_group.capacity_tasks_sg.id]
+    assign_public_ip = false
+  }
 
-	enable_execute_command = true
+  enable_execute_command = true
 
-	tags = { Env = var.env }
+  tags = { Env = var.env }
 }
 
 
 resource "aws_security_group" "capacity_tasks_sg" {
-	name        = "govwifi-capacity-tasks-sg-${var.env}"
-	description = "Security group for capacity testing ECS tasks"
-	vpc_id      = aws_vpc.capacity_public.id
+  name        = "govwifi-capacity-tasks-sg-${var.env}"
+  description = "Security group for capacity testing ECS tasks"
+  vpc_id      = aws_vpc.capacity_public.id
 
-	tags = {
-		Name = "${title(var.env)} Capacity Testing"
-	}
+  tags = {
+    Name = "${title(var.env)} Capacity Testing"
+  }
 
   ingress {
     description = "RADIUS traffic"
@@ -106,10 +106,10 @@ resource "aws_security_group" "capacity_tasks_sg" {
   }
 
   ingress {
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    cidr_blocks  	= ["0.0.0.0/0"]
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {

--- a/govwifi-capacity-testing/codebuild.tf
+++ b/govwifi-capacity-testing/codebuild.tf
@@ -1,0 +1,90 @@
+resource "aws_codebuild_project" "docker_capacity_testing_ecr" {
+  name          = "govwifi-docker-capacity-testing-to-ecr"
+  description   = "Builds and pushes docker-capacity-testing image to ECR"
+  build_timeout = "30"
+  service_role  = aws_iam_role.govwifi_capacity_test.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:6.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID"
+      value = var.aws_account_id
+    }
+
+    environment_variable {
+      name  = "ECR_REPOSITORY_URI"
+      value = aws_ecr_repository.capacity_testing.repository_url
+    }
+
+    environment_variable {
+      name  = "AWS_REGION"
+      value = "eu-west-2"
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_AUTHTOKEN_ENV"
+      value = "/govwifi/capacity_testing/docker_hub_authtoken"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DOCKER_HUB_USERNAME_ENV"
+      value = "/govwifi/capacity_testing/docker_hub_username"
+      type  = "PARAMETER_STORE"
+    }
+
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/GovWifi/govwifi-docker-radius-tools.git"
+    git_clone_depth = 1
+    buildspec       = <<-EOT
+      version: 0.2
+      phases:
+        pre_build:
+          commands:
+            - echo Logging in to Amazon ECR...
+            - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+            - REPOSITORY_NAME=$(echo $ECR_REPOSITORY_URI | cut -d'/' -f2)
+            - IMAGE_TAG="latest"
+        build:
+          commands:
+            - echo Building the Docker image on `date`
+            - docker build -t $ECR_REPOSITORY_URI:$IMAGE_TAG .
+            - docker tag $ECR_REPOSITORY_URI:$IMAGE_TAG $ECR_REPOSITORY_URI:latest
+        post_build:
+          commands:
+            - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+            - echo Pushing the Docker image to ECR on `date`
+            - docker push $ECR_REPOSITORY_URI:$IMAGE_TAG
+            - echo Writing image definitions file...
+            - printf '[{"name":"capacity-testing","imageUri":"%s"}]' $ECR_REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+      artifacts:
+        files: imagedefinitions.json
+    EOT
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "govwifi-docker-capacity-testing-group"
+      stream_name = "govwifi-docker-capacity-testing-stream"
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${aws_s3_bucket.codebuild_logs_bucket.id}/capacity-tests-codebuild-logs"
+    }
+  }
+
+}

--- a/govwifi-capacity-testing/ecr.tf
+++ b/govwifi-capacity-testing/ecr.tf
@@ -1,0 +1,44 @@
+resource "aws_ecr_repository" "capacity_testing" {
+  name                 = "govwifi-capacity-testing"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = false
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = "govwifi-capacity-testing"
+  }
+}
+
+resource "aws_ecr_repository_policy" "capacity_testing" {
+  repository = aws_ecr_repository.capacity_testing.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCodeBuildPush"
+        Effect = "Allow"
+        Principal = {
+          Service = "codebuild.amazonaws.com"
+        }
+        Action = [
+          "ecr:*"
+        ]
+      },
+      {
+        Sid    = "AllowECSTaskExecutionPull"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage"
+        ]
+      }
+    ]
+  })
+}

--- a/govwifi-capacity-testing/iam.tf
+++ b/govwifi-capacity-testing/iam.tf
@@ -1,0 +1,198 @@
+resource "aws_iam_role" "govwifi_capacity_test" {
+  name = "govwifi-capacity-testing-codebuild-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "codebuild.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "codebuild_policy" {
+  name        = "govwifi-codebuild-policy"
+  description = "Allows CodeBuild to push Docker images to ECR and create logs"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ECRAuthToken"
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ECRPushImage"
+        Effect = "Allow"
+        Action = [
+          "ecr:*"
+        ]
+        Resource = aws_ecr_repository.capacity_testing.arn
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      },
+      {
+        Sid    = "S3Logs"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject"
+        ]
+        Resource = "${aws_s3_bucket.codebuild_logs_bucket.arn}/*"
+      },
+      {
+        Sid    = "SSMParameters"
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameters",
+          "ssm:GetParameter"
+        ]
+        Resource = "arn:aws:ssm:eu-west-2:*:parameter/govwifi/capacity_testing/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "codebuild_policy" {
+  role       = aws_iam_role.govwifi_capacity_test.name
+  policy_arn = aws_iam_policy.codebuild_policy.arn
+}
+
+
+### ECS Roles
+
+resource "aws_iam_role" "ecs_task_execution" {
+	name = "ecsTaskExecutionRole-govwifi-capacity-${var.env}"
+	assume_role_policy = jsonencode({
+		Version = "2012-10-17"
+		Statement = [
+			{
+				Action = "sts:AssumeRole"
+				Effect = "Allow"
+				Principal = {
+					Service = "ecs-tasks.amazonaws.com"
+				}
+			}
+		]
+	})
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_managed" {
+	role       = aws_iam_role.ecs_task_execution.name
+	policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "ecs_exec_ssm_policy" {
+	name = "ecs-exec-ssm-policy-govwifi-capacity-${var.env}"
+	role = aws_iam_role.ecs_task_execution.id
+
+	policy = jsonencode({
+		Version = "2012-10-17"
+		Statement = [
+			{
+				Effect = "Allow"
+				Action = [
+					"ssmmessages:*"
+				]
+				Resource = "*"
+			},
+			{
+				Effect = "Allow"
+				Action = [
+					"ssm:GetParameters"
+				]
+				Resource = "arn:aws:ssm:*:*:parameter/govwifi/capacity_testing/*"
+			},
+			{
+				Effect = "Allow"
+				Action = [
+					"logs:CreateLogStream",
+					"logs:PutLogEvents",
+					"logs:CreateLogGroup"
+				]
+				Resource = "*"
+			}
+		]
+	})
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+	name = "govwifi-ecsTaskRole-capacity-${var.env}"
+	assume_role_policy = jsonencode({
+		Version = "2012-10-17"
+		Statement = [
+			{
+				Action = "sts:AssumeRole"
+				Effect = "Allow"
+				Principal = {
+					Service = "ecs-tasks.amazonaws.com"
+				}
+			}
+		]
+	})
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_role" {
+	role       = aws_iam_role.ecs_task_role.name
+	policy_arn = aws_iam_policy.ecs_task_role.arn
+}
+
+resource "aws_iam_policy" "ecs_task_role" {
+	name = "govwifi-capacity-ecs-task-policy-${var.env}"
+  path        = "/"
+  description = "Allows capacity testing tasks to be accessed by ecs exec (allows ssh like access to tasks), and also to access parameter store for dummy testing cert"
+
+	policy = jsonencode({
+		Version = "2012-10-17"
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssmmessages:*"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:*"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameter",
+                "ssm:GetParameters"
+            ],
+            "Resource": "arn:aws:ssm:${var.aws_region}:${var.aws_account_id}:parameter/govwifi/capacity_testing/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecs:ListTasks",
+                "ecs:DescribeTasks",
+                "ec2:DescribeNetworkInterfaces"
+            ],
+            "Resource": "*"
+        }
+    ]
+	})
+}

--- a/govwifi-capacity-testing/iam.tf
+++ b/govwifi-capacity-testing/iam.tf
@@ -79,120 +79,120 @@ resource "aws_iam_role_policy_attachment" "codebuild_policy" {
 ### ECS Roles
 
 resource "aws_iam_role" "ecs_task_execution" {
-	name = "ecsTaskExecutionRole-govwifi-capacity-${var.env}"
-	assume_role_policy = jsonencode({
-		Version = "2012-10-17"
-		Statement = [
-			{
-				Action = "sts:AssumeRole"
-				Effect = "Allow"
-				Principal = {
-					Service = "ecs-tasks.amazonaws.com"
-				}
-			}
-		]
-	})
+  name = "ecsTaskExecutionRole-govwifi-capacity-${var.env}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_managed" {
-	role       = aws_iam_role.ecs_task_execution.name
-	policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
 resource "aws_iam_role_policy" "ecs_exec_ssm_policy" {
-	name = "ecs-exec-ssm-policy-govwifi-capacity-${var.env}"
-	role = aws_iam_role.ecs_task_execution.id
+  name = "ecs-exec-ssm-policy-govwifi-capacity-${var.env}"
+  role = aws_iam_role.ecs_task_execution.id
 
-	policy = jsonencode({
-		Version = "2012-10-17"
-		Statement = [
-			{
-				Effect = "Allow"
-				Action = [
-					"ssmmessages:*"
-				]
-				Resource = "*"
-			},
-			{
-				Effect = "Allow"
-				Action = [
-					"ssm:GetParameters"
-				]
-				Resource = "arn:aws:ssm:*:*:parameter/govwifi/capacity_testing/*"
-			},
-			{
-				Effect = "Allow"
-				Action = [
-					"logs:CreateLogStream",
-					"logs:PutLogEvents",
-					"logs:CreateLogGroup"
-				]
-				Resource = "*"
-			}
-		]
-	})
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameters"
+        ]
+        Resource = "arn:aws:ssm:*:*:parameter/govwifi/capacity_testing/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:CreateLogGroup"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role" "ecs_task_role" {
-	name = "govwifi-ecsTaskRole-capacity-${var.env}"
-	assume_role_policy = jsonencode({
-		Version = "2012-10-17"
-		Statement = [
-			{
-				Action = "sts:AssumeRole"
-				Effect = "Allow"
-				Principal = {
-					Service = "ecs-tasks.amazonaws.com"
-				}
-			}
-		]
-	})
+  name = "govwifi-ecsTaskRole-capacity-${var.env}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_role" {
-	role       = aws_iam_role.ecs_task_role.name
-	policy_arn = aws_iam_policy.ecs_task_role.arn
+  role       = aws_iam_role.ecs_task_role.name
+  policy_arn = aws_iam_policy.ecs_task_role.arn
 }
 
 resource "aws_iam_policy" "ecs_task_role" {
-	name = "govwifi-capacity-ecs-task-policy-${var.env}"
+  name        = "govwifi-capacity-ecs-task-policy-${var.env}"
   path        = "/"
   description = "Allows capacity testing tasks to be accessed by ecs exec (allows ssh like access to tasks), and also to access parameter store for dummy testing cert"
 
-	policy = jsonencode({
-		Version = "2012-10-17"
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ssmmessages:*"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "logs:*"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ssm:GetParameter",
-                "ssm:GetParameters"
-            ],
-            "Resource": "arn:aws:ssm:${var.aws_region}:${var.aws_account_id}:parameter/govwifi/capacity_testing/*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ecs:ListTasks",
-                "ecs:DescribeTasks",
-                "ec2:DescribeNetworkInterfaces"
-            ],
-            "Resource": "*"
-        }
+  policy = jsonencode({
+    Version = "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ssmmessages:*"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:*"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ssm:GetParameter",
+          "ssm:GetParameters"
+        ],
+        "Resource" : "arn:aws:ssm:${var.aws_region}:${var.aws_account_id}:parameter/govwifi/capacity_testing/*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ecs:ListTasks",
+          "ecs:DescribeTasks",
+          "ec2:DescribeNetworkInterfaces"
+        ],
+        "Resource" : "*"
+      }
     ]
-	})
+  })
 }

--- a/govwifi-capacity-testing/iam.tf
+++ b/govwifi-capacity-testing/iam.tf
@@ -36,7 +36,7 @@ resource "aws_iam_policy" "codebuild_policy" {
         Action = [
           "ecr:*"
         ]
-        Resource = aws_ecr_repository.capacity_testing.arn
+        Resource = "${aws_ecr_repository.capacity_testing.arn}"
       },
       {
         Sid    = "CloudWatchLogs"
@@ -109,7 +109,10 @@ resource "aws_iam_role_policy" "ecs_exec_ssm_policy" {
       {
         Effect = "Allow"
         Action = [
-          "ssmmessages:*"
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
         ]
         Resource = "*"
       },
@@ -127,7 +130,7 @@ resource "aws_iam_role_policy" "ecs_exec_ssm_policy" {
           "logs:PutLogEvents",
           "logs:CreateLogGroup"
         ]
-        Resource = "*"
+        Resource = "${aws_cloudwatch_log_group.capacity_testing.arn}:*"
       }
     ]
   })
@@ -165,7 +168,10 @@ resource "aws_iam_policy" "ecs_task_role" {
       {
         "Effect" : "Allow",
         "Action" : [
-          "ssmmessages:*"
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
         ],
         "Resource" : "*"
       },
@@ -174,7 +180,9 @@ resource "aws_iam_policy" "ecs_task_role" {
         "Action" : [
           "logs:*"
         ],
-        "Resource" : "*"
+        "Resource" : [
+          "${aws_cloudwatch_log_group.capacity_testing.arn}:*"
+        ]
       },
       {
         "Effect" : "Allow",

--- a/govwifi-capacity-testing/locals.tf
+++ b/govwifi-capacity-testing/locals.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  aws_account_id = data.aws_caller_identity.current.account_id
+}

--- a/govwifi-capacity-testing/main.tf
+++ b/govwifi-capacity-testing/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/govwifi-capacity-testing/s3.tf
+++ b/govwifi-capacity-testing/s3.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_bucket" "codebuild_logs_bucket" {
+  bucket = "govwifi-capacity-testing-codebuild-logs"
+}
+
+resource "aws_s3_bucket_public_access_block" "codebuild_logs_bucket_block" {
+  bucket = aws_s3_bucket.codebuild_logs_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/govwifi-capacity-testing/variables.tf
+++ b/govwifi-capacity-testing/variables.tf
@@ -1,0 +1,11 @@
+variable "env" {
+}
+
+variable "aws_account_id" {
+}
+
+variable "aws_region" {
+}
+
+# variable "administrator_cidrs" {
+# }

--- a/govwifi-capacity-testing/vpc.tf
+++ b/govwifi-capacity-testing/vpc.tf
@@ -5,89 +5,89 @@
 data "aws_availability_zones" "azs" {}
 
 resource "aws_vpc" "capacity_public" {
-	cidr_block = "10.222.0.0/16"
-	tags = {
-		Name = "govwifi-capacity-public-${var.env}"
-		Env  = var.env
-	}
+  cidr_block = "10.222.0.0/16"
+  tags = {
+    Name = "govwifi-capacity-public-${var.env}"
+    Env  = var.env
+  }
 
-	enable_dns_support = true
-	enable_dns_hostnames = true
+  enable_dns_support   = true
+  enable_dns_hostnames = true
 }
 
 resource "aws_internet_gateway" "capacity_igw" {
-	vpc_id = aws_vpc.capacity_public.id
-	tags = { Name = "govwifi-capacity-igw-${var.env}" }
+  vpc_id = aws_vpc.capacity_public.id
+  tags   = { Name = "govwifi-capacity-igw-${var.env}" }
 }
 
 resource "aws_route_table" "capacity_public_rt" {
-	vpc_id = aws_vpc.capacity_public.id
-	route {
-		cidr_block = "0.0.0.0/0"
-		gateway_id = aws_internet_gateway.capacity_igw.id
-	}
-	tags = { Name = "govwifi-capacity-public-rt-${var.env}" }
+  vpc_id = aws_vpc.capacity_public.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.capacity_igw.id
+  }
+  tags = { Name = "govwifi-capacity-public-rt-${var.env}" }
 }
 
 resource "aws_subnet" "capacity_public" {
-	count                   = 2
-	vpc_id                  = aws_vpc.capacity_public.id
-	cidr_block              = cidrsubnet(aws_vpc.capacity_public.cidr_block, 8, count.index)
-	availability_zone       = data.aws_availability_zones.azs.names[count.index]
-	map_public_ip_on_launch = true
-	tags = {
-		Name = "govwifi-capacity-public-${var.env}-${count.index}"
-		Env  = var.env
-	}
+  count                   = 2
+  vpc_id                  = aws_vpc.capacity_public.id
+  cidr_block              = cidrsubnet(aws_vpc.capacity_public.cidr_block, 8, count.index)
+  availability_zone       = data.aws_availability_zones.azs.names[count.index]
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "govwifi-capacity-public-${var.env}-${count.index}"
+    Env  = var.env
+  }
 }
 
 resource "aws_route_table_association" "capacity_public_rta" {
-	count          = length(aws_subnet.capacity_public)
-	subnet_id      = aws_subnet.capacity_public[count.index].id
-	route_table_id = aws_route_table.capacity_public_rt.id
+  count          = length(aws_subnet.capacity_public)
+  subnet_id      = aws_subnet.capacity_public[count.index].id
+  route_table_id = aws_route_table.capacity_public_rt.id
 }
 
 # Private subnets for ECS tasks to route through NAT
 resource "aws_subnet" "capacity_private" {
-	count             = 2
-	vpc_id            = aws_vpc.capacity_public.id
-	cidr_block        = cidrsubnet(aws_vpc.capacity_public.cidr_block, 8, count.index + 10)
-	availability_zone = data.aws_availability_zones.azs.names[count.index]
-	tags = {
-		Name = "govwifi-capacity-private-${var.env}-${count.index}"
-		Env  = var.env
-	}
+  count             = 2
+  vpc_id            = aws_vpc.capacity_public.id
+  cidr_block        = cidrsubnet(aws_vpc.capacity_public.cidr_block, 8, count.index + 10)
+  availability_zone = data.aws_availability_zones.azs.names[count.index]
+  tags = {
+    Name = "govwifi-capacity-private-${var.env}-${count.index}"
+    Env  = var.env
+  }
 }
 
 # Elastic IP for NAT gateway
 resource "aws_eip" "nat_eip" {
-	domain = "vpc"
-	tags = { Name = "govwifi-capacity-nat-eip-${var.env}" }
-	depends_on = [aws_internet_gateway.capacity_igw]
+  domain     = "vpc"
+  tags       = { Name = "govwifi-capacity-nat-eip-${var.env}" }
+  depends_on = [aws_internet_gateway.capacity_igw]
 }
 
 # NAT gateway in the first public subnet
 resource "aws_nat_gateway" "capacity_nat" {
-	allocation_id = aws_eip.nat_eip.id
-	subnet_id     = aws_subnet.capacity_public[0].id
-	tags = { Name = "govwifi-capacity-nat-${var.env}" }
-	depends_on = [aws_internet_gateway.capacity_igw]
+  allocation_id = aws_eip.nat_eip.id
+  subnet_id     = aws_subnet.capacity_public[0].id
+  tags          = { Name = "govwifi-capacity-nat-${var.env}" }
+  depends_on    = [aws_internet_gateway.capacity_igw]
 }
 
 # Route table for private subnets pointing to NAT gateway
 resource "aws_route_table" "capacity_private_rt" {
-	vpc_id = aws_vpc.capacity_public.id
-	route {
-		cidr_block     = "0.0.0.0/0"
-		nat_gateway_id = aws_nat_gateway.capacity_nat.id
-	}
-	tags = { Name = "govwifi-capacity-private-rt-${var.env}" }
+  vpc_id = aws_vpc.capacity_public.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.capacity_nat.id
+  }
+  tags = { Name = "govwifi-capacity-private-rt-${var.env}" }
 }
 
 # Associate private subnets with the private route table
 resource "aws_route_table_association" "capacity_private_rta" {
-	count          = length(aws_subnet.capacity_private)
-	subnet_id      = aws_subnet.capacity_private[count.index].id
-	route_table_id = aws_route_table.capacity_private_rt.id
+  count          = length(aws_subnet.capacity_private)
+  subnet_id      = aws_subnet.capacity_private[count.index].id
+  route_table_id = aws_route_table.capacity_private_rt.id
 }
 

--- a/govwifi-capacity-testing/vpc.tf
+++ b/govwifi-capacity-testing/vpc.tf
@@ -1,0 +1,93 @@
+/*
+ Public VPC with two public subnets
+*/
+
+data "aws_availability_zones" "azs" {}
+
+resource "aws_vpc" "capacity_public" {
+	cidr_block = "10.222.0.0/16"
+	tags = {
+		Name = "govwifi-capacity-public-${var.env}"
+		Env  = var.env
+	}
+
+	enable_dns_support = true
+	enable_dns_hostnames = true
+}
+
+resource "aws_internet_gateway" "capacity_igw" {
+	vpc_id = aws_vpc.capacity_public.id
+	tags = { Name = "govwifi-capacity-igw-${var.env}" }
+}
+
+resource "aws_route_table" "capacity_public_rt" {
+	vpc_id = aws_vpc.capacity_public.id
+	route {
+		cidr_block = "0.0.0.0/0"
+		gateway_id = aws_internet_gateway.capacity_igw.id
+	}
+	tags = { Name = "govwifi-capacity-public-rt-${var.env}" }
+}
+
+resource "aws_subnet" "capacity_public" {
+	count                   = 2
+	vpc_id                  = aws_vpc.capacity_public.id
+	cidr_block              = cidrsubnet(aws_vpc.capacity_public.cidr_block, 8, count.index)
+	availability_zone       = data.aws_availability_zones.azs.names[count.index]
+	map_public_ip_on_launch = true
+	tags = {
+		Name = "govwifi-capacity-public-${var.env}-${count.index}"
+		Env  = var.env
+	}
+}
+
+resource "aws_route_table_association" "capacity_public_rta" {
+	count          = length(aws_subnet.capacity_public)
+	subnet_id      = aws_subnet.capacity_public[count.index].id
+	route_table_id = aws_route_table.capacity_public_rt.id
+}
+
+# Private subnets for ECS tasks to route through NAT
+resource "aws_subnet" "capacity_private" {
+	count             = 2
+	vpc_id            = aws_vpc.capacity_public.id
+	cidr_block        = cidrsubnet(aws_vpc.capacity_public.cidr_block, 8, count.index + 10)
+	availability_zone = data.aws_availability_zones.azs.names[count.index]
+	tags = {
+		Name = "govwifi-capacity-private-${var.env}-${count.index}"
+		Env  = var.env
+	}
+}
+
+# Elastic IP for NAT gateway
+resource "aws_eip" "nat_eip" {
+	domain = "vpc"
+	tags = { Name = "govwifi-capacity-nat-eip-${var.env}" }
+	depends_on = [aws_internet_gateway.capacity_igw]
+}
+
+# NAT gateway in the first public subnet
+resource "aws_nat_gateway" "capacity_nat" {
+	allocation_id = aws_eip.nat_eip.id
+	subnet_id     = aws_subnet.capacity_public[0].id
+	tags = { Name = "govwifi-capacity-nat-${var.env}" }
+	depends_on = [aws_internet_gateway.capacity_igw]
+}
+
+# Route table for private subnets pointing to NAT gateway
+resource "aws_route_table" "capacity_private_rt" {
+	vpc_id = aws_vpc.capacity_public.id
+	route {
+		cidr_block     = "0.0.0.0/0"
+		nat_gateway_id = aws_nat_gateway.capacity_nat.id
+	}
+	tags = { Name = "govwifi-capacity-private-rt-${var.env}" }
+}
+
+# Associate private subnets with the private route table
+resource "aws_route_table_association" "capacity_private_rta" {
+	count          = length(aws_subnet.capacity_private)
+	subnet_id      = aws_subnet.capacity_private[count.index].id
+	route_table_id = aws_route_table.capacity_private_rt.id
+}
+

--- a/govwifi/development/london.tf
+++ b/govwifi/development/london.tf
@@ -127,7 +127,7 @@ module "london_frontend" {
   # Instance-specific setup -------------------------------
   radius_instance_count = 3
   radius_task_count     = 3
-  radius_task_count_max = 3
+  radius_task_count_max = 6
   radius_task_count_min = 3
 
   enable_detailed_monitoring = false
@@ -554,10 +554,25 @@ module "london_account_policy" {
 
 }
 
+
 module "london_admin_portal_cyber_logs" {
   source = "../../govwifi-cyber-logs"
 
   region              = local.london_aws_region
   env                 = local.env
   account_access_arns = ["arn:aws:logs:${local.london_aws_region}:${local.aws_account_id}:*"]
+}
+
+module "london_capacity_testing" {
+  providers = {
+    aws = aws.london
+  }
+
+  source = "../../govwifi-capacity-testing"
+
+  env                 = local.env
+  aws_account_id      = local.aws_account_id
+  aws_region          = local.london_aws_region
+  # administrator_cidrs = var.administrator_cidrs
+
 }

--- a/govwifi/development/london.tf
+++ b/govwifi/development/london.tf
@@ -573,6 +573,5 @@ module "london_capacity_testing" {
   env            = local.env
   aws_account_id = local.aws_account_id
   aws_region     = local.london_aws_region
-  # administrator_cidrs = var.administrator_cidrs
 
 }

--- a/govwifi/development/london.tf
+++ b/govwifi/development/london.tf
@@ -570,9 +570,9 @@ module "london_capacity_testing" {
 
   source = "../../govwifi-capacity-testing"
 
-  env                 = local.env
-  aws_account_id      = local.aws_account_id
-  aws_region          = local.london_aws_region
+  env            = local.env
+  aws_account_id = local.aws_account_id
+  aws_region     = local.london_aws_region
   # administrator_cidrs = var.administrator_cidrs
 
 }


### PR DESCRIPTION
### What
- Adds a new Terraform module for capacity testing in London development, including:
    - dedicated VPC networking (public/private subnets, NAT, routing),
    - ECS Fargate cluster/service and task definition (with ECS Exec enabled),
    - ECR repository and repository policy,
    - CodeBuild pipeline to build/push the capacity-testing image,
    - IAM roles/policies for CodeBuild and ECS task execution,
    - CloudWatch log group and S3 bucket for build logs.
- Wires the new capacity-testing module into the London development stack.
- Increases London development frontend `radius_task_count_max` from `3` to `6`.

### Why
- Provides a repeatable, isolated environment to run and operate capacity-testing workloads via Terraform.
- Enables automated image build/publish and operational access (logs + ECS Exec) needed for test runs and troubleshooting.
- Raises frontend scaling headroom in development to better support higher-load/capacity test scenarios.


### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-2548