### PR TITLE
Add missing export of ENVIRONMENT_NAME

### DIFF
--- a/govwifi-metrics/codebuild.tf
+++ b/govwifi-metrics/codebuild.tf
@@ -79,7 +79,7 @@ phases:
       - echo "Building docker image..."
       - docker build --target production -t metrics-data-publisher:latest .
       - echo "Running recover_and_publish inside the container..."
-      - docker run --rm -w /tmp -e METRICS_API_URL -e METRICS_API_KEY -e TOKEN_NAME -e TOKEN_VALUE -e SITE_ID -e SERVER_URL -e PROJECT_NAME metrics-data-publisher:latest recover_and_publish
+      - docker run --rm -w /tmp -e ENVIRONMENT_NAME -e METRICS_API_URL -e METRICS_API_KEY -e TOKEN_NAME -e TOKEN_VALUE -e SITE_ID -e SERVER_URL -e PROJECT_NAME metrics-data-publisher:latest recover_and_publish
 EOF
   }
 


### PR DESCRIPTION
## Add missing export of ENVIRONMENT_NAME

### What

- Add the missing  export of ENVIRONMENT_NAME to the container running the recover_and_publish
- This prevented data publication from going to the correct Tableau data source file.

### Why

- The data source publication was defaulting to development for all environments due to this issue.

### Link to JIRA card (if applicable):

- [GW-2721](https://technologyprogramme.atlassian.net/browse/GW-2721)
