### PR TITLE
Add new env vars for logging-api

### DIFF
--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -43,12 +43,24 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.arn,
       data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn,
       data.aws_secretsmanager_secret.notify_do_not_reply.arn,
-      data.aws_secretsmanager_secret.notify_support_reply.arn,
-      data.aws_secretsmanager_secret.metrics_api_key.arn
+      data.aws_secretsmanager_secret.notify_support_reply.arn
     ]
   }
 }
 
+resource "aws_iam_role_policy" "secrets_manager_metrics_api_key_policy" {
+  count  = var.metrics_api_endpoint != "" ? 1 : 0
+  name   = "${var.aws_region_name}-api-cluster-access-metrics-api-secret-${var.env_name}"
+  role   = aws_iam_role.ecs_task_execution_role.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = data.aws_secretsmanager_secret.metrics_api_key[0].arn
+    }]
+  })
+}
 
 resource "aws_iam_user" "govwifi_deploy_pipeline" {
   count         = var.create_wordlist_bucket ? 1 : 0

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -43,12 +43,25 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.arn,
       data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn,
       data.aws_secretsmanager_secret.notify_do_not_reply.arn,
-      data.aws_secretsmanager_secret.notify_support_reply.arn,
-      data.aws_secretsmanager_secret.metrics_api_key.arn
+      data.aws_secretsmanager_secret.notify_support_reply.arn
     ]
   }
 }
 
+
+resource "aws_iam_role_policy" "secrets_manager_metrics_api_key_policy" {
+  count = var.metrics_api_endpoint != "" ? 1 : 0
+  name  = "${var.aws_region_name}-api-cluster-access-metrics-api-secret-${var.env_name}"
+  role  = aws_iam_role.ecs_task_execution_role.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = data.aws_secretsmanager_secret.metrics_api_key[0].arn
+    }]
+  })
+}
 
 resource "aws_iam_user" "govwifi_deploy_pipeline" {
   count         = var.create_wordlist_bucket ? 1 : 0

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -49,20 +49,6 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
 }
 
 resource "aws_iam_role_policy" "secrets_manager_metrics_api_key_policy" {
-  count  = var.metrics_api_endpoint != "" ? 1 : 0
-  name   = "${var.aws_region_name}-api-cluster-access-metrics-api-secret-${var.env_name}"
-  role   = aws_iam_role.ecs_task_execution_role.id
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = ["secretsmanager:GetSecretValue"]
-      Resource = data.aws_secretsmanager_secret.metrics_api_key[0].arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy" "secrets_manager_metrics_api_key_policy" {
   count = var.metrics_api_endpoint != "" ? 1 : 0
   name  = "${var.aws_region_name}-api-cluster-access-metrics-api-secret-${var.env_name}"
   role  = aws_iam_role.ecs_task_execution_role.id
@@ -315,5 +301,3 @@ resource "aws_cloudwatch_event_target" "logging_daily_session_deletion" {
 EOF
 
 }
-
-

--- a/govwifi-api/iam.tf
+++ b/govwifi-api/iam.tf
@@ -43,7 +43,8 @@ data "aws_iam_policy_document" "secrets_manager_policy" {
       data.aws_secretsmanager_secret.user_signup_api_sentry_dsn.arn,
       data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn,
       data.aws_secretsmanager_secret.notify_do_not_reply.arn,
-      data.aws_secretsmanager_secret.notify_support_reply.arn
+      data.aws_secretsmanager_secret.notify_support_reply.arn,
+      data.aws_secretsmanager_secret.metrics_api_key.arn
     ]
   }
 }

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -135,8 +135,8 @@ resource "aws_ecs_service" "logging_api_service" {
       [aws_security_group.logging_api_service.id]
     )
 
