### PR TITLE
Increase Timeout For Codebuild Jobs

### DIFF
--- a/govwifi-deploy/codebuild-built-apps-staging.tf
+++ b/govwifi-deploy/codebuild-built-apps-staging.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_built_app" {
   for_each       = toset(var.built_app_names)
   name           = "${each.key}-push-docker-image-to-staging-ECR"
   description    = "This project builds the ${each.key} image and pushes it to ECR"
-  build_timeout  = "20"
+  build_timeout  = "60"
   service_role   = aws_iam_role.govwifi_codebuild.arn
   encryption_key = aws_kms_key.codepipeline_key.arn
 


### PR DESCRIPTION
### What
Increase Timeout For Codebuild Jobs

### Why
Increase timeout for codebuild jobs, this is to stop the build from failing when the acceptence tests take too long.
