### PR TITLE
Add Metric Data Publishing CI/CD and scheduling

### DIFF
--- a/govwifi-deploy/ecr.tf
+++ b/govwifi-deploy/ecr.tf
@@ -52,6 +52,16 @@ resource "aws_ecr_repository_policy" "govwifi_ecr_database_backup_policy_develop
   repository = aws_ecr_repository.database_backup_ecr_development.name
   policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_development.json
 }
+### metrics data publisher ecr repo
+resource "aws_ecr_repository" "metrics_data_publisher_ecr_development" {
+  name = "govwifi/development/metrics-data-publisher"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_metrics_data_publisher_policy_development" {
+  repository = aws_ecr_repository.metrics_data_publisher_ecr_development.name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_development.json
+}
+
 ### smoke tests ecr repo
 resource "aws_ecr_repository" "smoke_tests_ecr_development" {
   name = "govwifi/development/smoke-tests"
@@ -136,6 +146,16 @@ resource "aws_ecr_repository" "database_backup_ecr_staging" {
 
 resource "aws_ecr_repository_policy" "govwifi_ecr_database_backup_policy_staging" {
   repository = aws_ecr_repository.database_backup_ecr_staging.name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_staging.json
+}
+
+### metrics data publisher ecr repo
+resource "aws_ecr_repository" "metrics_data_publisher_ecr_staging" {
+  name = "govwifi/staging/metrics-data-publisher"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_metrics_data_publisher_policy_staging" {
+  repository = aws_ecr_repository.metrics_data_publisher_ecr_staging.name
   policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_staging.json
 }
 
@@ -228,6 +248,16 @@ resource "aws_ecr_repository" "database_backup_ecr_production" {
 
 resource "aws_ecr_repository_policy" "govwifi_ecr_database_backup_policy" {
   repository = aws_ecr_repository.database_backup_ecr_production.name
+  policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_production.json
+}
+
+### metrics data publisher ecr repo
+resource "aws_ecr_repository" "metrics_data_publisher_ecr_production" {
+  name = "govwifi/production/metrics-data-publisher"
+}
+
+resource "aws_ecr_repository_policy" "govwifi_ecr_metrics_data_publisher_policy_production" {
+  repository = aws_ecr_repository.metrics_data_publisher_ecr_production.name
   policy     = data.aws_iam_policy_document.govwifi_ecr_repo_policy_production.json
 }
 

--- a/govwifi-deploy/locals.tf
+++ b/govwifi-deploy/locals.tf
@@ -38,7 +38,10 @@ locals {
       repo    = "govwifi-user-signup-api"
       regions = ["eu-west-2"]
     }
-
+    metrics-data-publisher = {
+      repo    = "govwifi-metrics-data-publisher"
+      regions = ["eu-west-2"]
+    }
     metrics-api = {
       repo    = "govwifi-metrics-api"
       regions = ["eu-west-2"]

--- a/govwifi-metrics/cluster.tf
+++ b/govwifi-metrics/cluster.tf
@@ -113,7 +113,94 @@ resource "aws_alb_target_group" "metrics_tg" {
     path                = "/health"
   }
 
+}
+
+resource "aws_ecs_task_definition" "metrics_data_publisher" {
+  family                   = "metrics-data-publisher-task-${var.env_name}"
+  requires_compatibilities = ["FARGATE"]
+  task_role_arn            = aws_iam_role.metrics_api_task_role.arn
+  execution_role_arn       = aws_iam_role.metrics_api_task_execution_role.arn
+  cpu                      = "256"
+  memory                   = "512"
+  network_mode             = "awsvpc"
+
+  container_definitions = <<EOF
+[
+    {
+      "name": "metrics-data-publisher",
+      "image": "${var.metrics_data_publisher_docker_image}",
+      "essential": true,
+      "command": ["recover_and_publish"],
+      "environment": [
+        {
+          "name": "METRICS_API_URL",
+          "value": "https://metrics.${var.env_subdomain}.service.gov.uk"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "METRICS_API_KEY",
+          "valueFrom": "${data.aws_secretsmanager_secret.metrics_api_key.arn}"
+        },
+        {
+          "name": "TOKEN_NAME",
+          "valueFrom": "${data.aws_secretsmanager_secret.metrics_data_publisher_tableau.arn}:TOKEN_NAME::"
+        },
+        {
+          "name": "TOKEN_VALUE",
+          "valueFrom": "${data.aws_secretsmanager_secret.metrics_data_publisher_tableau.arn}:TOKEN_VALUE::"
+        },
+        {
+          "name": "SITE_ID",
+          "valueFrom": "${data.aws_secretsmanager_secret.metrics_data_publisher_tableau.arn}:SITE_ID::"
+        },
+        {
+          "name": "SERVER_URL",
+          "valueFrom": "${data.aws_secretsmanager_secret.metrics_data_publisher_tableau.arn}:SERVER_URL::"
+        },
+        {
+          "name": "PROJECT_NAME",
+          "valueFrom": "${data.aws_secretsmanager_secret.metrics_data_publisher_tableau.arn}:PROJECT_NAME::"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "${aws_cloudwatch_log_group.metrics_log_group.name}",
+          "awslogs-region": "${var.aws_region}",
+          "awslogs-stream-prefix": "metrics-data-publisher"
+        }
+      }
+    }
+]
+EOF
+
   tags = var.tags
 }
 
+resource "aws_cloudwatch_event_rule" "metrics_data_publisher_schedule" {
+  name                = "metrics-data-publisher-schedule-${var.env_name}"
+  description         = "Trigger metrics-data-publisher at 05:00 UTC daily"
+  schedule_expression = "cron(0 5 * * ? *)"
+  tags                = var.tags
+}
 
+resource "aws_cloudwatch_event_target" "metrics_data_publisher_target" {
+  rule      = aws_cloudwatch_event_rule.metrics_data_publisher_schedule.name
+  target_id = "metrics-data-publisher-target-${var.env_name}"
+  arn       = aws_ecs_cluster.metrics_cluster.arn
+  role_arn  = aws_iam_role.metrics_events_role.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.metrics_data_publisher.arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      subnets          = var.backend_subnet_ids
+      security_groups  = [aws_security_group.metrics_service_out.id]
+      assign_public_ip = true
+    }
+  }
+}

--- a/govwifi-metrics/iam.tf
+++ b/govwifi-metrics/iam.tf
@@ -38,7 +38,8 @@ resource "aws_iam_role_policy" "metrics_api_task_execution_policy" {
         "kms:Decrypt"
       ],
       "Resource": [
-        "${data.aws_secretsmanager_secret.metrics_api_key.arn}"
+        "${data.aws_secretsmanager_secret.metrics_api_key.arn}",
+        "${data.aws_secretsmanager_secret.metrics_data_publisher_tableau.arn}"
       ]
     }
   ]