-    subnets          = var.private_subnet_ids
-    assign_public_ip = false
+    subnets          = var.subnet_ids
+    assign_public_ip = true
   }
 
   load_balancer {

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -72,10 +72,7 @@ resource "aws_ecs_task_definition" "logging_api_task" {
         },{
           "name": "VOLUMETRICS_ENDPOINT",
           "value": "https://${var.elasticsearch_endpoint}"
-        },{
-          "name": "METRICS_API_ENDPOINT",
-          "value": "${var.metrics_api_endpoint}"
-        }
+        }${var.metrics_api_endpoint != "" ? ",{\"name\":\"METRICS_API_ENDPOINT\",\"value\":\"${var.metrics_api_endpoint}\"}" : ""}
       ],
       "secrets": [
         {
@@ -93,10 +90,7 @@ resource "aws_ecs_task_definition" "logging_api_task" {
         },{
           "name": "SENTRY_DSN",
           "valueFrom": "${data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn}"
-        },{
-          "name": "METRICS_API_BEARER_TOKEN",
-          "valueFrom": "${data.aws_secretsmanager_secret.metrics_api_key.arn}"
-        }
+        }${var.metrics_api_endpoint != "" ? ",{\"name\":\"METRICS_API_BEARER_TOKEN\",\"valueFrom\":\"${data.aws_secretsmanager_secret.metrics_api_key[0].arn}\"}" : ""}
       ],
       "links": null,
       "workingDirectory": null,

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -72,10 +72,7 @@ resource "aws_ecs_task_definition" "logging_api_task" {
         },{
           "name": "VOLUMETRICS_ENDPOINT",
           "value": "https://${var.elasticsearch_endpoint}"
-        },{
-          "name": "METRICS_API_ENDPOINT",
-          "value": "${var.metrics_api_endpoint}"
-        }
+        }${var.metrics_api_endpoint != "" ? ",{\"name\":\"METRICS_API_ENDPOINT\",\"value\":\"${var.metrics_api_endpoint}\"}" : ""}
       ],
       "secrets": [
         {
@@ -93,10 +90,7 @@ resource "aws_ecs_task_definition" "logging_api_task" {
         },{
           "name": "SENTRY_DSN",
           "valueFrom": "${data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn}"
-        },{
-          "name": "METRICS_API_BEARER_TOKEN",
-          "valueFrom": "${data.aws_secretsmanager_secret.metrics_api_key.arn}"
-        }
+        }${var.metrics_api_endpoint != "" ? ",{\"name\":\"METRICS_API_BEARER_TOKEN\",\"valueFrom\":\"${data.aws_secretsmanager_secret.metrics_api_key[0].arn}\"}" : ""}
       ],
       "links": null,
       "workingDirectory": null,
@@ -141,8 +135,8 @@ resource "aws_ecs_service" "logging_api_service" {
       [aws_security_group.logging_api_service.id]
     )
 
-    subnets          = var.subnet_ids
-    assign_public_ip = true
+    subnets          = var.private_subnet_ids
+    assign_public_ip = false
   }
 
   load_balancer {

--- a/govwifi-api/logging-api-cluster.tf
+++ b/govwifi-api/logging-api-cluster.tf
@@ -72,6 +72,9 @@ resource "aws_ecs_task_definition" "logging_api_task" {
         },{
           "name": "VOLUMETRICS_ENDPOINT",
           "value": "https://${var.elasticsearch_endpoint}"
+        },{
+          "name": "METRICS_API_ENDPOINT",
+          "value": "${var.metrics_api_endpoint}"
         }
       ],
       "secrets": [
@@ -90,6 +93,9 @@ resource "aws_ecs_task_definition" "logging_api_task" {
         },{
           "name": "SENTRY_DSN",
           "valueFrom": "${data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn}"
+        },{
+          "name": "METRICS_API_BEARER_TOKEN",
+          "valueFrom": "${data.aws_secretsmanager_secret.metrics_api_key.arn}"
         }
       ],
       "links": null,

--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -189,6 +189,44 @@ EOF
 
 }
 
+resource "aws_cloudwatch_event_target" "publish_daily_total_metrics_logging" {
+  count     = var.logging_enabled
+  target_id = "${var.env_name}-logging-daily-metrics-totals"
+  arn       = aws_ecs_cluster.api_cluster.arn
+  rule      = aws_cloudwatch_event_rule.daily_metrics_logging_event[0].name
+  role_arn  = aws_iam_role.logging_scheduled_task_role[0].arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.logging_api_scheduled_task[0].arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      subnets = var.subnet_ids
+
+      security_groups = concat(
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id]
+      )
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "logging-api",
+      "command": ["bundle", "exec", "rake", "publish_daily_total_metrics"]
+    }
+  ]
+}
+EOF
+
+}
+
 
 resource "aws_cloudwatch_event_target" "publish_metrics_to_data_bucket" {
   count     = var.logging_enabled
@@ -301,7 +339,7 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
         },{
           "name": "SMOKE_TEST_IPS",
           "value": "${join(",", var.smoke_test_ips)}"
-        }
+        }${var.metrics_api_endpoint != "" ? ",{\"name\":\"METRICS_API_ENDPOINT\",\"value\":\"${var.metrics_api_endpoint}\"}" : ""}
       ],
       "secrets": [
         {
@@ -319,7 +357,7 @@ resource "aws_ecs_task_definition" "logging_api_scheduled_task" {
         },{
           "name": "SENTRY_DSN",
           "valueFrom": "${data.aws_secretsmanager_secret.logging_api_sentry_dsn.arn}"
-        }
+        }${var.metrics_api_endpoint != "" ? ",{\"name\":\"METRICS_API_BEARER_TOKEN\",\"valueFrom\":\"${data.aws_secretsmanager_secret.metrics_api_key[0].arn}\"}" : ""}
       ],
       "links": null,
       "workingDirectory": null,

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -78,6 +78,10 @@ data "aws_secretsmanager_secret" "logging_api_sentry_dsn" {
   name = "sentry/logging_api_dsn"
 }
 
