### PR TITLE
How Organisations with no signed MOU?

### DIFF
--- a/govwifi-admin/event-rules.tf
+++ b/govwifi-admin/event-rules.tf
@@ -61,3 +61,11 @@ resource "aws_cloudwatch_event_rule" "daily_publish_orgs_with_dormant_admins_cou
   schedule_expression = "cron(15 5 * * ? *)"
   state               = "ENABLED"
 }
+
+# rake metrics:publish_orgs_with_no_signed_mou_count
+resource "aws_cloudwatch_event_rule" "daily_publish_orgs_with_no_signed_mou_count" {
+  name                = "${var.env_name}-daily-publish-orgs-with-no-signed-mou-count"
+  description         = "Triggers daily 05:30 UTC"
+  schedule_expression = "cron(30 5 * * ? *)"
+  state               = "ENABLED"
+}

--- a/govwifi-admin/scheduled-tasks.tf
+++ b/govwifi-admin/scheduled-tasks.tf
@@ -358,6 +358,44 @@ resource "aws_cloudwatch_event_target" "publish_orgs_with_dormant_admins_count" 
 
 }
 
+# rake metrics:publish_orgs_with_no_signed_mou_count
+resource "aws_cloudwatch_event_target" "publish_orgs_with_no_signed_mou_count" {
+  target_id = "${var.env_name}-publish-orgs-with-no-signed-mou-count"
+  arn       = aws_ecs_cluster.admin_cluster.arn
+  rule      = aws_cloudwatch_event_rule.daily_publish_orgs_with_no_signed_mou_count.name
+  role_arn  = aws_iam_role.scheduled_task.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.admin_task.arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      subnets = length(var.private_subnet_ids) > 0 ? var.private_subnet_ids : var.subnet_ids
+
+      security_groups = concat(
+        [aws_security_group.admin_ec2_in.id],
+        [aws_security_group.admin_ec2_out.id]
+      )
+
+      assign_public_ip = length(var.private_subnet_ids) > 0 ? false : true
+    }
+  }
+
+  input = <<EOF
+  {
+    "containerOverrides": [
+      {
+        "name": "admin",
+        "command": ["bundle", "exec", "rake", "metrics:publish_orgs_with_no_signed_mou_count"]
+      }
+    ]
+  }
+  EOF
+
+}
+
 # Resets the GW and Super user creds used in smoke tests
 resource "aws_cloudwatch_event_target" "smoke_test_reset" {
   target_id = "${var.env_name}-smoke-test-reset"


### PR DESCRIPTION
## How Organisations with no signed MOU?

### What

- Adds a CloudWatch Events rule scheduling `metrics:publish_orgs_with_no_signed_mou_count` daily at 05:30 UTC
- Adds the matching ECS scheduled task target on the existing `admin_cluster`/`admin_task`
- Reuses the existing shared IAM role, S3 bucket access, and Metrics API secrets already granted to the admin task — no new IAM/variables needed

### Why

- Schedules the newly added `govwifi-admin` rake task so the "orgs with no signed MOU" metric publishes daily like other account-health metrics
- Follows the exact same pattern as the recently merged `publish_orgs_with_dormant_admins_count` scheduling PR

### Link to JIRA card (if applicable):

- [GW-2737](https://technologyprogramme.atlassian.net/browse/GW-2738)