### PR TITLE
move to using env_name for the metrics and tableau service and task d…

### DIFF
--- a/govwifi-ecs-update-service/codebuild-restart-ecs-clusters.tf
+++ b/govwifi-ecs-update-service/codebuild-restart-ecs-clusters.tf
@@ -23,7 +23,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_project_restart_ecs_cluster"
 
     environment_variable {
       name  = "CLUSTER_NAME"
-      value = each.key == "admin" ? "${var.env_name}-admin-cluster" : (each.key == "metrics-api" ? "metrics-cluster-${var.env_name}" : (each.key == "tableau-bridge" ? "metrics-cluster-${var.env_name}" : "${var.env_name}-api-cluster"))
+      value = each.key == "admin" ? "${var.env_name}-admin-cluster" : (each.key == "metrics-api" ? "${var.env_name}-metrics-cluster" : (each.key == "tableau-bridge" ? "${var.env_name}-metrics-cluster" : "${var.env_name}-api-cluster"))
     }
 
     # This is the Task Definition Family Name

--- a/govwifi-metrics/cluster.tf
+++ b/govwifi-metrics/cluster.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_cluster" "metrics_cluster" {
-  name = "metrics-cluster-${var.env}"
+  name = "${var.env_name}-metrics-cluster"
 
   tags = var.tags
 }

--- a/govwifi-metrics/cluster.tf
+++ b/govwifi-metrics/cluster.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_log_group" "metrics_log_group" {
 }
 
 resource "aws_ecs_task_definition" "metrics_api" {
-  family                   = "metrics-api-task-${var.env}"
+  family                   = "metrics-api-task-${var.env_name}"
   requires_compatibilities = ["FARGATE"]
   task_role_arn            = aws_iam_role.metrics_api_task_role.arn
   execution_role_arn       = aws_iam_role.metrics_api_task_execution_role.arn
@@ -65,7 +65,7 @@ EOF
 }
 
 resource "aws_ecs_service" "metrics_service" {
-  name             = "metrics-api-service-${var.env}"
+  name             = "metrics-api-service-${var.env_name}"
   cluster          = aws_ecs_cluster.metrics_cluster.id
   task_definition  = aws_ecs_task_definition.metrics_api.arn
   desired_count    = 1
@@ -125,7 +125,7 @@ resource "aws_cloudwatch_log_group" "tableau_bridge_log_group" {
 }
 
 resource "aws_ecs_task_definition" "tableau_bridge" {
-  family                   = "tableau-bridge-task-${var.env}"
+  family                   = "tableau-bridge-task-${var.env_name}"
   requires_compatibilities = ["FARGATE"]
   task_role_arn            = aws_iam_role.tableau_bridge_task_role.arn
   execution_role_arn       = aws_iam_role.tableau_bridge_task_execution_role.arn
@@ -191,7 +191,7 @@ EOF
 }
 
 resource "aws_ecs_service" "tableau_bridge_service" {
-  name             = "tableau-bridge-service-${var.env}"
+  name             = "tableau-bridge-service-${var.env_name}"
   cluster          = aws_ecs_cluster.metrics_cluster.id
   task_definition  = aws_ecs_task_definition.tableau_bridge.arn
   desired_count    = 1


### PR DESCRIPTION
move to using env_name for the metrics and tableau service and task definitions. This matches what the deploy expects for product wifi and wifi-london envs
