### PR TITLE
How many Organisations have dormant administrators?

### DIFF
--- a/govwifi-admin/event-rules.tf
+++ b/govwifi-admin/event-rules.tf
@@ -53,3 +53,11 @@ resource "aws_cloudwatch_event_rule" "daily_publish_organisation_count" {
   schedule_expression = "cron(00 5 * * ? *)"
   state               = "ENABLED"
 }
+
+# rake metrics:publish_orgs_with_dormant_admins_count
+resource "aws_cloudwatch_event_rule" "daily_publish_orgs_with_dormant_admins_count" {
+  name                = "${var.env_name}-daily-publish-orgs-with-dormant-admins-count"
+  description         = "Triggers daily 05:15 UTC"
+  schedule_expression = "cron(15 5 * * ? *)"
+  state               = "ENABLED"
+}

--- a/govwifi-admin/scheduled-tasks.tf
+++ b/govwifi-admin/scheduled-tasks.tf
@@ -320,6 +320,44 @@ resource "aws_cloudwatch_event_target" "publish_organisation_count" {
 
 }
 
+# rake metrics:publish_orgs_with_dormant_admins_count
+resource "aws_cloudwatch_event_target" "publish_orgs_with_dormant_admins_count" {
+  target_id = "${var.env_name}-publish-orgs-with-dormant-admins-count"
+  arn       = aws_ecs_cluster.admin_cluster.arn
+  rule      = aws_cloudwatch_event_rule.daily_publish_orgs_with_dormant_admins_count.name
+  role_arn  = aws_iam_role.scheduled_task.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.admin_task.arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      subnets = length(var.private_subnet_ids) > 0 ? var.private_subnet_ids : var.subnet_ids
+
+      security_groups = concat(
+        [aws_security_group.admin_ec2_in.id],
+        [aws_security_group.admin_ec2_out.id]
+      )
+
+      assign_public_ip = length(var.private_subnet_ids) > 0 ? false : true
+    }
+  }
+
+  input = <<EOF
+  {
+    "containerOverrides": [
+      {
+        "name": "admin",
+        "command": ["bundle", "exec", "rake", "metrics:publish_orgs_with_dormant_admins_count"]
+      }
+    ]
+  }
+  EOF
+
+}
+
 # Resets the GW and Super user creds used in smoke tests
 resource "aws_cloudwatch_event_target" "smoke_test_reset" {
   target_id = "${var.env_name}-smoke-test-reset"


### PR DESCRIPTION
## How many Organisations have dormant administrators?

### What

- Adds a new `aws_cloudwatch_event_rule` scheduling the `metrics:publish_orgs_with_dormant_admins_count` rake task daily at 05:15 UTC
- Adds the matching `aws_cloudwatch_event_target`, reusing the existing admin ECS cluster, task definition, and scheduled-task IAM role
- No new IAM permissions or environment variables needed — the task reuses the existing metrics bucket access already granted for `publish_organisation_count`

### Why

- The new govwifi-admin rake task (see companion PR) needs to run on a daily schedule like the other account-health metrics
- Following the existing `publish_organisation_count` pattern keeps this consistent with how all other admin rake tasks are scheduled, with no new infrastructure pattern introduced

### Link to JIRA card (if applicable):

- [GW-2741](https://technologyprogramme.atlassian.net/browse/GW-2741)
