### PR TITLE
Fix ECS Deployment Failure with Single Task

### DIFF
--- a/govwifi-api/authentication-api-cluster.tf
+++ b/govwifi-api/authentication-api-cluster.tf
@@ -121,7 +121,7 @@ resource "aws_ecs_service" "authentication_api_service" {
 
   ## DEPLOYMENT CONFIGURATION - Rolling using dynamic calculation to allow 1 in and 1 out during deployment, while ensuring 100% of tasks stay up.
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent         = 134 ## replaces tasks on a sliding scale, depending on desired task count.
+  deployment_maximum_percent         = 200 ## replaces tasks on a sliding scale, depending on desired task count.
 
   lifecycle {
     ## stops the tasks count from being reset.

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -147,7 +147,7 @@ resource "aws_ecs_service" "logging_api_service" {
 
   ## DEPLOYMENT CONFIGURATION - Rolling using dynamic calculation to allow 1 in and 1 out during deployment, while ensuring 100% of tasks stay up.
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent         = 134 ## replaces tasks on a sliding scale, depending on desired task count.
+  deployment_maximum_percent         = 200 ## replaces tasks on a sliding scale, depending on desired task count.
 
   lifecycle {
     ignore_changes = [desired_count]

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -227,7 +227,7 @@ resource "aws_ecs_service" "user_signup_api_service" {
 
   ## DEPLOYMENT CONFIGURATION - Rolling using dynamic calculation to allow 1 in and 1 out during deployment, while ensuring 100% of tasks stay up.
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent         = 134 ## replaces tasks on a sliding scale, depending on desired task count.
+  deployment_maximum_percent         = 200 ## replaces tasks on a sliding scale, depending on desired task count.
 
   lifecycle {
     ## stops the tasks count from being reset.


### PR DESCRIPTION
### What
This PR addresses the AWS ECS error: "Service (service-name) was unable to stop or start tasks during a deployment because of the service deployment configuration. Update the minimumHealthyPercent or maximumPercent value and try again." The issue occurred when services had only 1 desired task, preventing deployments due to insufficient capacity for rolling updates.

### Why
With minimumHealthyPercent at 100%, a single task deployment requires maximumPercent > 100% to allow ECS to launch a replacement task before terminating the old one. 200% ensures sufficient overhead for deployments with low task counts, preventing the referenced error ( [see AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-event-messages-list.html#service-event-messages-7) ).
