### PR TITLE
How many organisations have no active admins?

### DIFF
--- a/govwifi-admin/event-rules.tf
+++ b/govwifi-admin/event-rules.tf
@@ -77,3 +77,11 @@ resource "aws_cloudwatch_event_rule" "daily_publish_orgs_with_no_signed_mou_coun
   schedule_expression = "cron(30 5 * * ? *)"
   state               = "ENABLED"
 }
+
+# rake metrics:publish_orgs_have_no_active_admins_count
+resource "aws_cloudwatch_event_rule" "daily_publish_orgs_have_no_active_admins_count" {
+  name                = "${var.env_name}-daily-publish-orgs-have-no-active-admins-count"
+  description         = "Triggers daily 05:45 UTC"
+  schedule_expression = "cron(45 5 * * ? *)"
+  state               = "ENABLED"
+}

--- a/govwifi-admin/scheduled-tasks.tf
+++ b/govwifi-admin/scheduled-tasks.tf
@@ -434,6 +434,44 @@ resource "aws_cloudwatch_event_target" "publish_orgs_with_no_signed_mou_count" {
 
 }
 
+# rake metrics:publish_orgs_have_no_active_admins_count
+resource "aws_cloudwatch_event_target" "publish_orgs_have_no_active_admins_count" {
+  target_id = "${var.env_name}-publish-orgs-have-no-active-admins-count"
+  arn       = aws_ecs_cluster.admin_cluster.arn
+  rule      = aws_cloudwatch_event_rule.daily_publish_orgs_have_no_active_admins_count.name
+  role_arn  = aws_iam_role.scheduled_task.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.admin_task.arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      subnets = length(var.private_subnet_ids) > 0 ? var.private_subnet_ids : var.subnet_ids
+
+      security_groups = concat(
+        [aws_security_group.admin_ec2_in.id],
+        [aws_security_group.admin_ec2_out.id]
+      )
+
+      assign_public_ip = length(var.private_subnet_ids) > 0 ? false : true
+    }
+  }
+
+  input = <<EOF
+  {
+    "containerOverrides": [
+      {
+        "name": "admin",
+        "command": ["bundle", "exec", "rake", "metrics:publish_orgs_have_no_active_admins_count"]
+      }
+    ]
+  }
+  EOF
+
+}
+
 # Resets the GW and Super user creds used in smoke tests
 resource "aws_cloudwatch_event_target" "smoke_test_reset" {
   target_id = "${var.env_name}-smoke-test-reset"


### PR DESCRIPTION
## How many organisations have no active admins?

### What

- Adds a CloudWatch Events rule and ECS scheduled task target for the new `metrics:publish_orgs_have_no_active_admins_count` rake task.
- Follows the exact pattern of the existing dormant-admins/less-than-two-admins/no-signed-mou scheduled tasks: same IAM role, ECS cluster, and task definition, staggered at 05:45 UTC.
- No per-environment or IAM/S3 policy changes needed — the module already propagates to development, staging, and production, and the metrics bucket/API wiring is already bucket-wide and container-wide.

### Why

- Schedules the new govwifi-admin metric (GovWifi/govwifi-admin#2702) so it runs daily like its sibling account-health metrics.
- Keeps infra changes minimal and consistent with the established scheduling pattern.
- Ready to merge alongside the govwifi-admin PR that adds the rake task itself.

### Link to JIRA card (if applicable):

- [GW-2740](https://technologyprogramme.atlassian.net/browse/GW-2740)