### PR TITLE
Enable AWS ECS Container Insights

### DIFF
--- a/govwifi-admin/cluster.tf
+++ b/govwifi-admin/cluster.tf
@@ -1,5 +1,10 @@
 resource "aws_ecs_cluster" "admin_cluster" {
   name = "${var.env_name}-admin-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enhanced"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "admin_log_group" {

--- a/govwifi-api/cluster.tf
+++ b/govwifi-api/cluster.tf
@@ -3,6 +3,6 @@ resource "aws_ecs_cluster" "api_cluster" {
 
   setting {
     name  = "containerInsights"
-    value = "enabled"
+    value = "enhanced"
   }
 }

--- a/govwifi-frontend/cluster.tf
+++ b/govwifi-frontend/cluster.tf
@@ -5,7 +5,7 @@ resource "aws_ecs_cluster" "frontend_fargate" {
 
   setting {
     name  = "containerInsights"
-    value = "enabled"
+    value = "enhanced"
   }
 }
 


### PR DESCRIPTION
### What
This change enables AWS ECS Container Insights with enhanced observability across all ECS clusters (API, Frontend, Admin, Metrics, and Capacity Testing) by updating the containerInsights setting from "enabled" (or "disabled") to "enhanced" in the respective cluster configurations. This provides detailed, task-level metrics including CPU, memory, network I/O, and storage utilisation which helps with observability and analysis.

### Why
Enhanced observability improves debugging capabilities and validates auto-scaling decisions in production environments. AWS says that the change is zero downtime as it only modifies cluster-level monitoring settings without affecting running tasks or services.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-2394