### PR TITLE
Route publish_daily_total_metrics rake task via private subnets to reach metrics API

### DIFF
--- a/govwifi-api/logging-scheduled-tasks.tf
+++ b/govwifi-api/logging-scheduled-tasks.tf
@@ -203,14 +203,14 @@ resource "aws_cloudwatch_event_target" "publish_daily_total_metrics_logging" {
     platform_version    = "1.4.0"
 
     network_configuration {
-      subnets = var.subnet_ids
+      subnets = length(var.private_subnet_ids) > 0 ? var.private_subnet_ids : var.subnet_ids
 
       security_groups = concat(
         [aws_security_group.api_in.id],
         [aws_security_group.api_out.id]
       )
 
-      assign_public_ip = true
+      assign_public_ip = length(var.private_subnet_ids) > 0 ? false : true
     }
   }
 

--- a/govwifi-api/variables.tf
+++ b/govwifi-api/variables.tf
@@ -122,7 +122,8 @@ variable "subnet_ids" {
 }
 
 variable "private_subnet_ids" {
-  type = list(string)
+  type    = list(string)
+  default = []
 }
 
 variable "user_signup_docker_image" {

--- a/govwifi-backend/security-groups.tf
+++ b/govwifi-backend/security-groups.tf
@@ -66,6 +66,16 @@ resource "aws_security_group" "be_db_in" {
     protocol    = "tcp"
     cidr_blocks = [for subnet in aws_subnet.wifi_backend_subnet : subnet.cidr_block]
   }
+
+  dynamic "ingress" {
+    for_each = length(aws_subnet.wifi_backend_private_subnets) > 0 ? [1] : []
+    content {
+      from_port   = 3306
+      to_port     = 3306
+      protocol    = "tcp"
+      cidr_blocks = [for subnet in aws_subnet.wifi_backend_private_subnets : subnet.cidr_block]
+    }
+  }
 }
 
 resource "aws_security_group" "be_radius_api_in" {


### PR DESCRIPTION
***Note***: This relies on [PR1014](https://github.com/GovWifi/govwifi-terraform/pull/1014) being approved first.

### What

- Moves the `publish_daily_total_metrics_logging` EventBridge target to private subnets so its outbound traffic routes via the NAT gateway (static EIP), which is whitelisted in the metrics ALB security group
- Extends `be_db_in` to allow MySQL connections from private subnet CIDRs, so the rake task can reach the session and users databases from its new network position
- Adds `default = []` to `private_subnet_ids` variable as a safety net; falls back to public subnets for Dublin where private subnets do not exist

### Why

- The metrics ALB is internet-facing. 
- Tasks in public subnets reach it via the internet gateway, which source-NATs their private IP to their public IP. 
- The metrics ALB security group has no rule matching a dynamic public IP, so the connection times out. 
- Tasks in private subnets avoid this by routing through the NAT gateway, whose static EIP is already permitted in the metrics ALB security group.

### Link to JIRA card (if applicable)
- [GW-2271](https://technologyprogramme.atlassian.net/browse/GW-2271)