### PR TITLE
Speed up acceptance test.

### DIFF
--- a/govwifi-deploy/codebuild-acceptance-tests.tf
+++ b/govwifi-deploy/codebuild-acceptance-tests.tf
@@ -1,7 +1,7 @@
 resource "aws_codebuild_project" "govwifi_codebuild_acceptance_tests" {
   name           = "acceptance-tests"
   description    = "This project runs the frontend acceptance tests"
-  build_timeout  = "20"
+  build_timeout  = "30"
   service_role   = aws_iam_role.govwifi_codebuild.arn
   encryption_key = aws_kms_key.codepipeline_key.arn
 
@@ -10,8 +10,8 @@ resource "aws_codebuild_project" "govwifi_codebuild_acceptance_tests" {
   }
 
   environment {
-    compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:7.0"
+    compute_type                = "BUILD_GENERAL1_MEDIUM"
+    image                       = "aws/codebuild/standard:8.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true

--- a/govwifi/tools/.terraform.lock.hcl
+++ b/govwifi/tools/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "6.50.0"
   hashes = [
     "h1:D8uNiOpl3UkAX4zI5T47ALMiRFXTa1XfdQC+TBu3RmE=",
+    "h1:mNg4vBXXqbO0hY2jCxhOyKVrnjEO0viTG2EY4oAlWaQ=",
     "zh:0072806bb262c6d86bc25b4a75750e469881144c14818afdba7b82db840e1588",
     "zh:1ebc2dae335dad7a8b16a1985b69a63a14954282bb44fdba7d5103f77551ac7b",
     "zh:2dab48fe8f3193b8216d578ac1e3674fa566435cc7dbce2953d55b72e31d0241",


### PR DESCRIPTION
### What
Change image type and build time for acceptance tests

### Why
Because they consume more memory and cpu and are timing out.


### Link to JIRA card (if applicable): 
N/A