@@ -92,4 +93,54 @@ resource "aws_iam_role_policy" "metrics_api_task_policy" {
 EOF
 }
 
+resource "aws_iam_role" "metrics_events_role" {
+  name = "metrics-events-role-${var.env}-${var.region_name}"
 
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "metrics_events_policy" {
+  name = "metrics-events-policy-${var.env}-${var.region_name}"
+  role = aws_iam_role.metrics_events_role.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:RunTask"
+      ],
+      "Resource": [
+        "${aws_ecs_task_definition.metrics_data_publisher.arn}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Resource": [
+        "${aws_iam_role.metrics_api_task_execution_role.arn}",
+        "${aws_iam_role.metrics_api_task_role.arn}"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/govwifi-metrics/secrets.tf
+++ b/govwifi-metrics/secrets.tf
@@ -6,12 +6,14 @@ data "aws_secretsmanager_secret_version" "metrics_db_credentials_data" {
   secret_id = data.aws_secretsmanager_secret.metrics_db_credentials.id
 }
 
-
-
 data "aws_secretsmanager_secret" "metrics_api_key" {
   name = "govwifi/metrics-api/key"
 }
 
 data "aws_secretsmanager_secret_version" "metrics_api_key_data" {
   secret_id = data.aws_secretsmanager_secret.metrics_api_key.id
+}
+
+data "aws_secretsmanager_secret" "metrics_data_publisher_tableau" {
+  name = "govwifi/metrics-data-publisher/tableau"
 }

--- a/govwifi-metrics/variables.tf
+++ b/govwifi-metrics/variables.tf
@@ -120,7 +120,10 @@ variable "metrics_api_docker_image" {
   description = "Docker image for the metrics API"
 }
 
-
+variable "metrics_data_publisher_docker_image" {
+  type        = string
+  description = "Docker image for the metrics data publisher scheduled task"
+}
 
 variable "vpc_endpoints_security_group_id" {
   type        = string

--- a/govwifi/development/london.tf
+++ b/govwifi/development/london.tf
@@ -616,8 +616,9 @@ module "london_metrics" {
 
   bastion_sg_id = module.london_backend.bastion_sg_id
 
-  metrics_api_docker_image        = local.metrics_api_docker_image
-  vpc_endpoints_security_group_id = module.london_backend.vpc_endpoints_security_group_id
+  metrics_api_docker_image            = local.metrics_api_docker_image
+  metrics_data_publisher_docker_image = format("%s/metrics-data-publisher:%s", local.docker_image_path, local.env)
+  vpc_endpoints_security_group_id     = module.london_backend.vpc_endpoints_security_group_id
 
   administrator_cidrs     = var.administrator_cidrs
   nat_gateway_elastic_ips = module.london_backend.nat_gateway_elastic_ips

--- a/govwifi/staging/london.tf
+++ b/govwifi/staging/london.tf
@@ -572,8 +572,9 @@ module "london_metrics" {
 
   bastion_sg_id = module.london_backend.bastion_sg_id
 
-  metrics_api_docker_image        = local.metrics_api_docker_image
-  vpc_endpoints_security_group_id = module.london_backend.vpc_endpoints_security_group_id
+  metrics_api_docker_image            = local.metrics_api_docker_image
+  metrics_data_publisher_docker_image = format("%s/metrics-data-publisher:%s", local.docker_image_path, local.env)
+  vpc_endpoints_security_group_id     = module.london_backend.vpc_endpoints_security_group_id
 
   administrator_cidrs     = var.administrator_cidrs
   nat_gateway_elastic_ips = module.london_backend.nat_gateway_elastic_ips

--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -36,8 +36,8 @@ module "govwifi_deploy" {
 
   source = "../../govwifi-deploy"
 
-  deployed_app_names     = ["user-signup-api", "logging-api", "admin", "authentication-api", "metrics-api"]
-  built_app_names        = ["frontend", "safe-restarter", "database-backup", "smoke-tests", "metrics-data-publisher"]
+  deployed_app_names     = ["user-signup-api", "logging-api", "admin", "authentication-api", "metrics-api", "metrics-data-publisher"]
+  built_app_names        = ["frontend", "safe-restarter", "database-backup", "smoke-tests", ]
   frontend_docker_images = ["raddb", "frontend"]
 }
 

--- a/govwifi/tools/main.tf
+++ b/govwifi/tools/main.tf
@@ -37,7 +37,7 @@ module "govwifi_deploy" {
   source = "../../govwifi-deploy"
 
   deployed_app_names     = ["user-signup-api", "logging-api", "admin", "authentication-api", "metrics-api"]
-  built_app_names        = ["frontend", "safe-restarter", "database-backup", "smoke-tests"]
+  built_app_names        = ["frontend", "safe-restarter", "database-backup", "smoke-tests", "metrics-data-publisher"]
   frontend_docker_images = ["raddb", "frontend"]
 }
 

--- a/govwifi/wifi-london/main.tf
+++ b/govwifi/wifi-london/main.tf
@@ -703,8 +703,9 @@ module "london_metrics" {
 
   bastion_sg_id = module.backend.bastion_sg_id
 
-  metrics_api_docker_image        = local.metrics_api_docker_image
-  vpc_endpoints_security_group_id = module.backend.vpc_endpoints_security_group_id
+  metrics_api_docker_image            = local.metrics_api_docker_image
+  metrics_data_publisher_docker_image = format("%s/metrics-data-publisher:%s", local.docker_image_path, local.env)
+  vpc_endpoints_security_group_id     = module.backend.vpc_endpoints_security_group_id
 
   administrator_cidrs     = var.administrator_cidrs
   nat_gateway_elastic_ips = module.backend.nat_gateway_elastic_ips


### PR DESCRIPTION
Abandon the approach to shoe-horn the non api container+scheduled task into the app deployment ci/cd pipeline.