+data "aws_secretsmanager_secret" "metrics_api_key" {
+  name = "govwifi/metrics-api/key"
+}
+
 data "aws_secretsmanager_secret_version" "tools_account" {
   secret_id = data.aws_secretsmanager_secret.tools_account.id
 }

--- a/govwifi-api/secrets-manager.tf
+++ b/govwifi-api/secrets-manager.tf
@@ -79,7 +79,8 @@ data "aws_secretsmanager_secret" "logging_api_sentry_dsn" {
 }
 
 data "aws_secretsmanager_secret" "metrics_api_key" {
-  name = "govwifi/metrics-api/key"
+  count = var.metrics_api_endpoint != "" ? 1 : 0
+  name  = "govwifi/metrics-api/key"
 }
 
 data "aws_secretsmanager_secret_version" "tools_account" {

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -243,3 +243,9 @@ variable "smoke_test_ips" {
 variable "log_retention" {
   type = number
 }
+
+variable "metrics_api_endpoint" {
+  type        = string
+  default     = ""
+  description = "The metrics API endpoint URL (e.g. https://metrics.wifi.service.gov.uk)"
+}

--- a/govwifi-metrics/outputs.tf
+++ b/govwifi-metrics/outputs.tf
@@ -22,3 +22,8 @@ output "cluster_database_name" {
   description = "Database name"
   value       = aws_rds_cluster.metrics_db_cluster.database_name
 }
+
+output "metrics_api_endpoint" {
+  description = "The metrics API endpoint hostname"
+  value       = "metrics.${var.env_subdomain}.service.gov.uk"
+}

--- a/govwifi-metrics/securitygroup.tf
+++ b/govwifi-metrics/securitygroup.tf
@@ -63,6 +63,13 @@ resource "aws_security_group" "metrics_alb_in" {
     protocol    = "tcp"
     cidr_blocks = var.administrator_cidrs
   }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [for ip in var.nat_gateway_elastic_ips : "${ip}/32"]
+  }
 }
 
 resource "aws_security_group" "metrics_alb_out" {

--- a/govwifi-metrics/variables.tf
+++ b/govwifi-metrics/variables.tf
@@ -135,3 +135,9 @@ variable "administrator_cidrs" {
   description = "IPs associated with the GDS/CDIO VPN to allow access"
   default     = []
 }
+
+variable "nat_gateway_elastic_ips" {
+  type        = list(string)
+  description = "Elastic IPs of the NAT gateways"
+  default     = []
+}

--- a/govwifi/development/london.tf
+++ b/govwifi/development/london.tf
@@ -312,6 +312,8 @@ module "london_api" {
 
   elasticsearch_endpoint = module.london_elasticsearch.endpoint
   smoke_test_ips         = module.london_tests_vpc.eip_public_ips
+
+  metrics_api_endpoint = "https://metrics.${local.env_subdomain}.service.gov.uk"
 }
 
 module "london_route53_notifications" {

--- a/govwifi/development/london.tf
+++ b/govwifi/development/london.tf
@@ -620,7 +620,8 @@ module "london_metrics" {
   tableau_bridge_docker_image     = local.tableau_bridge_docker_image
   vpc_endpoints_security_group_id = module.london_backend.vpc_endpoints_security_group_id
 
-  administrator_cidrs = var.administrator_cidrs
+  administrator_cidrs     = var.administrator_cidrs
+  nat_gateway_elastic_ips = module.london_backend.nat_gateway_elastic_ips
 
   tags = {
     Name = "london-metrics-development"

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -312,6 +312,8 @@ module "london_api" {
 
   elasticsearch_endpoint = module.london_elasticsearch.endpoint
   smoke_test_ips         = module.london_tests_vpc.eip_public_ips
+
+  metrics_api_endpoint = "https://metrics.${local.env_subdomain}.service.gov.uk"
 }
 
 module "london_route53_notifications" {

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -576,7 +576,8 @@ module "london_metrics" {
   tableau_bridge_docker_image     = local.tableau_bridge_docker_image
   vpc_endpoints_security_group_id = module.london_backend.vpc_endpoints_security_group_id
 
-  administrator_cidrs = var.administrator_cidrs
+  administrator_cidrs     = var.administrator_cidrs
+  nat_gateway_elastic_ips = module.london_backend.nat_gateway_elastic_ips
 
   tags = {
     Name = "london-metrics-staging"

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -386,6 +386,8 @@ module "api" {
 
   elasticsearch_endpoint = module.govwifi_elasticsearch.endpoint
   smoke_test_ips         = module.london_tests_vpc.eip_public_ips
+
+  metrics_api_endpoint = "https://metrics.${local.env_subdomain}.service.gov.uk"
 }
 
 module "london_critical_notifications" {

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -707,7 +707,8 @@ module "london_metrics" {
   tableau_bridge_docker_image     = local.tableau_bridge_docker_image
   vpc_endpoints_security_group_id = module.backend.vpc_endpoints_security_group_id
 
-  administrator_cidrs = var.administrator_cidrs
+  administrator_cidrs     = var.administrator_cidrs
+  nat_gateway_elastic_ips = module.backend.nat_gateway_elastic_ips
 
   tags = {
     Name = "london-metrics-production"


### PR DESCRIPTION
# Add new env vars for logging-api

### What

  Summary of what was changed across 12 files:

  - **`govwifi-api/variables.tf`** — added `metrics_api_endpoint` variable (default `""` so Dublin environments without a metrics module are unaffected)

  - **`govwifi-api/secrets-manager.tf`** — added a conditional data block for the `govwifi/metrics-api/key` secret, gated on `count = var.metrics_api_endpoint != "" ? 1 : 0`

  - **`govwifi-api/iam.tf`** — added a new conditional IAM role policy (`secrets_manager_metrics_api_key_policy`) granting the ECS task execution role `secretsmanager:GetSecretValue` on the `govwifi/metrics-api/key`
   secret. Kept separate from the shared policy so Dublin environments are unaffected.

  - **`govwifi-api/logging-api-cluster.tf`** — added `METRICS_API_ENDPOINT` (env var) and `METRICS_API_BEARER_TOKEN` (secret) to the logging-api service container definition, conditionally omitted when
  `metrics_api_endpoint` is empty so the JSON remains valid in all environments.

  - **`govwifi-api/logging-scheduled-tasks.tf`** — added the same `METRICS_API_ENDPOINT` and `METRICS_API_BEARER_TOKEN` conditional entries to the scheduled task definition, so the `publish_daily_total_metrics` rake
   task has the metrics API credentials available at runtime.

  - **`govwifi-metrics/variables.tf`** — added `nat_gateway_elastic_ips` variable (default `[]`) to accept the backend NAT gateway Elastic IPs.

  - **`govwifi-metrics/securitygroup.tf`** — added a port 443 ingress rule to the metrics ALB security group allowing traffic from the backend NAT gateway Elastic IPs, enabling logging-api tasks to reach the metrics
   ALB.

  - **`govwifi-metrics/outputs.tf`** — added `metrics_api_endpoint` output for completeness/future use.

  - **`govwifi/wifi-london/main.tf`, `govwifi/staging/london.tf`, `govwifi/development/london.tf`** — passed `metrics_api_endpoint = "https://metrics.${local.env_subdomain}.service.gov.uk"` to each `api` module
  call, and `nat_gateway_elastic_ips = module.london_backend.nat_gateway_elastic_ips` to each `london_metrics` module call. Dublin environments are unchanged.

  **Notes:**
  - The endpoint URL is constructed from `local.env_subdomain` in each caller rather than via a `module.london_metrics` output, because the metrics module already depends on the api module's security group
  (`api_sg_id`), which would create a circular dependency.
  - All new resources that reference the metrics secret use the same `count`-based conditional pattern to ensure Dublin environments (which have no metrics module and no `govwifi/metrics-api/key` secret) are
  unaffected.

### Why

- This will authorise the Logging API to POST metrics data to the Metrics API.
- This will schedule daily results calculation and upload to S3 and the Metrics API.


### Link to JIRA card (if applicable): 
- [GW-2719](https://technologyprogramme.atlassian.net/browse/GW-2719)